### PR TITLE
Using custom errors in the card payment processor contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ typechain-types
 cache
 artifacts
 
+#IDE-specific files
+.idea

--- a/contracts/CardPaymentProcessorUpgradeable.sol
+++ b/contracts/CardPaymentProcessorUpgradeable.sol
@@ -132,6 +132,48 @@ contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableEx
     mapping(bytes32 => bool) private _paymentRevocationFlags;
     mapping(bytes32 => bool) private _paymentReversionFlags;
 
+    /// @dev Zero has been passed when setting the new value of the revocation counter maximum.
+    error ZeroNewValueOfRevocationCounterMaximum();
+
+    /// @dev Zero amount of tokens has been passed when making a payment.
+    error ZeroPaymentAmount();
+
+    /// @dev Zero authorization ID has been passed as a function argument.
+    error ZeroAuthorizationId();
+
+    /// @dev The payment with the provided authorization ID already exists and was not revoked.
+    error PaymentAlreadyExists();
+
+    /**
+     * @dev Revocation counter of the payment reached the configured maximum and payment cannot be made.
+     * @param configuredRevocationCounterMaximum The configured maximum value.
+     */
+    error RevocationCounterReachedMaximum(uint8 configuredRevocationCounterMaximum);
+
+    /// @dev The input array of authorization IDs of a function is empty.
+    error EmptyInputArrayOfAuthorizationIds();
+
+    /// @dev Zero cash out account has been passed as a function argument.
+    error ZeroCashOutAccount();
+
+    /// @dev Zero parent transaction has been passed as a function argument.
+    error ZeroParentTransactionHash();
+
+    /// @dev Payment with the provided authorization ID is uncleared, but it should be cleared.
+    error PaymentIsUncleared();
+
+    /// @dev Payment with the provided authorization ID is cleared, but it should be uncleared.
+    error PaymentIsCleared();
+
+    /**
+     * @dev The payment with the provided authorization ID has an inappropriate status.
+     * @param currentStatus The current status of payment with the provided authorization ID.
+     */
+    error InappropriatePaymentStatus(PaymentStatus currentStatus);
+
+    /// @dev The payment with the provided authorization ID does not exist.
+    error PaymentDoesNotExit();
+
     function initialize(address token_) public initializer {
         __CardPaymentProcessor_init(token_);
     }
@@ -216,10 +258,9 @@ contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableEx
      * @param newValue The new value of revocation counter maximum to set.
      */
     function setRevocationCounterMaximum(uint8 newValue) external onlyRole(OWNER_ROLE) {
-        require(
-            newValue > 0,
-            "CardPaymentProcessor: new value of the revocation counter maximum must be greater than 0"
-        );
+        if (newValue == 0) {
+            revert ZeroNewValueOfRevocationCounterMaximum();
+        }
 
         uint8 oldValue = _revocationCounterMaximum;
         if (oldValue == newValue) {
@@ -271,27 +312,22 @@ contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableEx
         Payment storage payment = _payments[authorizationId];
         address sender = _msgSender();
 
-        require(
-            amount > 0,
-            "CardPaymentProcessor: payment amount must be greater than 0"
-        );
-
-        require(
-            authorizationId != 0,
-            "CardPaymentProcessor: authorization ID must not equal 0"
-        );
+        if (amount == 0) {
+            revert ZeroPaymentAmount();
+        }
+        if (authorizationId == 0) {
+            revert ZeroAuthorizationId();
+        }
 
         PaymentStatus status = payment.status;
-        require(
-            status == PaymentStatus.Nonexistent || status == PaymentStatus.Revoked,
-            "CardPaymentProcessor: payment with the provided authorization ID already exists and was not revoked"
-        );
+        if (status != PaymentStatus.Nonexistent && status != PaymentStatus.Revoked) {
+            revert PaymentAlreadyExists();
+        }
 
         uint8 revocationCounter = payment.revocationCounter;
-        require(
-            revocationCounter < _revocationCounterMaximum,
-            "CardPaymentProcessor: revocation counter of the payment has reached the configured maximum"
-        );
+        if (revocationCounter >= _revocationCounterMaximum) {
+            revert RevocationCounterReachedMaximum(_revocationCounterMaximum);
+        }
 
         IERC20Upgradeable(token).transferFrom(
             sender,
@@ -352,10 +388,9 @@ contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableEx
      * @param authorizationIds The card transaction authorization IDs from the off-chain card processing backend.
      */
     function clearPayments(bytes16[] memory authorizationIds) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
-        require(
-            authorizationIds.length != 0,
-            "CardPaymentProcessor: input array of authorization IDs is empty"
-        );
+        if (authorizationIds.length == 0) {
+            revert EmptyInputArrayOfAuthorizationIds();
+        }
 
         uint256 totalAmount = 0;
         for (uint256 i = 0; i < authorizationIds.length; i++) {
@@ -402,10 +437,9 @@ contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableEx
      * @param authorizationIds The card transaction authorization IDs from the off-chain card processing backend.
      */
     function unclearPayments(bytes16[] memory authorizationIds) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
-        require(
-            authorizationIds.length != 0,
-            "CardPaymentProcessor: input array of authorization IDs is empty"
-        );
+        if (authorizationIds.length == 0) {
+            revert EmptyInputArrayOfAuthorizationIds();
+        }
         uint256 totalAmount = 0;
         for (uint256 i = 0; i < authorizationIds.length; i++) {
             totalAmount = totalAmount + unclearPaymentInternal(authorizationIds[i]);
@@ -509,10 +543,9 @@ contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableEx
         whenNotPaused
         onlyRole(EXECUTOR_ROLE)
     {
-        require(
-            cashOutAccount != address(0),
-            "CardPaymentProcessor: cash out account is the zero address"
-        );
+        if (cashOutAccount == address(0)) {
+            revert ZeroCashOutAccount();
+        }
 
         uint256 amount = confirmPaymentInternal(authorizationId);
         _totalClearedBalance = _totalClearedBalance - amount;
@@ -543,14 +576,12 @@ contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableEx
         whenNotPaused
         onlyRole(EXECUTOR_ROLE)
     {
-        require(
-            authorizationIds.length != 0,
-            "CardPaymentProcessor: input array of authorization IDs is empty"
-        );
-        require(
-            cashOutAccount != address(0),
-            "CardPaymentProcessor: cash out account is the zero address"
-        );
+        if (authorizationIds.length == 0) {
+            revert EmptyInputArrayOfAuthorizationIds();
+        }
+        if (cashOutAccount == address(0)) {
+            revert ZeroCashOutAccount();
+        }
 
         uint256 totalAmount = 0;
         for (uint256 i = 0; i < authorizationIds.length; i++) {
@@ -562,10 +593,9 @@ contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableEx
     }
 
     function clearPaymentInternal(bytes16 authorizationId) internal returns (uint256 amount) {
-        require(
-            authorizationId != 0,
-            "CardPaymentProcessor: authorization ID must not equal 0"
-        );
+        if (authorizationId == 0) {
+            revert ZeroAuthorizationId();
+        }
 
         Payment storage payment = _payments[authorizationId];
 
@@ -591,10 +621,9 @@ contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableEx
     }
 
     function unclearPaymentInternal(bytes16 authorizationId) internal returns (uint256 amount) {
-        require(
-            authorizationId != 0,
-            "CardPaymentProcessor: authorization ID must not equal 0"
-        );
+        if (authorizationId == 0) {
+            revert ZeroAuthorizationId();
+        }
 
         Payment storage payment = _payments[authorizationId];
 
@@ -620,10 +649,9 @@ contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableEx
     }
 
     function confirmPaymentInternal(bytes16 authorizationId) internal returns (uint256 amount) {
-        require(
-            authorizationId != 0,
-            "CardPaymentProcessor: authorization ID must not equal 0"
-        );
+        if (authorizationId == 0) {
+            revert ZeroAuthorizationId();
+        }
 
         Payment storage payment = _payments[authorizationId];
 
@@ -652,22 +680,19 @@ contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableEx
     )
         internal
     {
-        require(
-            authorizationId != 0,
-            "CardPaymentProcessor: authorization ID must not equal 0"
-        );
-        require(
-            parentTxHash != 0,
-            "CardPaymentProcessor: parent transaction hash should not equal 0"
-        );
+        if (authorizationId == 0) {
+            revert ZeroAuthorizationId();
+        }
+        if (parentTxHash == 0) {
+            revert ZeroParentTransactionHash();
+        }
 
         Payment storage payment = _payments[authorizationId];
         PaymentStatus status = payment.status;
 
-        require(
-            status != PaymentStatus.Nonexistent,
-            "CardPaymentProcessor: payment with the provided authorization ID does not exist"
-        );
+        if (status == PaymentStatus.Nonexistent) {
+            revert PaymentDoesNotExit();
+        }
 
         address account = payment.account;
         uint256 amount = payment.amount;
@@ -679,7 +704,7 @@ contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableEx
             _clearedBalances[account] = _clearedBalances[account] - amount;
             _totalClearedBalance = _totalClearedBalance - amount;
         } else {
-            revert("CardPaymentProcessor: payment with the provided authorization ID has an inappropriate status");
+            revert InappropriatePaymentStatus(status);
         }
 
         IERC20Upgradeable(token).transfer(account, amount);
@@ -720,32 +745,26 @@ contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableEx
     }
 
     function checkClearedStatus(PaymentStatus status) internal pure {
-        require(
-            status != PaymentStatus.Nonexistent,
-            "CardPaymentProcessor: payment with the provided authorization ID does not exist"
-        );
-        require(
-            status != PaymentStatus.Uncleared,
-            "CardPaymentProcessor: payment with the provided authorization ID is uncleared"
-        );
-        require(
-            status == PaymentStatus.Cleared,
-            "CardPaymentProcessor: payment with the provided authorization ID has an inappropriate status"
-        );
+        if (status == PaymentStatus.Nonexistent) {
+            revert PaymentDoesNotExit();
+        }
+        if (status == PaymentStatus.Uncleared) {
+            revert PaymentIsUncleared();
+        }
+        if (status != PaymentStatus.Cleared) {
+            revert InappropriatePaymentStatus(status);
+        }
     }
 
     function checkUnclearedStatus(PaymentStatus status) internal pure {
-        require(
-            status != PaymentStatus.Nonexistent,
-            "CardPaymentProcessor: payment with the provided authorization ID does not exist"
-        );
-        require(
-            status != PaymentStatus.Cleared,
-            "CardPaymentProcessor: payment with the provided authorization ID is cleared"
-        );
-        require(
-            status == PaymentStatus.Uncleared,
-            "CardPaymentProcessor: payment with the provided authorization ID has an inappropriate status"
-        );
+        if (status == PaymentStatus.Nonexistent) {
+            revert PaymentDoesNotExit();
+        }
+        if (status == PaymentStatus.Cleared) {
+            revert PaymentIsCleared();
+        }
+        if (status != PaymentStatus.Uncleared) {
+            revert InappropriatePaymentStatus(status);
+        }
     }
 }

--- a/contracts/CardPaymentProcessorUpgradeable.sol
+++ b/contracts/CardPaymentProcessorUpgradeable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/CardPaymentProcessorUpgradeable.sol
+++ b/contracts/CardPaymentProcessorUpgradeable.sol
@@ -1,0 +1,751 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import "./base/PausableExUpgradeable.sol";
+
+/**
+ * @title CardPaymentProcessorUpgradeable contract
+ * @dev Wrapper for the card payment operations.
+ */
+contract CardPaymentProcessorUpgradeable is AccessControlUpgradeable, PausableExUpgradeable {
+
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+    bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
+
+    event MakePayment(
+        bytes16 indexed authorizationId,
+        bytes16 indexed correlationId,
+        address indexed account,
+        uint256 amount,
+        uint8 revocationCounter
+    );
+
+    event ClearPayment(
+        bytes16 indexed authorizationId,
+        address indexed account,
+        uint256 amount,
+        uint256 clearedBalance,
+        uint256 unclearedBalance,
+        uint8 revocationCounter
+    );
+
+    event UnclearPayment(
+        bytes16 indexed authorizationId,
+        address indexed account,
+        uint256 amount,
+        uint256 clearedBalance,
+        uint256 unclearedBalance,
+        uint8 revocationCounter
+    );
+
+    event RevokePayment(
+        bytes16 indexed authorizationId,
+        bytes16 indexed correlationId,
+        address indexed account,
+        uint256 amount,
+        uint256 clearedBalance,
+        uint256 unclearedBalance,
+        bool wasPaymentCleared,
+        bytes32 parentTransactionHash,
+        uint8 revocationCounter
+    );
+
+    event ReversePayment(
+        bytes16 indexed authorizationId,
+        bytes16 indexed correlationId,
+        address indexed account,
+        uint256 amount,
+        uint256 clearedBalance,
+        uint256 unclearedBalance,
+        bool wasPaymentCleared,
+        bytes32 parentTransactionHash,
+        uint8 revocationCounter
+    );
+
+    event ConfirmPayment(
+        bytes16 indexed authorizationId,
+        address indexed account,
+        uint256 amount,
+        uint256 clearedBalance,
+        uint8 revocationCounter
+    );
+
+    event SetRevocationCounterMaximum(
+        uint8 oldValue,
+        uint8 newValue
+    );
+
+    /**
+     * @dev Possible statuses of a payment as an enum
+     *
+     * The possible values:
+     * - Nonexistent -- the payment does not exist (the default value).
+     * - Uncleared -- the status immediately after the payment making.
+     * - Cleared -- the payment has been cleared and is ready to be confirmed.
+     * - Revoked -- the payment was revoked due to some technical reason.
+     *              The related tokens have been transferred back to a customer.
+     *              The payment can be made again with the same authorizationId.
+     * - Reversed -- the payment was reversed due to the decision of the off-chain card processing service.
+     *               The related tokens have been transferred back to a customer.
+     *               The payment cannot be made again with the same authorizationId.
+     * - Confirmed -- the payment was approved.
+     *                The related tokens have been transferred to a special cash-out account to further operations.
+     *                The payment cannot be made again with the same authorizationId.
+     */
+    enum PaymentStatus {
+        Nonexistent, // 0
+        Uncleared,   // 1
+        Cleared,     // 2
+        Revoked,     // 3
+        Reversed,    // 4
+        Confirmed    // 5
+    }
+
+    /**
+     * @dev Structure with the data of a single payment:
+     *
+     * - account -- the account who made the payment;
+     * - amount -- the amount of tokens in the payment;
+     * - status -- the current status of the payment according to the {PaymentStatus} enum;
+     * - revocationCounter -- the number of revocation of the payment.
+     */
+    struct Payment {
+        address account;
+        uint256 amount;
+        PaymentStatus status;
+        uint8 revocationCounter;
+    }
+
+    /// @dev The address of the underlying token contract.
+    address public token;
+
+    uint256 private _totalClearedBalance;
+    uint256 private _totalUnclearedBalance;
+    uint8 private _revocationCounterMaximum;
+
+    mapping(address => uint256) private _unclearedBalances;
+    mapping(address => uint256) private _clearedBalances;
+    mapping(bytes16 => Payment) private _payments;
+    mapping(bytes32 => bool) private _paymentRevocationFlags;
+    mapping(bytes32 => bool) private _paymentReversionFlags;
+
+    function initialize(address token_) public initializer {
+        __CardPaymentProcessor_init(token_);
+    }
+
+    function __CardPaymentProcessor_init(address token_) internal onlyInitializing {
+        __AccessControl_init_unchained();
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __Pausable_init_unchained();
+        __PausableEx_init_unchained(OWNER_ROLE);
+
+        __CardPaymentProcessor_init_unchained(token_);
+    }
+
+    function __CardPaymentProcessor_init_unchained(address token_) internal onlyInitializing {
+        token = token_;
+        _revocationCounterMaximum = type(uint8).max;
+
+        _setRoleAdmin(OWNER_ROLE, OWNER_ROLE);
+        _setRoleAdmin(EXECUTOR_ROLE, OWNER_ROLE);
+
+        _setupRole(OWNER_ROLE, _msgSender());
+    }
+
+    /**
+     * @dev Returns the total uncleared amount of tokens locked in the contract.
+     */
+    function totalUnclearedBalance() external view virtual returns (uint256) {
+        return _totalUnclearedBalance;
+    }
+
+    /**
+     * @dev Returns the total cleared amount of tokens locked in the contract.
+     */
+    function totalClearedBalance() external view virtual returns (uint256) {
+        return _totalClearedBalance;
+    }
+
+    /**
+     * @dev Returns the uncleared balance for an account.
+     * @param account The address of the account.
+     */
+    function unclearedBalanceOf(address account) external view virtual returns (uint256) {
+        return _unclearedBalances[account];
+    }
+
+    /**
+     * @dev Returns the cleared balance for an account.
+     * @param account The address of the account.
+     */
+    function clearedBalanceOf(address account) external view virtual returns (uint256) {
+        return _clearedBalances[account];
+    }
+
+    /**
+     * @dev Returns payment data for a card transaction authorization ID.
+     * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
+     */
+    function paymentFor(bytes16 authorizationId) external view virtual returns (Payment memory) {
+        return _payments[authorizationId];
+    }
+
+    /**
+     * @dev Checks if a payment related to a parent transaction hash has been revoked.
+     * @param parentTxHash The hash of the transaction where the payment was made.
+     */
+    function isPaymentRevoked(bytes32 parentTxHash) external view virtual returns (bool) {
+        return _paymentRevocationFlags[parentTxHash];
+    }
+
+    /**
+     * @dev Checks if a payment related to a parent transaction hash has been reversed.
+     * @param parentTxHash The hash of the transaction where the payment was made.
+     */
+    function isPaymentReversed(bytes32 parentTxHash) external view virtual returns (bool) {
+        return _paymentReversionFlags[parentTxHash];
+    }
+
+    /**
+     * @dev Sets a new value for the revocation counter maximum.
+     * Emits a {SetRevocationCounterMaximum} event if the new value differs from the old one.
+     * @param newValue The new value of revocation counter maximum to set.
+     */
+    function setRevocationCounterMaximum(uint8 newValue) external onlyRole(OWNER_ROLE) {
+        require(
+            newValue > 0,
+            "CardPaymentProcessor: new value of the revocation counter maximum must be greater than 0"
+        );
+
+        uint8 oldValue = _revocationCounterMaximum;
+        if (oldValue == newValue) {
+            return;
+        }
+
+        _revocationCounterMaximum = newValue;
+        emit SetRevocationCounterMaximum(
+            oldValue,
+            newValue
+        );
+    }
+
+    /**
+     * @dev Returns the value of the revocation counter maximum.
+     */
+    function revocationCounterMaximum() external virtual view returns (uint8) {
+        return _revocationCounterMaximum;
+    }
+
+
+    /**
+     * @dev Makes a card payment.
+     *
+     * Transfers the underlying tokens from the payer (who is the caller of the function) to this contract.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The amount of tokens in the payment should be greater then zero.
+     * - The authorization ID of the payment should not be zero.
+     * - The payment with the authorization ID should not exist or
+     *   should be revoked not more then the configured maximum times.
+     *
+     * Emits a {MakePayment} event.
+     *
+     * @param amount The amount of tokens to be transferred to this contract because of the payment.
+     * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
+     * @param correlationId The ID that is correlated to call of this function in the off-chain card processing backend.
+     */
+    function makePayment(
+        uint256 amount,
+        bytes16 authorizationId,
+        bytes16 correlationId
+    )
+        external
+        whenNotPaused
+    {
+        Payment storage payment = _payments[authorizationId];
+        address sender = _msgSender();
+
+        require(
+            amount > 0,
+            "CardPaymentProcessor: payment amount must be greater than 0"
+        );
+
+        require(
+            authorizationId != 0,
+            "CardPaymentProcessor: authorization ID must not equal 0"
+        );
+
+        PaymentStatus status = payment.status;
+        require(
+            status == PaymentStatus.Nonexistent || status == PaymentStatus.Revoked,
+            "CardPaymentProcessor: payment with the provided authorization ID already exists and was not revoked"
+        );
+
+        uint8 revocationCounter = payment.revocationCounter;
+        require(
+            revocationCounter < _revocationCounterMaximum,
+            "CardPaymentProcessor: revocation counter of the payment has reached the configured maximum"
+        );
+
+        IERC20Upgradeable(token).transferFrom(
+            sender,
+            address(this),
+            amount
+        );
+
+        payment.account = sender;
+        payment.amount = amount;
+        payment.status = PaymentStatus.Uncleared;
+
+        _unclearedBalances[sender] = _unclearedBalances[sender] + amount;
+        _totalUnclearedBalance = _totalUnclearedBalance + amount;
+
+        emit MakePayment(
+            authorizationId,
+            correlationId,
+            sender,
+            amount,
+            revocationCounter
+        );
+    }
+
+    /**
+     * @dev Executes a clearing operation for a single previously made card payment.
+     *
+     * Requirements:
+     *
+     * - The payment should have the "uncleared" status.
+     * - The contract must not be paused.
+     * - The caller should have the {EXECUTOR_ROLE} role.
+     * - The input authorization ID of the payment should not be zero.
+     *
+     * Emits a {ClearPayment} event for the payment.
+     *
+     * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
+     */
+    function clearPayment(bytes16 authorizationId) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
+        uint256 amount = clearPaymentInternal(authorizationId);
+
+        _totalUnclearedBalance = _totalUnclearedBalance - amount;
+        _totalClearedBalance = _totalClearedBalance + amount;
+    }
+
+    /**
+     * @dev Executes a clearing operation for several previously made card payments.
+     *
+     * Requirements:
+     *
+     * - Each payment should have the "uncleared" status or the call will be reverted.
+     * - The contract must not be paused.
+     * - The caller should have the {EXECUTOR_ROLE} role.
+     * - The input array of the the authorization IDs should not be empty.
+     * - All the authorization IDs of the payments should not be zero.
+     *
+     * Emits a {ClearPayment} event for each payment.
+     *
+     * @param authorizationIds The card transaction authorization IDs from the off-chain card processing backend.
+     */
+    function clearPayments(bytes16[] memory authorizationIds) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
+        require(
+            authorizationIds.length != 0,
+            "CardPaymentProcessor: input array of authorization IDs is empty"
+        );
+
+        uint256 totalAmount = 0;
+        for (uint256 i = 0; i < authorizationIds.length; i++) {
+            totalAmount += clearPaymentInternal(authorizationIds[i]);
+        }
+        _totalUnclearedBalance = _totalUnclearedBalance - totalAmount;
+        _totalClearedBalance = _totalClearedBalance + totalAmount;
+    }
+
+    /**
+     * @dev Cancels a previously executed clearing operation for a single card payment.
+     *
+     * Requirements:
+     *
+     * - The payment should have the "cleared" status or the call will be reverted.
+     * - The contract must not be paused.
+     * - The caller should have the {EXECUTOR_ROLE} role.
+     * - The input authorization ID of the payment should not be zero.
+     *
+     * Emits a {UnclearPayment} event for the payment.
+     *
+     * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
+     */
+    function unclearPayment(bytes16 authorizationId) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
+        uint256 amount = unclearPaymentInternal(authorizationId);
+
+        _totalClearedBalance = _totalClearedBalance - amount;
+        _totalUnclearedBalance = _totalUnclearedBalance + amount;
+    }
+
+    /**
+     * @dev Cancels a previously executed clearing operation for several card payments.
+     *
+     * Requirements:
+     *
+     * - Each payment should have the "cleared" status or the call will be reverted.
+     * - The contract must not be paused.
+     * - The caller should have the {EXECUTOR_ROLE} role.
+     * - The input array of the the authorization IDs should not be empty.
+     * - All the authorization IDs of the payments should not be zero.
+     *
+     * Emits a {UnclearPayment} event for the payment.
+     *
+     * @param authorizationIds The card transaction authorization IDs from the off-chain card processing backend.
+     */
+    function unclearPayments(bytes16[] memory authorizationIds) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
+        require(
+            authorizationIds.length != 0,
+            "CardPaymentProcessor: input array of authorization IDs is empty"
+        );
+        uint256 totalAmount = 0;
+        for (uint256 i = 0; i < authorizationIds.length; i++) {
+            totalAmount = totalAmount + unclearPaymentInternal(authorizationIds[i]);
+        }
+        _totalClearedBalance = _totalClearedBalance - totalAmount;
+        _totalUnclearedBalance = _totalUnclearedBalance + totalAmount;
+    }
+
+    /**
+     * @dev Performs the reverse of a previously made card payment.
+     * Finalizes the payment: no other operations can be done for the payment.
+     * Transfers tokens back from this contract to the payer.
+     *
+     * Requirements:
+     *
+     * - The payment should have "cleared" or "uncleared" statuses.
+     * - The contract must not be paused.
+     * - The caller should have the {EXECUTOR_ROLE} role.
+     * - The input authorization ID and parent transaction hash of the payment should not be zero.
+     *
+     * Emits a {ReversePayment} event for the payment.
+     *
+     * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
+     * @param correlationId The ID that is correlated to call of this function in the off-chain card processing backend.
+     * @param parentTxHash The hash of the transaction where the payment was made.
+     */
+    function reversePayment(
+        bytes16 authorizationId,
+        bytes16 correlationId,
+        bytes32 parentTxHash
+    )
+        external
+        whenNotPaused
+        onlyRole(EXECUTOR_ROLE)
+    {
+        cancelPaymentInternal(
+            authorizationId,
+            correlationId,
+            parentTxHash,
+            PaymentStatus.Reversed
+        );
+    }
+
+    /**
+     * @dev Performs the revocation of a previously made card payment and increase its revocation counter.
+     * Does not finalize the payment: it can be made again until revocation counter reaches the configured maximum.
+     * Transfers tokens back from this contract to the payer.
+     *
+     * Requirements:
+     *
+     * - The payment should have "cleared" or "uncleared" statuses.
+     * - The contract must not be paused.
+     * - The caller should have the {EXECUTOR_ROLE} role.
+     * - The input authorization ID and parent transaction hash of the payment should not be zero.
+     *
+     * Emits a {RevokePayment} event for the payment.
+     *
+     * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
+     * @param correlationId The ID that is correlated to call of this function in the off-chain card processing backend.
+     * @param parentTxHash The hash of the transaction where the payment was made.
+     */
+    function revokePayment(
+        bytes16 authorizationId,
+        bytes16 correlationId,
+        bytes32 parentTxHash
+    )
+        external
+        whenNotPaused
+        onlyRole(EXECUTOR_ROLE)
+    {
+        cancelPaymentInternal(
+            authorizationId,
+            correlationId,
+            parentTxHash,
+            PaymentStatus.Revoked
+        );
+    }
+
+    /**
+     * @dev Executes the final step of single card payments processing with token transferring.
+     * Finalizes the payment: no other operations can be done for the payment.
+     * Transfers previously cleared tokens gotten from a payer to a dedicated cash-out account for further operations.
+     *
+     * Requirements:
+     *
+     * - The payment should have the "cleared" status.
+     * - The contract must not be paused.
+     * - The caller should have the {EXECUTOR_ROLE} role.
+     * - The input authorization ID and cash out account of the payment should not be zero.
+     *
+     * Emits a {ConfirmPayment} event for the payment.
+     *
+     * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
+     * @param cashOutAccount The account to transfer cleared tokens to.
+     */
+    function confirmPayment(
+        bytes16 authorizationId,
+        address cashOutAccount
+    )
+        external
+        whenNotPaused
+        onlyRole(EXECUTOR_ROLE)
+    {
+        require(
+            cashOutAccount != address(0),
+            "CardPaymentProcessor: cash out account is the zero address"
+        );
+
+        uint256 amount = confirmPaymentInternal(authorizationId);
+        _totalClearedBalance = _totalClearedBalance - amount;
+        IERC20Upgradeable(token).transfer(cashOutAccount, amount);
+    }
+
+    /**
+     * @dev Executes the final step of several card payments processing with token transferring.
+     * Finalizes the payment: no other operations can be done for the payments.
+     * Transfers previously cleared tokens gotten from payers to a dedicated cash-out account for further operations.
+     *
+     * Requirements:
+     *
+     * - Each payment should have the "cleared" status or the call will be reverted.
+     * - The contract must not be paused.
+     * - The caller should have the {EXECUTOR_ROLE} role.
+     *
+     * Emits a {ConfirmPayment} event for the payment.
+     *
+     * @param authorizationIds The card transaction authorization IDs from the off-chain card processing backend.
+     * @param cashOutAccount The account to transfer cleared tokens to.
+     */
+    function confirmPayments(
+        bytes16[] memory authorizationIds,
+        address cashOutAccount
+    )
+        external
+        whenNotPaused
+        onlyRole(EXECUTOR_ROLE)
+    {
+        require(
+            authorizationIds.length != 0,
+            "CardPaymentProcessor: input array of authorization IDs is empty"
+        );
+        require(
+            cashOutAccount != address(0),
+            "CardPaymentProcessor: cash out account is the zero address"
+        );
+
+        uint256 totalAmount = 0;
+        for (uint256 i = 0; i < authorizationIds.length; i++) {
+            totalAmount += confirmPaymentInternal(authorizationIds[i]);
+        }
+        _totalClearedBalance = _totalClearedBalance - totalAmount;
+
+        IERC20Upgradeable(token).transfer(cashOutAccount, totalAmount);
+    }
+
+    function clearPaymentInternal(bytes16 authorizationId) internal returns (uint256 amount) {
+        require(
+            authorizationId != 0,
+            "CardPaymentProcessor: authorization ID must not equal 0"
+        );
+
+        Payment storage payment = _payments[authorizationId];
+
+        checkUnclearedStatus(payment.status);
+        payment.status = PaymentStatus.Cleared;
+
+        address account = payment.account;
+        amount = payment.amount;
+
+        uint256 newUnclearedBalance = _unclearedBalances[account] - amount;
+        _unclearedBalances[account] = newUnclearedBalance;
+        uint256 newClearedBalance = _clearedBalances[account] + amount;
+        _clearedBalances[account] = newClearedBalance;
+
+        emit ClearPayment(
+            authorizationId,
+            account,
+            amount,
+            newClearedBalance,
+            newUnclearedBalance,
+            payment.revocationCounter
+        );
+    }
+
+    function unclearPaymentInternal(bytes16 authorizationId) internal returns (uint256 amount) {
+        require(
+            authorizationId != 0,
+            "CardPaymentProcessor: authorization ID must not equal 0"
+        );
+
+        Payment storage payment = _payments[authorizationId];
+
+        checkClearedStatus(payment.status);
+        payment.status = PaymentStatus.Uncleared;
+
+        address account = payment.account;
+        amount = payment.amount;
+
+        uint256 newClearedBalance = _clearedBalances[account] - amount;
+        _clearedBalances[account] = newClearedBalance;
+        uint256 newUnclearedBalance = _unclearedBalances[account] + amount;
+        _unclearedBalances[account] = newUnclearedBalance;
+
+        emit UnclearPayment(
+            authorizationId,
+            account,
+            amount,
+            newClearedBalance,
+            newUnclearedBalance,
+            payment.revocationCounter
+        );
+    }
+
+    function confirmPaymentInternal(bytes16 authorizationId) internal returns (uint256 amount) {
+        require(
+            authorizationId != 0,
+            "CardPaymentProcessor: authorization ID must not equal 0"
+        );
+
+        Payment storage payment = _payments[authorizationId];
+
+        checkClearedStatus(payment.status);
+        payment.status = PaymentStatus.Confirmed;
+
+        address account = payment.account;
+        amount = payment.amount;
+        uint256 newClearedBalance = _clearedBalances[account] - amount;
+        _clearedBalances[account] = newClearedBalance;
+
+        emit ConfirmPayment(
+            authorizationId,
+            account,
+            amount,
+            newClearedBalance,
+            payment.revocationCounter
+        );
+    }
+
+    function cancelPaymentInternal(
+        bytes16 authorizationId,
+        bytes16 correlationId,
+        bytes32 parentTxHash,
+        PaymentStatus targetStatus
+    )
+        internal
+    {
+        require(
+            authorizationId != 0,
+            "CardPaymentProcessor: authorization ID must not equal 0"
+        );
+        require(
+            parentTxHash != 0,
+            "CardPaymentProcessor: parent transaction hash should not equal 0"
+        );
+
+        Payment storage payment = _payments[authorizationId];
+        PaymentStatus status = payment.status;
+
+        require(
+            status != PaymentStatus.Nonexistent,
+            "CardPaymentProcessor: payment with the provided authorization ID does not exist"
+        );
+
+        address account = payment.account;
+        uint256 amount = payment.amount;
+
+        if (status == PaymentStatus.Uncleared) {
+            _unclearedBalances[account] = _unclearedBalances[account] - amount;
+            _totalUnclearedBalance = _totalUnclearedBalance - amount;
+        } else if (status == PaymentStatus.Cleared) {
+            _clearedBalances[account] = _clearedBalances[account] - amount;
+            _totalClearedBalance = _totalClearedBalance - amount;
+        } else {
+            revert("CardPaymentProcessor: payment with the provided authorization ID has an inappropriate status");
+        }
+
+        IERC20Upgradeable(token).transfer(account, amount);
+
+        if (targetStatus == PaymentStatus.Revoked) {
+            payment.status = PaymentStatus.Revoked;
+            uint8 newRevocationCounter = payment.revocationCounter + 1;
+            payment.revocationCounter = newRevocationCounter;
+            _paymentRevocationFlags[parentTxHash] = true;
+
+            emit RevokePayment(
+                authorizationId,
+                correlationId,
+                account,
+                amount,
+                _clearedBalances[account],
+                _unclearedBalances[account],
+                status == PaymentStatus.Cleared,
+                parentTxHash,
+                newRevocationCounter
+            );
+        } else {
+            payment.status = PaymentStatus.Reversed;
+            _paymentReversionFlags[parentTxHash] = true;
+
+            emit ReversePayment(
+                authorizationId,
+                correlationId,
+                account,
+                amount,
+                _clearedBalances[account],
+                _unclearedBalances[account],
+                status == PaymentStatus.Cleared,
+                parentTxHash,
+                payment.revocationCounter
+            );
+        }
+    }
+
+    function checkClearedStatus(PaymentStatus status) internal pure {
+        require(
+            status != PaymentStatus.Nonexistent,
+            "CardPaymentProcessor: payment with the provided authorization ID does not exist"
+        );
+        require(
+            status != PaymentStatus.Uncleared,
+            "CardPaymentProcessor: payment with the provided authorization ID is uncleared"
+        );
+        require(
+            status == PaymentStatus.Cleared,
+            "CardPaymentProcessor: payment with the provided authorization ID has an inappropriate status"
+        );
+    }
+
+    function checkUnclearedStatus(PaymentStatus status) internal pure {
+        require(
+            status != PaymentStatus.Nonexistent,
+            "CardPaymentProcessor: payment with the provided authorization ID does not exist"
+        );
+        require(
+            status != PaymentStatus.Cleared,
+            "CardPaymentProcessor: payment with the provided authorization ID is cleared"
+        );
+        require(
+            status == PaymentStatus.Uncleared,
+            "CardPaymentProcessor: payment with the provided authorization ID has an inappropriate status"
+        );
+    }
+}

--- a/contracts/base/PausableExUpgradeable.sol
+++ b/contracts/base/PausableExUpgradeable.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+
+/**
+ * @title PausableExUpgradeable base contract
+ * @dev Extends OpenZeppelin's PausableUpgradeable contract and AccessControlUpgradeable contract.
+ * Introduces the {PAUSER_ROLE} role to control the paused state the contract that is inherited from this one.
+ * The admins of the {PAUSER_ROLE} roles are accounts with the role defined in the init() function.
+ */
+abstract contract PausableExUpgradeable is AccessControlUpgradeable, PausableUpgradeable {
+
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    function __PausableEx_init(bytes32 pauserRoleAdmin) internal initializer {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __Pausable_init_unchained();
+        __PausableEx_init_unchained(pauserRoleAdmin);
+    }
+
+    function __PausableEx_init_unchained(bytes32 pauserRoleAdmin) internal initializer {
+        _setRoleAdmin(PAUSER_ROLE, pauserRoleAdmin);
+    }
+
+    /**
+     * @dev Triggers the paused state of the contract.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller should have the {PAUSER_ROLE} role.
+     *
+     * Emits a {Paused} event if it is executed successfully.
+     */
+    function pause() external onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    /**
+     * @dev Triggers the unpaused state.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller should have the {PAUSER_ROLE} role.
+     *
+     * Emits a {Unpaused} event if it is executed successfully.
+     */
+    function unpause() external onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+}

--- a/contracts/mocks/ERC20UpgradeableMock.sol
+++ b/contracts/mocks/ERC20UpgradeableMock.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+
+/**
+ * @title ERC20UpgradeableMock contract
+ * @dev An implementation of the {ERC20Upgradeable} contract for test purposes.
+ */
+contract ERC20UpgradeableMock is ERC20Upgradeable {
+
+    /**
+     * @dev The initialize function of the upgradable contract.
+     * @param name_ The name of the token to set for this ERC20-comparable contract.
+     * @param symbol_ The symbol of the token to set for this ERC20-comparable contract.
+     */
+    function initialize(
+        string memory name_,
+        string memory symbol_
+    )
+        public
+        initializer
+    {
+        __ERC20_init(name_, symbol_);
+    }
+
+    /**
+     * @dev Cals the appropriate internal function to mint needed amount of tokens for an account.
+     * @param account The address of an account to mint for.
+     * @param amount The amount of tokens to mint.
+     */
+    function mint(address account, uint256 amount) external returns (bool) {
+        _mint(account, amount);
+        return true;
+    }
+}

--- a/contracts/mocks/base/PausableExUpgradeableMock.sol
+++ b/contracts/mocks/base/PausableExUpgradeableMock.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../../base/PausableExUpgradeable.sol";
+
+/**
+ * @title PausableExUpgradeableMock contract
+ * @dev An implementation of the {PausableExUpgradeable} contract for test purposes.
+ */
+contract PausableExUpgradeableMock is PausableExUpgradeable {
+
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /**
+     * @dev The initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
+    function initialize() public {
+        _setupRole(OWNER_ROLE, _msgSender());
+        __PausableEx_init(OWNER_ROLE);
+    }
+
+    /**
+     * @dev The unchained initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
+    function initialize_unchained() public {
+        _setupRole(OWNER_ROLE, _msgSender());
+        __PausableEx_init_unchained(OWNER_ROLE);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,6 +1,6 @@
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
-import '@openzeppelin/hardhat-upgrades';
+import "@openzeppelin/hardhat-upgrades";
 
 const config: HardhatUserConfig = {
   solidity: {
@@ -17,6 +17,19 @@ const config: HardhatUserConfig = {
       accounts: {
         mnemonic: "test test test test test test test test test test test junk",
       },
+    },
+    ganache: {
+      url: "http://127.0.0.1:7545",
+      accounts: {
+        mnemonic: "test test test test test test test test test test test junk"
+      }
+    },
+    substrate: {
+      url: "http://127.0.0.1:9933",
+      accounts: {
+        mnemonic: "test test test test test test test test test test test junk",
+      },
+      gas: "auto"
     },
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,21 @@
 {
   "name": "brlc-periphery",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "dependencies": {
-        "@openzeppelin/contracts": "^4.7.0",
-        "@openzeppelin/contracts-upgradeable": "^4.7.0"
-      },
+      "name": "brlc-periphery",
+      "version": "1.0.0",
+      "license": "MIT",
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^1.0.2",
-        "@openzeppelin/hardhat-upgrades": "^1.19.0",
+        "@openzeppelin/contracts-upgradeable": "^4.7.2",
+        "@openzeppelin/hardhat-upgrades": "^1.19.1",
+        "@types/chai": "^4.3.1",
+        "@types/mocha": "^9.1.1",
+        "@types/node": "^18.6.3",
+        "chai": "^4.3.6",
         "hardhat": "^2.10.1",
         "ts-node": "^10.9.1",
         "typescript": "^4.7.4"
@@ -77,6 +82,15 @@
         "buffer-xor": "^2.0.1",
         "ethereumjs-util": "^7.1.1",
         "miller-rabin": "^4.0.0"
+      }
+    },
+    "node_modules/@ethereumjs/ethash/node_modules/buffer-xor": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
+      "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/@ethereumjs/tx": {
@@ -558,28 +572,6 @@
         "ws": "7.4.6"
       }
     },
-    "node_modules/@ethersproject/providers/node_modules/ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@ethersproject/random": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.1.tgz",
@@ -899,29 +891,6 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
     },
-    "node_modules/@metamask/eth-sig-util/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
     "node_modules/@metamask/eth-sig-util/node_modules/ethereumjs-util": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
@@ -1093,24 +1062,21 @@
         "hardhat": "^2.0.4"
       }
     },
-    "node_modules/@openzeppelin/contracts": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.0.tgz",
-      "integrity": "sha512-52Qb+A1DdOss8QvJrijYYPSf32GUg2pGaG/yCxtaA3cu4jduouTdg4XZSMLW9op54m1jH7J8hoajhHKOPsoJFw=="
-    },
     "node_modules/@openzeppelin/contracts-upgradeable": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.0.tgz",
-      "integrity": "sha512-wO3PyoAaAV/rA77cK8H4c3SbO98QylTjfiFxyvURUZKTFLV180rnAvna1x7/Nxvt0Gqv+jt1sXKC7ygxsq8iCw=="
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.2.tgz",
+      "integrity": "sha512-3dgc6qVmFch/uOmlmKnw5/v3JxwXcZD4T10/9CI1OUbX8AqjoZrBGKfxN1z3QxnIXRU/X31/BItJezJSDDTe7Q==",
+      "dev": true
     },
     "node_modules/@openzeppelin/hardhat-upgrades": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.19.0.tgz",
-      "integrity": "sha512-351QqDO3nZ96g0BO/bQnaTflix4Nw4ELWC/hZ8PwicsuVxRmxN/GZhxPrs62AOdiQdZ+xweawrVXa5knliRd4A==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.19.1.tgz",
+      "integrity": "sha512-LvUClx+c8DIS6T5ZEPsz+HSRztvY9wjAI4qZH8IaTswjPAT/mqXZWmuQF96fFopR+jKpUNmI4IUo5wLt2TkdKQ==",
       "dev": true,
       "dependencies": {
         "@openzeppelin/upgrades-core": "^1.16.0",
         "chalk": "^4.1.0",
+        "debug": "^4.1.1",
         "proper-lockfile": "^4.1.1"
       },
       "bin": {
@@ -1119,6 +1085,7 @@
       "peerDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.0.0",
         "@nomiclabs/hardhat-etherscan": "^3.1.0",
+        "ethers": "^5.0.5",
         "hardhat": "^2.0.2"
       },
       "peerDependenciesMeta": {
@@ -1198,12 +1165,11 @@
       }
     },
     "node_modules/@openzeppelin/upgrades-core": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.16.1.tgz",
-      "integrity": "sha512-+hejbeAfsZWIQL5Ih13gkdm2KO6kbERc1ektzcyb25/OtUwaRjIIHxW++LdC/3Hg5uzThVOzJBfiLdAbgwD+OA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.17.0.tgz",
+      "integrity": "sha512-GaR3XiJ5PUKrHwz+EFJ9gtj2/taiFRWufbUaCgc1JEit1ERB9fI8PWEO0VTL+KzCZPl6meyT7RIhKNBRcX6jsA==",
       "dev": true,
       "dependencies": {
-        "bn.js": "^5.1.2",
         "cbor": "^8.0.0",
         "chalk": "^4.1.0",
         "compare-versions": "^4.0.0",
@@ -1491,9 +1457,9 @@
       "peer": true
     },
     "node_modules/@truffle/interface-adapter": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.19.tgz",
-      "integrity": "sha512-x7IZvsyx36DAJCJVZ9gUe1Lh8AhODhJoW7I+lJXIlGxj3EmZbao4/sHo+cN4u9i94yVTyGwYd78NzbP0a/LAog==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.20.tgz",
+      "integrity": "sha512-GL0pNZ8vshlU4SokKD0L7Pb/Vrxcb5ZALGhH9+uKvm6bXnY6XjnxvEYZ1KgK/p+uoYCLY53g9Sgn/CXvcWmGLg==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -1568,14 +1534,14 @@
       "peer": true
     },
     "node_modules/@truffle/provider": {
-      "version": "0.2.57",
-      "resolved": "https://registry.npmjs.org/@truffle/provider/-/provider-0.2.57.tgz",
-      "integrity": "sha512-O8VxF2uQwa+KB4HDg9lG7uhQ/+AOvchX+1STpQBSSAGfov1+EROM0iRZUNoPm71Pu0C9ji2WmXbNW/COjUMaMA==",
+      "version": "0.2.58",
+      "resolved": "https://registry.npmjs.org/@truffle/provider/-/provider-0.2.58.tgz",
+      "integrity": "sha512-WxglXYNz+YhgtLlocU9KjllmguP5xyFLcT/YHkEXvY6MuqLV2hcANswsTiB8axD+qaauBtwmVyJ0LS+ObJTzSw==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@truffle/error": "^0.1.0",
-        "@truffle/interface-adapter": "^0.5.19",
+        "@truffle/interface-adapter": "^0.5.20",
         "debug": "^4.3.1",
         "web3": "1.7.4"
       }
@@ -1700,8 +1666,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
       "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/chai-as-promised": {
       "version": "7.1.5",
@@ -1778,13 +1743,12 @@
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
       "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.0.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
-      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==",
+      "version": "18.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
+      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
       "dev": true
     },
     "node_modules/@types/pbkdf2": {
@@ -1797,9 +1761,9 @@
       }
     },
     "node_modules/@types/prettier": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
-      "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.4.tgz",
+      "integrity": "sha512-fOwvpvQYStpb/zHMx0Cauwywu9yLDmzWiiQBC7gJyq5tYLUXFZvDG7VK1B7WBxxjBJNKFOZ0zLoOQn8vmATbhw==",
       "dev": true,
       "peer": true
     },
@@ -1875,9 +1839,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1999,12 +1963,13 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
+      "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/ansi-styles": {
@@ -2159,7 +2124,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -2449,12 +2413,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/browserify-aes/node_modules/buffer-xor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-      "dev": true
-    },
     "node_modules/browserify-cipher": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
@@ -2567,13 +2525,10 @@
       "peer": true
     },
     "node_modules/buffer-xor": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
-      "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.1"
-      }
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true
     },
     "node_modules/bufferutil": {
       "version": "4.0.6",
@@ -2694,7 +2649,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
       "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -2726,7 +2680,6 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -2763,7 +2716,6 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -2882,53 +2834,6 @@
         "colors": "^1.1.2"
       }
     },
-    "node_modules/cli-table3/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cli-table3/node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cli-table3/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2938,6 +2843,50 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/clone-response": {
@@ -3175,9 +3124,9 @@
       "peer": true
     },
     "node_modules/core-js-pure": {
-      "version": "3.23.5",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.23.5.tgz",
-      "integrity": "sha512-8t78LdpKSuCq4pJYCYk8hl7XEkAX+BP16yRIwL3AanTksxuEf7CM83vRyctmiEL8NDZ3jpUcv56fk9/zG3aIuw==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.1.tgz",
+      "integrity": "sha512-r1nJk41QLLPyozHUUPmILCEMtMw24NG4oWK6RbsDdjzQgg9ZvrUsPBj1MnG0wXXp1DCDU6j+wUvEmBSrtRbLXg==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -3776,9 +3725,9 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.61",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "dev": true,
       "hasInstallScript": true,
       "peer": true,
@@ -3860,20 +3809,6 @@
       },
       "optionalDependencies": {
         "source-map": "~0.2.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/esprima": {
@@ -4103,6 +4038,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/eth-gas-reporter/node_modules/ethereum-cryptography": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
+      "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.6.3",
+        "@scure/bip32": "1.1.0",
+        "@scure/bip39": "1.1.0"
+      }
+    },
     "node_modules/eth-gas-reporter/node_modules/ethers": {
       "version": "4.0.49",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.49.tgz",
@@ -4190,16 +4138,6 @@
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "node_modules/eth-gas-reporter/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/eth-gas-reporter/node_modules/js-sha3": {
@@ -4587,15 +4525,26 @@
       }
     },
     "node_modules/ethereum-cryptography": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
-      "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
       "dev": true,
       "dependencies": {
-        "@noble/hashes": "1.1.2",
-        "@noble/secp256k1": "1.6.3",
-        "@scure/bip32": "1.1.0",
-        "@scure/bip39": "1.1.0"
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/ethereumjs-abi": {
@@ -4622,29 +4571,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
-    },
-    "node_modules/ethereumjs-abi/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
     },
     "node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
       "version": "6.2.1",
@@ -4675,29 +4601,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/ethereumjs-util/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/ethers": {
@@ -4908,9 +4811,9 @@
       }
     },
     "node_modules/ext/node_modules/type": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.6.1.tgz",
+      "integrity": "sha512-OvgH5rB0XM+iDZGQ1Eg/o7IZn0XYJFVrN/9FQ4OWIYILyJJgVP2s1hLTOFn6UOZoDUI/HctGa0PFlE2n2HW3NQ==",
       "dev": true,
       "peer": true
     },
@@ -5248,7 +5151,6 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -5483,6 +5385,16 @@
         "uglify-js": "^3.1.4"
       }
     },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -5595,6 +5507,18 @@
       },
       "peerDependencies": {
         "hardhat": "^2.0.2"
+      }
+    },
+    "node_modules/hardhat/node_modules/ethereum-cryptography": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
+      "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+      "dev": true,
+      "dependencies": {
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.6.3",
+        "@scure/bip32": "1.1.0",
+        "@scure/bip39": "1.1.0"
       }
     },
     "node_modules/has": {
@@ -6103,12 +6027,13 @@
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
+      "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/is-function": {
@@ -6767,7 +6692,6 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
       "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "get-func-name": "^2.0.0"
       }
@@ -7824,7 +7748,6 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -8917,6 +8840,16 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/solc": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/solc/-/solc-0.7.3.tgz",
@@ -9059,12 +8992,17 @@
       "peer": true
     },
     "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.8.0"
       }
     },
     "node_modules/source-map-support": {
@@ -9075,6 +9013,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -9184,17 +9131,17 @@
       "peer": true
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/string.prototype.trimend": {
@@ -9228,15 +9175,16 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
       "dev": true,
+      "peer": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^3.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/strip-hex-prefix": {
@@ -9482,12 +9430,60 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/table/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tar": {
       "version": "4.4.19",
@@ -9827,7 +9823,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -9958,9 +9953,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz",
-      "integrity": "sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
+      "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
       "dev": true,
       "optional": true,
       "peer": true,
@@ -10236,6 +10231,25 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/web3-core-helpers/node_modules/web3-utils": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethereumjs-util": "^7.1.0",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/web3-core-method": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.4.tgz",
@@ -10248,6 +10262,25 @@
         "web3-core-promievent": "1.7.4",
         "web3-core-subscriptions": "1.7.4",
         "web3-utils": "1.7.4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-core-method/node_modules/web3-utils": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethereumjs-util": "^7.1.0",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -10304,6 +10337,25 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/web3-core/node_modules/web3-utils": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethereumjs-util": "^7.1.0",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/web3-eth": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.7.4.tgz",
@@ -10342,6 +10394,25 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/web3-eth-abi/node_modules/web3-utils": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethereumjs-util": "^7.1.0",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/web3-eth-accounts": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.7.4.tgz",
@@ -10365,13 +10436,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/web3-eth-accounts/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/web3-eth-accounts/node_modules/eth-lib": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
@@ -10384,6 +10448,13 @@
         "xhr-request-promise": "^0.1.2"
       }
     },
+    "node_modules/web3-eth-accounts/node_modules/eth-lib/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/web3-eth-accounts/node_modules/uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -10393,6 +10464,25 @@
       "peer": true,
       "bin": {
         "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/web3-eth-accounts/node_modules/web3-utils": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethereumjs-util": "^7.1.0",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-contract": {
@@ -10410,6 +10500,25 @@
         "web3-core-subscriptions": "1.7.4",
         "web3-eth-abi": "1.7.4",
         "web3-utils": "1.7.4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-contract/node_modules/web3-utils": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethereumjs-util": "^7.1.0",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -10435,6 +10544,25 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/web3-eth-ens/node_modules/web3-utils": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethereumjs-util": "^7.1.0",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/web3-eth-iban": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.4.tgz",
@@ -10444,6 +10572,25 @@
       "dependencies": {
         "bn.js": "^5.2.1",
         "web3-utils": "1.7.4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-iban/node_modules/web3-utils": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethereumjs-util": "^7.1.0",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -10474,6 +10621,44 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/web3-eth-personal/node_modules/web3-utils": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethereumjs-util": "^7.1.0",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth/node_modules/web3-utils": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethereumjs-util": "^7.1.0",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/web3-net": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.7.4.tgz",
@@ -10484,6 +10669,25 @@
         "web3-core": "1.7.4",
         "web3-core-method": "1.7.4",
         "web3-utils": "1.7.4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-net/node_modules/web3-utils": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethereumjs-util": "^7.1.0",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -10550,6 +10754,25 @@
       }
     },
     "node_modules/web3-utils": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.5.tgz",
+      "integrity": "sha512-9AqNOziQky4wNQadEwEfHiBdOZqopIHzQQVzmvvv6fJwDSMhP+khqmAZC7YTiGjs0MboyZ8tWNivqSO1699XQw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethereumjs-util": "^7.1.0",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3/node_modules/web3-utils": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
       "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
@@ -10671,53 +10894,6 @@
         "string-width": "^1.0.2 || 2"
       }
     },
-    "node_modules/wide-align/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -10782,6 +10958,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -10815,6 +11000,41 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -10822,9 +11042,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -10977,6 +11197,50 @@
         "node": ">=10"
       }
     },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -11058,6 +11322,17 @@
         "buffer-xor": "^2.0.1",
         "ethereumjs-util": "^7.1.1",
         "miller-rabin": "^4.0.0"
+      },
+      "dependencies": {
+        "buffer-xor": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
+          "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.1"
+          }
+        }
       }
     },
     "@ethereumjs/tx": {
@@ -11347,16 +11622,6 @@
         "@ethersproject/web": "^5.6.1",
         "bech32": "1.1.4",
         "ws": "7.4.6"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "dev": true,
-          "peer": true,
-          "requires": {}
-        }
       }
     },
     "@ethersproject/random": {
@@ -11562,29 +11827,6 @@
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
         },
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "dev": true,
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        },
         "ethereumjs-util": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
@@ -11702,24 +11944,21 @@
         "undici": "^5.4.0"
       }
     },
-    "@openzeppelin/contracts": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.0.tgz",
-      "integrity": "sha512-52Qb+A1DdOss8QvJrijYYPSf32GUg2pGaG/yCxtaA3cu4jduouTdg4XZSMLW9op54m1jH7J8hoajhHKOPsoJFw=="
-    },
     "@openzeppelin/contracts-upgradeable": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.0.tgz",
-      "integrity": "sha512-wO3PyoAaAV/rA77cK8H4c3SbO98QylTjfiFxyvURUZKTFLV180rnAvna1x7/Nxvt0Gqv+jt1sXKC7ygxsq8iCw=="
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.2.tgz",
+      "integrity": "sha512-3dgc6qVmFch/uOmlmKnw5/v3JxwXcZD4T10/9CI1OUbX8AqjoZrBGKfxN1z3QxnIXRU/X31/BItJezJSDDTe7Q==",
+      "dev": true
     },
     "@openzeppelin/hardhat-upgrades": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.19.0.tgz",
-      "integrity": "sha512-351QqDO3nZ96g0BO/bQnaTflix4Nw4ELWC/hZ8PwicsuVxRmxN/GZhxPrs62AOdiQdZ+xweawrVXa5knliRd4A==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.19.1.tgz",
+      "integrity": "sha512-LvUClx+c8DIS6T5ZEPsz+HSRztvY9wjAI4qZH8IaTswjPAT/mqXZWmuQF96fFopR+jKpUNmI4IUo5wLt2TkdKQ==",
       "dev": true,
       "requires": {
         "@openzeppelin/upgrades-core": "^1.16.0",
         "chalk": "^4.1.0",
+        "debug": "^4.1.1",
         "proper-lockfile": "^4.1.1"
       },
       "dependencies": {
@@ -11775,12 +12014,11 @@
       }
     },
     "@openzeppelin/upgrades-core": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.16.1.tgz",
-      "integrity": "sha512-+hejbeAfsZWIQL5Ih13gkdm2KO6kbERc1ektzcyb25/OtUwaRjIIHxW++LdC/3Hg5uzThVOzJBfiLdAbgwD+OA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.17.0.tgz",
+      "integrity": "sha512-GaR3XiJ5PUKrHwz+EFJ9gtj2/taiFRWufbUaCgc1JEit1ERB9fI8PWEO0VTL+KzCZPl6meyT7RIhKNBRcX6jsA==",
       "dev": true,
       "requires": {
-        "bn.js": "^5.1.2",
         "cbor": "^8.0.0",
         "chalk": "^4.1.0",
         "compare-versions": "^4.0.0",
@@ -11998,9 +12236,9 @@
       "peer": true
     },
     "@truffle/interface-adapter": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.19.tgz",
-      "integrity": "sha512-x7IZvsyx36DAJCJVZ9gUe1Lh8AhODhJoW7I+lJXIlGxj3EmZbao4/sHo+cN4u9i94yVTyGwYd78NzbP0a/LAog==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.20.tgz",
+      "integrity": "sha512-GL0pNZ8vshlU4SokKD0L7Pb/Vrxcb5ZALGhH9+uKvm6bXnY6XjnxvEYZ1KgK/p+uoYCLY53g9Sgn/CXvcWmGLg==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -12078,14 +12316,14 @@
       }
     },
     "@truffle/provider": {
-      "version": "0.2.57",
-      "resolved": "https://registry.npmjs.org/@truffle/provider/-/provider-0.2.57.tgz",
-      "integrity": "sha512-O8VxF2uQwa+KB4HDg9lG7uhQ/+AOvchX+1STpQBSSAGfov1+EROM0iRZUNoPm71Pu0C9ji2WmXbNW/COjUMaMA==",
+      "version": "0.2.58",
+      "resolved": "https://registry.npmjs.org/@truffle/provider/-/provider-0.2.58.tgz",
+      "integrity": "sha512-WxglXYNz+YhgtLlocU9KjllmguP5xyFLcT/YHkEXvY6MuqLV2hcANswsTiB8axD+qaauBtwmVyJ0LS+ObJTzSw==",
       "dev": true,
       "peer": true,
       "requires": {
         "@truffle/error": "^0.1.0",
-        "@truffle/interface-adapter": "^0.5.19",
+        "@truffle/interface-adapter": "^0.5.20",
         "debug": "^4.3.1",
         "web3": "1.7.4"
       }
@@ -12188,8 +12426,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
       "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@types/chai-as-promised": {
       "version": "7.1.5",
@@ -12266,13 +12503,12 @@
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
       "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@types/node": {
-      "version": "18.0.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
-      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==",
+      "version": "18.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
+      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
       "dev": true
     },
     "@types/pbkdf2": {
@@ -12285,9 +12521,9 @@
       }
     },
     "@types/prettier": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
-      "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.4.tgz",
+      "integrity": "sha512-fOwvpvQYStpb/zHMx0Cauwywu9yLDmzWiiQBC7gJyq5tYLUXFZvDG7VK1B7WBxxjBJNKFOZ0zLoOQn8vmATbhw==",
       "dev": true,
       "peer": true
     },
@@ -12354,9 +12590,9 @@
       }
     },
     "acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true
     },
     "acorn-walk": {
@@ -12441,10 +12677,11 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
+      "peer": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -12575,8 +12812,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -12817,14 +13053,6 @@
         "evp_bytestokey": "^1.0.3",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
-      },
-      "dependencies": {
-        "buffer-xor": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-          "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-          "dev": true
-        }
       }
     },
     "browserify-cipher": {
@@ -12925,13 +13153,10 @@
       "peer": true
     },
     "buffer-xor": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
-      "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.1"
-      }
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true
     },
     "bufferutil": {
       "version": "4.0.6",
@@ -13023,7 +13248,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
       "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -13039,7 +13263,6 @@
           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
           "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
           "dev": true,
-          "peer": true,
           "requires": {
             "type-detect": "^4.0.0"
           }
@@ -13078,8 +13301,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
@@ -13170,43 +13392,6 @@
         "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-          "dev": true,
-          "peer": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-          "dev": true,
-          "peer": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "cliui": {
@@ -13218,6 +13403,40 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "clone-response": {
@@ -13426,9 +13645,9 @@
       "peer": true
     },
     "core-js-pure": {
-      "version": "3.23.5",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.23.5.tgz",
-      "integrity": "sha512-8t78LdpKSuCq4pJYCYk8hl7XEkAX+BP16yRIwL3AanTksxuEf7CM83vRyctmiEL8NDZ3jpUcv56fk9/zG3aIuw==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.1.tgz",
+      "integrity": "sha512-r1nJk41QLLPyozHUUPmILCEMtMw24NG4oWK6RbsDdjzQgg9ZvrUsPBj1MnG0wXXp1DCDU6j+wUvEmBSrtRbLXg==",
       "dev": true
     },
     "core-util-is": {
@@ -13926,9 +14145,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.61",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -13991,19 +14210,6 @@
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.2.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-          "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
       }
     },
     "esprima": {
@@ -14183,6 +14389,19 @@
           "dev": true,
           "peer": true
         },
+        "ethereum-cryptography": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
+          "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@noble/hashes": "1.1.2",
+            "@noble/secp256k1": "1.6.3",
+            "@scure/bip32": "1.1.0",
+            "@scure/bip39": "1.1.0"
+          }
+        },
         "ethers": {
           "version": "4.0.49",
           "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.49.tgz",
@@ -14254,13 +14473,6 @@
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.0"
           }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-          "dev": true,
-          "peer": true
         },
         "js-sha3": {
           "version": "0.5.7",
@@ -14588,15 +14800,26 @@
       }
     },
     "ethereum-cryptography": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
-      "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
       "dev": true,
       "requires": {
-        "@noble/hashes": "1.1.2",
-        "@noble/secp256k1": "1.6.3",
-        "@scure/bip32": "1.1.0",
-        "@scure/bip39": "1.1.0"
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
       }
     },
     "ethereumjs-abi": {
@@ -14623,29 +14846,6 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
-        },
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "dev": true,
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
         },
         "ethereumjs-util": {
           "version": "6.2.1",
@@ -14675,31 +14875,6 @@
         "create-hash": "^1.1.2",
         "ethereum-cryptography": "^0.1.3",
         "rlp": "^2.2.4"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "dev": true,
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
       }
     },
     "ethers": {
@@ -14881,9 +15056,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.6.1.tgz",
+          "integrity": "sha512-OvgH5rB0XM+iDZGQ1Eg/o7IZn0XYJFVrN/9FQ4OWIYILyJJgVP2s1hLTOFn6UOZoDUI/HctGa0PFlE2n2HW3NQ==",
           "dev": true,
           "peer": true
         }
@@ -15155,8 +15330,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.2",
@@ -15336,6 +15510,15 @@
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "har-schema": {
@@ -15410,6 +15593,20 @@
         "undici": "^5.4.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
+      },
+      "dependencies": {
+        "ethereum-cryptography": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
+          "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+          "dev": true,
+          "requires": {
+            "@noble/hashes": "1.1.2",
+            "@noble/secp256k1": "1.6.3",
+            "@scure/bip32": "1.1.0",
+            "@scure/bip39": "1.1.0"
+          }
+        }
       }
     },
     "hardhat-gas-reporter": {
@@ -15797,10 +15994,11 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "dev": true,
+      "peer": true
     },
     "is-function": {
       "version": "1.0.2",
@@ -16305,7 +16503,6 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
       "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "get-func-name": "^2.0.0"
       }
@@ -17154,8 +17351,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.1.2",
@@ -17998,6 +18194,13 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -18123,10 +18326,15 @@
       }
     },
     "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
     },
     "source-map-support": {
       "version": "0.5.21",
@@ -18136,6 +18344,14 @@
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "sprintf-js": {
@@ -18226,14 +18442,14 @@
       "peer": true
     },
     "string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "string.prototype.trimend": {
@@ -18261,12 +18477,13 @@
       }
     },
     "strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-hex-prefix": {
@@ -18437,12 +18654,48 @@
             "uri-js": "^4.2.2"
           }
         },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true,
+          "peer": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true,
+          "peer": true
+        },
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true,
           "peer": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
         }
       }
     },
@@ -18737,8 +18990,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "type-fest": {
       "version": "0.21.3",
@@ -18831,9 +19083,9 @@
       "peer": true
     },
     "uglify-js": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz",
-      "integrity": "sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
+      "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
       "dev": true,
       "optional": true,
       "peer": true
@@ -19007,6 +19259,24 @@
         "web3-net": "1.7.4",
         "web3-shh": "1.7.4",
         "web3-utils": "1.7.4"
+      },
+      "dependencies": {
+        "web3-utils": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+          "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "bn.js": "^5.2.1",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-bzz": {
@@ -19052,6 +19322,22 @@
           "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
           "dev": true,
           "peer": true
+        },
+        "web3-utils": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+          "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "bn.js": "^5.2.1",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
@@ -19064,6 +19350,24 @@
       "requires": {
         "web3-eth-iban": "1.7.4",
         "web3-utils": "1.7.4"
+      },
+      "dependencies": {
+        "web3-utils": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+          "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "bn.js": "^5.2.1",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-core-method": {
@@ -19078,6 +19382,24 @@
         "web3-core-promievent": "1.7.4",
         "web3-core-subscriptions": "1.7.4",
         "web3-utils": "1.7.4"
+      },
+      "dependencies": {
+        "web3-utils": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+          "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "bn.js": "^5.2.1",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-core-promievent": {
@@ -19134,6 +19456,24 @@
         "web3-eth-personal": "1.7.4",
         "web3-net": "1.7.4",
         "web3-utils": "1.7.4"
+      },
+      "dependencies": {
+        "web3-utils": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+          "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "bn.js": "^5.2.1",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-abi": {
@@ -19145,6 +19485,24 @@
       "requires": {
         "@ethersproject/abi": "^5.6.3",
         "web3-utils": "1.7.4"
+      },
+      "dependencies": {
+        "web3-utils": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+          "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "bn.js": "^5.2.1",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-accounts": {
@@ -19167,13 +19525,6 @@
         "web3-utils": "1.7.4"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-          "dev": true,
-          "peer": true
-        },
         "eth-lib": {
           "version": "0.2.8",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
@@ -19184,6 +19535,15 @@
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+              "dev": true,
+              "peer": true
+            }
           }
         },
         "uuid": {
@@ -19192,6 +19552,22 @@
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
           "dev": true,
           "peer": true
+        },
+        "web3-utils": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+          "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "bn.js": "^5.2.1",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
@@ -19210,6 +19586,24 @@
         "web3-core-subscriptions": "1.7.4",
         "web3-eth-abi": "1.7.4",
         "web3-utils": "1.7.4"
+      },
+      "dependencies": {
+        "web3-utils": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+          "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "bn.js": "^5.2.1",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-ens": {
@@ -19227,6 +19621,24 @@
         "web3-eth-abi": "1.7.4",
         "web3-eth-contract": "1.7.4",
         "web3-utils": "1.7.4"
+      },
+      "dependencies": {
+        "web3-utils": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+          "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "bn.js": "^5.2.1",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-iban": {
@@ -19238,6 +19650,24 @@
       "requires": {
         "bn.js": "^5.2.1",
         "web3-utils": "1.7.4"
+      },
+      "dependencies": {
+        "web3-utils": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+          "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "bn.js": "^5.2.1",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-personal": {
@@ -19261,6 +19691,22 @@
           "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
           "dev": true,
           "peer": true
+        },
+        "web3-utils": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+          "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "bn.js": "^5.2.1",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
@@ -19274,6 +19720,24 @@
         "web3-core": "1.7.4",
         "web3-core-method": "1.7.4",
         "web3-utils": "1.7.4"
+      },
+      "dependencies": {
+        "web3-utils": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
+          "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "bn.js": "^5.2.1",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-providers-http": {
@@ -19324,9 +19788,9 @@
       }
     },
     "web3-utils": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
-      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.5.tgz",
+      "integrity": "sha512-9AqNOziQky4wNQadEwEfHiBdOZqopIHzQQVzmvvv6fJwDSMhP+khqmAZC7YTiGjs0MboyZ8tWNivqSO1699XQw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -19427,43 +19891,6 @@
       "peer": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-          "dev": true,
-          "peer": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-          "dev": true,
-          "peer": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "word-wrap": {
@@ -19517,6 +19944,12 @@
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -19540,6 +19973,32 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
         }
       }
     },
@@ -19550,9 +20009,9 @@
       "dev": true
     },
     "ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true,
       "requires": {}
     },
@@ -19650,6 +20109,40 @@
         "string-width": "^4.2.0",
         "y18n": "^5.0.5",
         "yargs-parser": "^20.2.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,35 @@
 {
+  "name": "brlc-periphery",
+  "version": "1.0.0",
+  "description": "The periphery smart contracts, which is used together with the BRLC token",
+  "scripts": {
+    "test": "npx hardhat test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudwalk/brlc-periphery.git"
+  },
+  "keywords": [
+    "blockchain",
+    "solidity",
+    "BRLC"
+  ],
+  "author": "CloudWalk",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/cloudwalk/brlc-periphery/issues"
+  },
+  "homepage": "https://github.com/cloudwalk/brlc-periphery#readme",
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^1.0.2",
-    "@openzeppelin/hardhat-upgrades": "^1.19.0",
+    "@openzeppelin/contracts-upgradeable": "^4.7.2",
+    "@openzeppelin/hardhat-upgrades": "^1.19.1",
+    "@types/chai": "^4.3.1",
+    "@types/mocha": "^9.1.1",
+    "@types/node": "^18.6.3",
+    "chai": "^4.3.6",
     "hardhat": "^2.10.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
-  },
-  "dependencies": {
-    "@openzeppelin/contracts": "^4.7.0",
-    "@openzeppelin/contracts-upgradeable": "^4.7.0"
   }
 }

--- a/test-utils/README.md
+++ b/test-utils/README.md
@@ -1,0 +1,3 @@
+## Test utils directory
+
+This directory contains some custom utilities used in the tests

--- a/test-utils/eth.ts
+++ b/test-utils/eth.ts
@@ -1,0 +1,6 @@
+import { TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider"
+
+export async function proveTx(txResponsePromise: Promise<TransactionResponse>): Promise<TransactionReceipt> {
+  const txReceipt = await txResponsePromise;
+  return txReceipt.wait();
+}

--- a/test-utils/misc.ts
+++ b/test-utils/misc.ts
@@ -1,0 +1,43 @@
+function countNumberArrayTotal(array: number[]) {
+  return array.reduce((sum: number, currentValue: number) => {
+    return sum + currentValue;
+  });
+}
+
+function createBytesString(
+  baseString: string | number | undefined,
+  byteLength: number
+) {
+  baseString = !baseString ? "" : baseString.toString();
+  if (baseString.length > byteLength * 2) {
+    throw new Error(
+      `Creating of bytes string failed. ` +
+      `The length of the base string if greater than allowed maximum length. ` +
+      `The base string: '${baseString}'. ` +
+      `The target byte length: '${byteLength}'`
+    );
+  }
+  if (!/^[0-9a-fA-F]+$/.test(baseString)) {
+    throw new Error(
+      `Creating of bytes16 string failed. ` +
+      `The base string content is incorrect. ` +
+      `The base string: '${baseString}'`
+    );
+  }
+
+  return (
+    "0x" +
+    "0".repeat(byteLength * 2 - baseString.length) +
+    baseString.toLowerCase()
+  );
+}
+
+function createRevertMessageDueToMissingRole(address: string, role: string) {
+  return `AccessControl: account ${address.toLowerCase()} is missing role ${role.toLowerCase()}`;
+}
+
+export {
+  countNumberArrayTotal,
+  createBytesString,
+  createRevertMessageDueToMissingRole
+}

--- a/test/CardPaymentProcessorUpgradeable.test.ts
+++ b/test/CardPaymentProcessorUpgradeable.test.ts
@@ -79,36 +79,22 @@ function checkEquality(
 }
 
 describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
-  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED =
-    "Initializable: contract is already initialized";
-  const REVERT_MESSAGE_IF_CALLER_IS_NEW_REVOCATION_COUNTER_MAXIMUM_VALUE_IS_ZERO =
-    "CardPaymentProcessor: new value of the revocation counter maximum must be greater than 0";
-  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED =
-    "Pausable: paused";
-  const REVERT_MESSAGE_IF_PAYMENT_AMOUNT_IS_ZERO =
-    "CardPaymentProcessor: payment amount must be greater than 0";
-  const REVERT_MESSAGE_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY =
-    "CardPaymentProcessor: input array of authorization IDs is empty";
-  const REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO =
-    "CardPaymentProcessor: authorization ID must not equal 0";
-  const REVERT_MESSAGE_IF_CASH_OUT_ACCOUNT_IS_ZERO_ADDRESS =
-    "CardPaymentProcessor: cash out account is the zero address";
-  const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE =
-    "ERC20: transfer amount exceeds balance";
-  const REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_ALREADY_EXISTS =
-    "CardPaymentProcessor: payment with the provided authorization ID already exists and was not revoked";
-  const REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST =
-    "CardPaymentProcessor: payment with the provided authorization ID does not exist";
-  const REVERT_MESSAGE_IF_PAYMENT_IS_CLEARED =
-    "CardPaymentProcessor: payment with the provided authorization ID is cleared";
-  const REVERT_MESSAGE_IF_PAYMENT_IS_UNCLEARED =
-    "CardPaymentProcessor: payment with the provided authorization ID is uncleared";
-  const REVERT_MESSAGE_IF_PARENT_TX_HASH_IS_ZERO =
-    "CardPaymentProcessor: parent transaction hash should not equal 0";
-  const REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS =
-    "CardPaymentProcessor: payment with the provided authorization ID has an inappropriate status";
-  const REVERT_MESSAGE_IF_PAYMENT_REVOCATION_COUNTER_HAS_REACHED_MAXIMUM =
-    "CardPaymentProcessor: revocation counter of the payment has reached the configured maximum";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+  const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
+
+  const REVERT_ERROR_IF_NEW_REVOCATION_COUNTER_MAXIMUM_VALUE_IS_ZERO = "ZeroNewValueOfRevocationCounterMaximum";
+  const REVERT_ERROR_IF_PAYMENT_AMOUNT_IS_ZERO = "ZeroPaymentAmount";
+  const REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO = "ZeroAuthorizationId";
+  const REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS = "PaymentAlreadyExists";
+  const REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST = "PaymentDoesNotExit";
+  const REVERT_ERROR_IF_PAYMENT_IS_CLEARED = "PaymentIsCleared";
+  const REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY = "EmptyInputArrayOfAuthorizationIds";
+  const REVERT_ERROR_IF_PAYMENT_IS_UNCLEARED = "PaymentIsUncleared";
+  const REVERT_ERROR_IF_PARENT_TX_HASH_IS_ZERO = "ZeroParentTransactionHash";
+  const REVERT_ERROR_IF_CASH_OUT_ACCOUNT_IS_ZERO_ADDRESS = "ZeroCashOutAccount";
+  const REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS = "InappropriatePaymentStatus";
+  const REVERT_ERROR_IF_PAYMENT_REVOCATION_COUNTER_REACHED_MAXIMUM = "RevocationCounterReachedMaximum";
 
   let cardPaymentProcessor: Contract;
   let tokenMock: Contract;
@@ -308,7 +294,10 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
 
     it("Is reverted if the new value is zero", async () => {
       await expect(cardPaymentProcessor.setRevocationCounterMaximum(0))
-        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NEW_REVOCATION_COUNTER_MAXIMUM_VALUE_IS_ZERO);
+        .to.be.revertedWithCustomError(
+          cardPaymentProcessor,
+          REVERT_ERROR_IF_NEW_REVOCATION_COUNTER_MAXIMUM_VALUE_IS_ZERO
+        );
     });
 
     it("Emits the correct event, changes the revocation counter maximum properly", async () => {
@@ -368,7 +357,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
         zeroAmount,
         authorizationId,
         correlationId
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AMOUNT_IS_ZERO);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AMOUNT_IS_ZERO);
     });
 
     it("Is reverted if the payment authorization ID is zero", async () => {
@@ -376,7 +365,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
         payment.amount,
         ZERO_BYTES16_STRING,
         correlationId
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
     });
 
     it("Is reverted if the user has not enough token balance", async () => {
@@ -422,7 +411,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
         payment.amount + 1,
         authorizationId,
         otherMakingPaymentCorrelationsId
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_ALREADY_EXISTS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
     });
   });
 
@@ -463,13 +452,13 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
     it("Is reverted if the payment authorization ID is zero", async () => {
       await expect(cardPaymentProcessor.connect(admin).clearPayment(
         ZERO_BYTES16_STRING
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
     });
 
     it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
       await expect(cardPaymentProcessor.connect(admin).clearPayment(
         createBytesString(payment.authorizationId + 1, BYTES16_LENGTH)
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Does not transfer tokens, emits the correct event, changes the state properly", async () => {
@@ -503,7 +492,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
       ));
       await expect(cardPaymentProcessor.connect(admin).clearPayment(
         authorizationId
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_IS_CLEARED);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_CLEARED);
     });
   });
 
@@ -563,13 +552,13 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
     it("Is reverted if the payment authorization IDs array is empty", async () => {
       await expect(cardPaymentProcessor.connect(admin).clearPayments(
         []
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
     });
 
     it("Is reverted if one of the payment authorization IDs is zero", async () => {
       await expect(cardPaymentProcessor.connect(admin).clearPayments(
         [authorizationIds[0], ZERO_BYTES16_STRING]
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
     });
 
     it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
@@ -578,7 +567,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
           authorizationIds[0],
           createBytesString(payments[payments.length - 1].authorizationId + 1, BYTES16_LENGTH),
         ]
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Is reverted if one of the payments has been already cleared", async () => {
@@ -587,7 +576,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
       ));
       await expect(cardPaymentProcessor.connect(admin).clearPayments(
         authorizationIds
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_IS_CLEARED);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_CLEARED);
     });
 
     it("Does not transfer tokens, emits the correct events, changes the state properly", async () => {
@@ -662,13 +651,13 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
     it("Is reverted if the payment authorization ID is zero", async () => {
       await expect(cardPaymentProcessor.connect(admin).unclearPayment(
         ZERO_BYTES16_STRING
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
     });
 
     it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
       await expect(cardPaymentProcessor.connect(admin).unclearPayment(
         createBytesString(payment.authorizationId + 1, BYTES16_LENGTH)
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Does not transfer tokens, emits the correct event, changes the state properly", async () => {
@@ -702,7 +691,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
       ));
       await expect(cardPaymentProcessor.connect(admin).unclearPayment(
         authorizationId
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_IS_UNCLEARED);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_UNCLEARED);
     });
   });
 
@@ -761,13 +750,13 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
     it("Is reverted if the payment authorization IDs array is empty", async () => {
       await expect(cardPaymentProcessor.connect(admin).unclearPayments(
         []
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
     });
 
     it("Is reverted if one of the payment authorization IDs is zero", async () => {
       await expect(cardPaymentProcessor.connect(admin).unclearPayments(
         [authorizationIds[0], ZERO_BYTES16_STRING]
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
     });
 
     it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
@@ -776,7 +765,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
           authorizationIds[0],
           createBytesString(payments[payments.length - 1].authorizationId + 1, BYTES16_LENGTH)
         ]
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Is reverted if one of the payments is uncleared", async () => {
@@ -785,7 +774,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
       ));
       await expect(cardPaymentProcessor.connect(admin).unclearPayments(
         authorizationIds
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_IS_UNCLEARED);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_UNCLEARED);
     });
 
     it("Does not transfer tokens, emits the correct events, changes the state properly", async () => {
@@ -870,7 +859,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
         ZERO_BYTES16_STRING,
         reversingPaymentCorrelationId,
         parentTxHash
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
     });
 
     it("Is reverted if the parent transaction hash is zero", async () => {
@@ -878,7 +867,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
         authorizationId,
         reversingPaymentCorrelationId,
         ZERO_BYTES32_STRING,
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PARENT_TX_HASH_IS_ZERO);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PARENT_TX_HASH_IS_ZERO);
     });
 
     it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
@@ -886,7 +875,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
         createBytesString(payment.authorizationId + 1, BYTES16_LENGTH),
         reversingPaymentCorrelationId,
         parentTxHash
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     describe("Transfers tokens as expected, emits the correct event, changes the state properly", async () => {
@@ -983,7 +972,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
         ZERO_BYTES16_STRING,
         reversingPaymentCorrelationId,
         parentTxHash
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
     });
 
     it("Is reverted if the parent transaction hash is zero", async () => {
@@ -991,7 +980,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
         authorizationId,
         reversingPaymentCorrelationId,
         ZERO_BYTES32_STRING,
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PARENT_TX_HASH_IS_ZERO);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PARENT_TX_HASH_IS_ZERO);
     });
 
     it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
@@ -999,7 +988,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
         createBytesString(payment.authorizationId + 1, BYTES16_LENGTH),
         reversingPaymentCorrelationId,
         parentTxHash
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     describe("Transfers tokens as expected, emits the correct event, changes the state properly", async () => {
@@ -1090,21 +1079,21 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
       await expect(cardPaymentProcessor.connect(admin).confirmPayment(
         ZERO_BYTES16_STRING,
         cashOutAccount.address
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
     });
 
     it("Is reverted if the input cash out account is the zero address", async () => {
       await expect(cardPaymentProcessor.connect(admin).confirmPayment(
         authorizationId,
         ethers.constants.AddressZero
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_CASH_OUT_ACCOUNT_IS_ZERO_ADDRESS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASH_OUT_ACCOUNT_IS_ZERO_ADDRESS);
     });
 
     it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
       await expect(cardPaymentProcessor.connect(admin).confirmPayment(
         createBytesString(payment.authorizationId + 1, BYTES16_LENGTH),
         cashOutAccount.address
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Is reverted if the payment is uncleared", async () => {
@@ -1114,7 +1103,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
       await expect(cardPaymentProcessor.connect(admin).confirmPayment(
         authorizationId,
         cashOutAccount.address
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_IS_UNCLEARED);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_UNCLEARED);
     });
 
     it("Transfers tokens as expected, emits the correct event, changes the state properly", async () => {
@@ -1206,21 +1195,21 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
       await expect(cardPaymentProcessor.connect(admin).confirmPayments(
         [],
         cashOutAccount.address
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
     });
 
     it("Is reverted if the input cash out account is the zero address", async () => {
       await expect(cardPaymentProcessor.connect(admin).confirmPayments(
         authorizationIds,
         ethers.constants.AddressZero
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_CASH_OUT_ACCOUNT_IS_ZERO_ADDRESS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASH_OUT_ACCOUNT_IS_ZERO_ADDRESS);
     });
 
     it("Is reverted if one of the payment authorization IDs is zero", async () => {
       await expect(cardPaymentProcessor.connect(admin).confirmPayments(
         [authorizationIds[0], ZERO_BYTES16_STRING],
         cashOutAccount.address
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
     });
 
     it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
@@ -1230,7 +1219,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
           createBytesString(payments[payments.length - 1].authorizationId + 1, BYTES16_LENGTH)
         ],
         cashOutAccount.address
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Is reverted if one of the payments is uncleared", async () => {
@@ -1240,7 +1229,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
       await expect(cardPaymentProcessor.connect(admin).confirmPayments(
         authorizationIds,
         cashOutAccount.address
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_IS_UNCLEARED);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_UNCLEARED);
     });
 
     it("Transfer tokens, emits the correct events, changes the state properly", async () => {
@@ -1289,41 +1278,41 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
     async function checkRevertingOfAllPaymentProcessingFunctionsExceptMaking() {
       await expect(cardPaymentProcessor.connect(admin).clearPayment(
         authorizationIds[0],
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
 
       await expect(cardPaymentProcessor.connect(admin).clearPayments(
         authorizationIds,
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
 
       await expect(cardPaymentProcessor.connect(admin).unclearPayment(
         authorizationIds[0],
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
 
       await expect(cardPaymentProcessor.connect(admin).unclearPayments(
         authorizationIds,
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
 
       await expect(cardPaymentProcessor.connect(admin).revokePayment(
         authorizationIds[0],
         someCorrelationId,
         someParentTxHash
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
 
       await expect(cardPaymentProcessor.connect(admin).reversePayment(
         authorizationIds[0],
         someCorrelationId,
         someParentTxHash
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
 
       await expect(cardPaymentProcessor.connect(admin).confirmPayment(
         authorizationIds[0],
         cashOutAccount.address
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
 
       await expect(cardPaymentProcessor.connect(admin).confirmPayments(
         authorizationIds,
         cashOutAccount.address
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
     }
 
     beforeEach(async () => {
@@ -1401,7 +1390,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
         payments[0].amount,
         authorizationIds[0],
         createBytesString(payments[0].makingPaymentCorrelationId, BYTES16_LENGTH)
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_ALREADY_EXISTS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
 
       await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking();
       await checkCardPaymentProcessorState(payments);
@@ -1417,7 +1406,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
         payments[0].amount,
         authorizationIds[0],
         createBytesString(payments[0].makingPaymentCorrelationId, BYTES16_LENGTH)
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_ALREADY_EXISTS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
 
       await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking();
       await checkCardPaymentProcessorState(payments);
@@ -1431,7 +1420,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
         payments[0].amount,
         authorizationIds[0],
         someCorrelationId
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_ALREADY_EXISTS);
+      )).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
     });
 
     it("Making payment function is reverted if the revocation counter has reached the maximum", async () => {
@@ -1455,7 +1444,10 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
         payments[0].amount,
         authorizationIds[0],
         someCorrelationId
-      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_REVOCATION_COUNTER_HAS_REACHED_MAXIMUM);
+      )).to.be.revertedWithCustomError(
+        cardPaymentProcessor,
+        REVERT_ERROR_IF_PAYMENT_REVOCATION_COUNTER_REACHED_MAXIMUM
+      );
     });
   });
 });

--- a/test/CardPaymentProcessorUpgradeable.test.ts
+++ b/test/CardPaymentProcessorUpgradeable.test.ts
@@ -1,0 +1,1461 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../test-utils/eth";
+import { countNumberArrayTotal, createBytesString, createRevertMessageDueToMissingRole } from "../test-utils/misc";
+
+const BYTES16_LENGTH: number = 16;
+const BYTES32_LENGTH: number = 32;
+const ZERO_BYTES16_STRING: string = createBytesString("00", BYTES16_LENGTH);
+const ZERO_BYTES32_STRING: string = createBytesString("00", BYTES32_LENGTH);
+const SOME_BYTES16_STRING = createBytesString("ABCD", BYTES16_LENGTH);
+const SOME_BYTES32_STRING = createBytesString("DCBA", BYTES32_LENGTH);
+
+enum PaymentStatus {
+  Nonexistent = 0,
+  Uncleared = 1,
+  Cleared = 2,
+  Revoked = 3,
+  Reversed = 4,
+  Confirmed = 5,
+}
+
+interface TestPayment {
+  authorizationId: number;
+  account: SignerWithAddress;
+  amount: number;
+  status: PaymentStatus;
+  revocationCounter?: number;
+  makingPaymentCorrelationId: number;
+  parentTxHash?: string;
+}
+
+interface CardPaymentProcessorState {
+  tokenBalance: number;
+  totalClearedBalance: number;
+  totalUnclearedBalance: number;
+  clearedBalancesPerAccount: Map<string, number>;
+  unclearedBalancesPerAccount: Map<string, number>;
+}
+
+function checkEquality(
+  actualOnChainPayment: any,
+  expectedPayment: TestPayment,
+  paymentIndex: number
+) {
+  if (expectedPayment.status == PaymentStatus.Nonexistent) {
+    expect(actualOnChainPayment.account).to.equal(
+      ethers.constants.AddressZero,
+      `payment[${paymentIndex}].account is incorrect`
+    );
+    expect(actualOnChainPayment.amount).to.equal(
+      0,
+      `payment[${paymentIndex}].amount is incorrect`
+    );
+    expect(actualOnChainPayment.amount).to.equal(
+      0,
+      `payment[${paymentIndex}].status is incorrect`
+    );
+    expect(actualOnChainPayment.revocationCounter).to.equal(0);
+  } else {
+    expect(actualOnChainPayment.account).to.equal(
+      expectedPayment.account.address,
+      `payment[${paymentIndex}].account is incorrect`
+    );
+    expect(actualOnChainPayment.amount).to.equal(
+      expectedPayment.amount,
+      `payment[${paymentIndex}].amount is incorrect`
+    );
+    expect(actualOnChainPayment.status).to.equal(
+      expectedPayment.status,
+      `payment[${paymentIndex}].status is incorrect`
+    );
+    expect(actualOnChainPayment.revocationCounter).to.equal(
+      expectedPayment.revocationCounter || 0,
+      `payment[${paymentIndex}].revocationCounter is incorrect`
+    );
+  }
+}
+
+describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED =
+    "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CALLER_IS_NEW_REVOCATION_COUNTER_MAXIMUM_VALUE_IS_ZERO =
+    "CardPaymentProcessor: new value of the revocation counter maximum must be greater than 0";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED =
+    "Pausable: paused";
+  const REVERT_MESSAGE_IF_PAYMENT_AMOUNT_IS_ZERO =
+    "CardPaymentProcessor: payment amount must be greater than 0";
+  const REVERT_MESSAGE_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY =
+    "CardPaymentProcessor: input array of authorization IDs is empty";
+  const REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO =
+    "CardPaymentProcessor: authorization ID must not equal 0";
+  const REVERT_MESSAGE_IF_CASH_OUT_ACCOUNT_IS_ZERO_ADDRESS =
+    "CardPaymentProcessor: cash out account is the zero address";
+  const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE =
+    "ERC20: transfer amount exceeds balance";
+  const REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_ALREADY_EXISTS =
+    "CardPaymentProcessor: payment with the provided authorization ID already exists and was not revoked";
+  const REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST =
+    "CardPaymentProcessor: payment with the provided authorization ID does not exist";
+  const REVERT_MESSAGE_IF_PAYMENT_IS_CLEARED =
+    "CardPaymentProcessor: payment with the provided authorization ID is cleared";
+  const REVERT_MESSAGE_IF_PAYMENT_IS_UNCLEARED =
+    "CardPaymentProcessor: payment with the provided authorization ID is uncleared";
+  const REVERT_MESSAGE_IF_PARENT_TX_HASH_IS_ZERO =
+    "CardPaymentProcessor: parent transaction hash should not equal 0";
+  const REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS =
+    "CardPaymentProcessor: payment with the provided authorization ID has an inappropriate status";
+  const REVERT_MESSAGE_IF_PAYMENT_REVOCATION_COUNTER_HAS_REACHED_MAXIMUM =
+    "CardPaymentProcessor: revocation counter of the payment has reached the configured maximum";
+
+  let cardPaymentProcessor: Contract;
+  let tokenMock: Contract;
+  let deployer: SignerWithAddress;
+  let user1: SignerWithAddress;
+  let user2: SignerWithAddress;
+  let ownerRole: string;
+  let pauserRole: string;
+  let executorRole: string;
+
+  async function setUpContractsForPayments(payments: TestPayment[]) {
+    for (let payment of payments) {
+      await proveTx(tokenMock.mint(payment.account.address, payment.amount));
+      const allowance: BigNumber = await tokenMock.allowance(payment.account.address, cardPaymentProcessor.address);
+      if (allowance.lt(BigNumber.from(ethers.constants.MaxUint256))) {
+        await proveTx(tokenMock.connect(payment.account).approve(
+          cardPaymentProcessor.address,
+          ethers.constants.MaxUint256
+        ));
+      }
+    }
+  }
+
+  async function makePayments(payments: TestPayment[]) {
+    for (let payment of payments) {
+      await proveTx(cardPaymentProcessor.connect(payment.account).makePayment(
+        payment.amount,
+        createBytesString(payment.authorizationId, BYTES16_LENGTH),
+        createBytesString(payment.makingPaymentCorrelationId, BYTES16_LENGTH)
+      ));
+      payment.status = PaymentStatus.Uncleared;
+    }
+  }
+
+  async function setExecutorRole(account: SignerWithAddress) {
+    await proveTx(cardPaymentProcessor.grantRole(executorRole, account.address));
+  }
+
+  async function clearPayments(payments: TestPayment[], adminAccount: SignerWithAddress) {
+    const authorizationIds: string[] = [];
+    payments.forEach((payment: TestPayment) => {
+      authorizationIds.push(createBytesString(payment.authorizationId, BYTES16_LENGTH));
+      payment.status = PaymentStatus.Cleared;
+    });
+    await proveTx(cardPaymentProcessor.connect(adminAccount).clearPayments(authorizationIds));
+  }
+
+  function defineBalancesPerAccount(payments: TestPayment[], targetPaymentStatus: PaymentStatus): Map<string, number> {
+    const balancesPerAccount: Map<string, number> = new Map<string, number>();
+
+    payments.forEach((payment: TestPayment) => {
+      const address: string = payment.account.address;
+      let newBalance: number = balancesPerAccount.get(address) || 0;
+      if (payment.status == targetPaymentStatus) {
+        newBalance += payment.amount;
+      }
+      balancesPerAccount.set(address, newBalance);
+    });
+
+    return balancesPerAccount;
+  }
+
+  function defineExpectedCardPaymentProcessorState(payments: TestPayment[]): CardPaymentProcessorState {
+    const tokenBalance: number = countNumberArrayTotal(
+      payments.map(
+        function (payment: TestPayment): number {
+          return payment.status == PaymentStatus.Uncleared || payment.status == PaymentStatus.Cleared
+            ? payment.amount
+            : 0;
+        }
+      )
+    );
+    const totalClearedBalance: number = countNumberArrayTotal(
+      payments.map(
+        function (payment: TestPayment): number {
+          return payment.status == PaymentStatus.Cleared ? payment.amount : 0;
+        }
+      )
+    );
+    const totalUnclearedBalance: number = countNumberArrayTotal(payments.map(
+        function (payment: TestPayment): number {
+          return payment.status == PaymentStatus.Uncleared ? payment.amount : 0;
+        }
+      )
+    );
+    const clearedBalancesPerAccount: Map<string, number> =
+      defineBalancesPerAccount(payments, PaymentStatus.Cleared);
+    const unclearedBalancesPerAccount: Map<string, number> =
+      defineBalancesPerAccount(payments, PaymentStatus.Uncleared);
+
+    return {
+      tokenBalance,
+      totalUnclearedBalance,
+      totalClearedBalance,
+      clearedBalancesPerAccount,
+      unclearedBalancesPerAccount,
+    };
+  }
+
+  async function checkPaymentStructuresOnBlockchain(payments: TestPayment[]) {
+    for (let i = 0; i < payments.length; ++i) {
+      const expectedPayment: TestPayment = payments[i];
+      const actualPayment = await cardPaymentProcessor.paymentFor(
+        createBytesString(expectedPayment.authorizationId, BYTES16_LENGTH)
+      );
+      checkEquality(actualPayment, expectedPayment, i);
+      if (!!expectedPayment.parentTxHash) {
+        expect(await cardPaymentProcessor.isPaymentReversed(expectedPayment.parentTxHash)).to.equal(
+          expectedPayment.status == PaymentStatus.Reversed
+        );
+        expect(await cardPaymentProcessor.isPaymentRevoked(expectedPayment.parentTxHash)).to.equal(
+          expectedPayment.status == PaymentStatus.Revoked
+        );
+      }
+    }
+  }
+
+  async function checkBalancesOnBlockchain(
+    expectedBalancesPerAccount: Map<string, number>,
+    isClearedBalance: boolean
+  ) {
+    for (const account of expectedBalancesPerAccount.keys()) {
+      const expectedBalance = expectedBalancesPerAccount.get(account);
+      if (!expectedBalance) {
+        continue;
+      }
+      if (isClearedBalance) {
+        expect(await cardPaymentProcessor.clearedBalanceOf(account)).to.equal(
+          expectedBalance,
+          `The cleared balance for account ${account} is wrong`
+        );
+      } else {
+        expect(await cardPaymentProcessor.unclearedBalanceOf(account)).to.equal(
+          expectedBalance,
+          `The uncleared balance for account ${account} is wrong`
+        );
+      }
+    }
+  }
+
+  async function checkCardPaymentProcessorState(payments: TestPayment[]) {
+    const expectedState: CardPaymentProcessorState = defineExpectedCardPaymentProcessorState(payments);
+    await checkPaymentStructuresOnBlockchain(payments);
+    await checkBalancesOnBlockchain(expectedState.clearedBalancesPerAccount, true);
+    await checkBalancesOnBlockchain(expectedState.unclearedBalancesPerAccount, false);
+
+    expect(await cardPaymentProcessor.totalClearedBalance()).to.equal(
+      expectedState.totalClearedBalance,
+      `The total cleared balance is wrong`
+    );
+
+    expect(await cardPaymentProcessor.totalUnclearedBalance()).to.equal(
+      expectedState.totalUnclearedBalance,
+      `The total uncleared balance is wrong`
+    );
+
+    expect(await tokenMock.balanceOf(cardPaymentProcessor.address)).to.equal(
+      expectedState.tokenBalance,
+      `The processor token balance is wrong`
+    );
+  }
+
+  beforeEach(async () => {
+    // Deploy the token mock contract
+    const TokenMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    tokenMock = await upgrades.deployProxy(TokenMock, ["BRL Coin", "BRLC"]);
+    await tokenMock.deployed();
+
+    // Deploy the being tested contract
+    const CardPaymentProcessor: ContractFactory = await ethers.getContractFactory("CardPaymentProcessorUpgradeable");
+    cardPaymentProcessor = await upgrades.deployProxy(CardPaymentProcessor, [tokenMock.address]);
+    await cardPaymentProcessor.deployed();
+
+    // Get user accounts
+    [deployer, user1, user2] = await ethers.getSigners();
+
+    //Roles
+    ownerRole = (await cardPaymentProcessor.OWNER_ROLE()).toLowerCase();
+    pauserRole = (await cardPaymentProcessor.PAUSER_ROLE()).toLowerCase();
+    executorRole = (await cardPaymentProcessor.EXECUTOR_ROLE()).toLowerCase();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(cardPaymentProcessor.initialize(tokenMock.address))
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Function 'setRevocationCounterMaximum()'", async () => {
+    const revocationCounterNewValue: number = 123;
+    const revocationCounterMaximumDefaultValue: number = 255;
+
+    it("Is reverted if is called not by the account with the owner role", async () => {
+      await expect(cardPaymentProcessor.connect(user1).setRevocationCounterMaximum(
+        revocationCounterNewValue
+      )).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
+    });
+
+    it("Is reverted if the new value is zero", async () => {
+      await expect(cardPaymentProcessor.setRevocationCounterMaximum(0))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NEW_REVOCATION_COUNTER_MAXIMUM_VALUE_IS_ZERO);
+    });
+
+    it("Emits the correct event, changes the revocation counter maximum properly", async () => {
+      expect(await cardPaymentProcessor.revocationCounterMaximum()).to.equal(revocationCounterMaximumDefaultValue);
+      await expect(cardPaymentProcessor.setRevocationCounterMaximum(
+        revocationCounterNewValue
+      )).to.emit(
+        cardPaymentProcessor,
+        "SetRevocationCounterMaximum"
+      ).withArgs(
+        revocationCounterMaximumDefaultValue,
+        revocationCounterNewValue
+      );
+    });
+
+    it("Does not emit events if the new value equals the old one", async () => {
+      await expect(cardPaymentProcessor.setRevocationCounterMaximum(
+        revocationCounterMaximumDefaultValue
+      )).not.to.emit(
+        cardPaymentProcessor,
+        "SetRevocationCounterMaximum"
+      );
+    });
+  });
+
+  describe("Function 'makePayment()'", async () => {
+    let payment: TestPayment;
+    let authorizationId: string;
+    let correlationId: string;
+
+    beforeEach(async () => {
+      payment = {
+        authorizationId: 123,
+        account: user1,
+        amount: 234,
+        status: PaymentStatus.Nonexistent,
+        makingPaymentCorrelationId: 345,
+      };
+      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
+      correlationId = createBytesString(payment.makingPaymentCorrelationId, BYTES16_LENGTH);
+      await setUpContractsForPayments([payment]);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
+      await proveTx(cardPaymentProcessor.pause());
+      await expect(cardPaymentProcessor.connect(payment.account).makePayment(
+        payment.amount,
+        authorizationId,
+        correlationId
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the payment token amount is zero", async () => {
+      const zeroAmount: number = 0;
+      await expect(cardPaymentProcessor.connect(payment.account).makePayment(
+        zeroAmount,
+        authorizationId,
+        correlationId
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AMOUNT_IS_ZERO);
+    });
+
+    it("Is reverted if the payment authorization ID is zero", async () => {
+      await expect(cardPaymentProcessor.connect(payment.account).makePayment(
+        payment.amount,
+        ZERO_BYTES16_STRING,
+        correlationId
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the user has not enough token balance", async () => {
+      const excessTokenAmount: number = payment.amount + 1;
+      await expect(cardPaymentProcessor.connect(payment.account).makePayment(
+        excessTokenAmount,
+        authorizationId,
+        correlationId
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfers tokens as expected, emits the correct event, changes the state properly", async () => {
+      await checkCardPaymentProcessorState([payment]);
+      await expect(cardPaymentProcessor.connect(payment.account).makePayment(
+        payment.amount,
+        authorizationId,
+        correlationId
+      )).to.changeTokenBalances(
+        tokenMock,
+        [cardPaymentProcessor, payment.account],
+        [+payment.amount, -payment.amount]
+      ).and.to.emit(
+        cardPaymentProcessor,
+        "MakePayment"
+      ).withArgs(
+        authorizationId,
+        correlationId,
+        payment.account.address,
+        payment.amount,
+        payment.revocationCounter || 0
+      );
+      payment.status = PaymentStatus.Uncleared;
+      await checkCardPaymentProcessorState([payment]);
+    });
+
+    it("Is reverted if the payment authorization ID already exists", async () => {
+      await makePayments([payment]);
+      const otherMakingPaymentCorrelationsId: string = createBytesString(
+        payment.makingPaymentCorrelationId + 1,
+        BYTES16_LENGTH
+      );
+      await expect(cardPaymentProcessor.connect(payment.account).makePayment(
+        payment.amount + 1,
+        authorizationId,
+        otherMakingPaymentCorrelationsId
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_ALREADY_EXISTS);
+    });
+  });
+
+  describe("Function 'clearPayment()'", async () => {
+    let payment: TestPayment;
+    let admin: SignerWithAddress;
+    let authorizationId: string;
+
+    beforeEach(async () => {
+      payment = {
+        authorizationId: 123,
+        account: user1,
+        amount: 234,
+        status: PaymentStatus.Nonexistent,
+        makingPaymentCorrelationId: 345,
+      };
+      admin = user2;
+      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
+      await setUpContractsForPayments([payment]);
+      await setExecutorRole(admin);
+      await makePayments([payment]);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
+      await proveTx(cardPaymentProcessor.pause());
+      await expect(cardPaymentProcessor.connect(admin).clearPayment(
+        authorizationId
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the executor role", async () => {
+      await expect(cardPaymentProcessor.connect(deployer).clearPayment(
+        authorizationId
+      )).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+    });
+
+    it("Is reverted if the payment authorization ID is zero", async () => {
+      await expect(cardPaymentProcessor.connect(admin).clearPayment(
+        ZERO_BYTES16_STRING
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
+      await expect(cardPaymentProcessor.connect(admin).clearPayment(
+        createBytesString(payment.authorizationId + 1, BYTES16_LENGTH)
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+    });
+
+    it("Does not transfer tokens, emits the correct event, changes the state properly", async () => {
+      await checkCardPaymentProcessorState([payment]);
+      const expectedClearedBalance: number = payment.amount;
+      const expectedUnclearedBalance: number = 0;
+      await expect(cardPaymentProcessor.connect(admin).clearPayment(
+        authorizationId
+      )).to.changeTokenBalances(
+        tokenMock,
+        [cardPaymentProcessor, payment.account],
+        [0, 0]
+      ).and.to.emit(
+        cardPaymentProcessor,
+        "ClearPayment"
+      ).withArgs(
+        authorizationId,
+        payment.account.address,
+        payment.amount,
+        expectedClearedBalance,
+        expectedUnclearedBalance,
+        payment.revocationCounter || 0
+      );
+      payment.status = PaymentStatus.Cleared;
+      await checkCardPaymentProcessorState([payment]);
+    });
+
+    it("Is reverted if the payment has already been cleared", async () => {
+      await proveTx(cardPaymentProcessor.connect(admin).clearPayment(
+        authorizationId
+      ));
+      await expect(cardPaymentProcessor.connect(admin).clearPayment(
+        authorizationId
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_IS_CLEARED);
+    });
+  });
+
+  describe("Function 'clearPayments()'", async () => {
+    let payments: TestPayment[];
+    let admin: SignerWithAddress;
+    let authorizationIds: string[];
+    let accountAddresses: string[];
+    let expectedClearedBalances: number[];
+    let expectedUnclearedBalances: number[];
+
+    beforeEach(async () => {
+      payments = [
+        {
+          authorizationId: 123,
+          account: user1,
+          amount: 234,
+          status: PaymentStatus.Nonexistent,
+          makingPaymentCorrelationId: 345,
+        },
+        {
+          authorizationId: 456,
+          account: user2,
+          amount: 567,
+          status: PaymentStatus.Nonexistent,
+          makingPaymentCorrelationId: 789,
+        },
+      ];
+      admin = user2;
+      authorizationIds = payments.map(
+        (payment: TestPayment) => createBytesString(payment.authorizationId, BYTES16_LENGTH)
+      );
+      accountAddresses = payments.map(
+        (payment: TestPayment) => payment.account.address
+      );
+      expectedClearedBalances = payments.map((payment: TestPayment) => payment.amount);
+      expectedUnclearedBalances = payments.map(() => 0);
+      await setUpContractsForPayments(payments);
+      await setExecutorRole(admin);
+      await makePayments(payments);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
+      await proveTx(cardPaymentProcessor.pause());
+      await expect(cardPaymentProcessor.connect(admin).clearPayments(
+        authorizationIds
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the executor role", async () => {
+      await expect(cardPaymentProcessor.connect(deployer).clearPayments(
+        authorizationIds
+      )).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+    });
+
+    it("Is reverted if the payment authorization IDs array is empty", async () => {
+      await expect(cardPaymentProcessor.connect(admin).clearPayments(
+        []
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
+    });
+
+    it("Is reverted if one of the payment authorization IDs is zero", async () => {
+      await expect(cardPaymentProcessor.connect(admin).clearPayments(
+        [authorizationIds[0], ZERO_BYTES16_STRING]
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
+      await expect(cardPaymentProcessor.connect(admin).clearPayments(
+        [
+          authorizationIds[0],
+          createBytesString(payments[payments.length - 1].authorizationId + 1, BYTES16_LENGTH),
+        ]
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+    });
+
+    it("Is reverted if one of the payments has been already cleared", async () => {
+      await proveTx(cardPaymentProcessor.connect(admin).clearPayment(
+        authorizationIds[0]
+      ));
+      await expect(cardPaymentProcessor.connect(admin).clearPayments(
+        authorizationIds
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_IS_CLEARED);
+    });
+
+    it("Does not transfer tokens, emits the correct events, changes the state properly", async () => {
+      await checkCardPaymentProcessorState(payments);
+      await expect(cardPaymentProcessor.connect(admin).clearPayments(
+        authorizationIds
+      )).to.changeTokenBalances(
+        tokenMock,
+        [cardPaymentProcessor, ...accountAddresses],
+        [0, ...accountAddresses.map(() => 0)]
+      ).and.to.emit(
+        cardPaymentProcessor,
+        "ClearPayment"
+      ).withArgs(
+        authorizationIds[0],
+        payments[0].account.address,
+        payments[0].amount,
+        expectedClearedBalances[0],
+        expectedUnclearedBalances[0],
+        payments[0].revocationCounter || 0
+      ).and.to.emit(
+        cardPaymentProcessor,
+        "ClearPayment"
+      ).withArgs(
+        authorizationIds[1],
+        payments[1].account.address,
+        payments[1].amount,
+        expectedClearedBalances[1],
+        expectedUnclearedBalances[1],
+        payments[1].revocationCounter || 0
+      );
+      payments.forEach((payment: TestPayment) => payment.status = PaymentStatus.Cleared);
+      await checkCardPaymentProcessorState(payments);
+    });
+  });
+
+  describe("Function 'unclearPayment()'", async () => {
+    let payment: TestPayment;
+    let admin: SignerWithAddress;
+    let authorizationId: string;
+
+    beforeEach(async () => {
+      payment = {
+        authorizationId: 543,
+        account: user1,
+        amount: 432,
+        status: PaymentStatus.Nonexistent,
+        makingPaymentCorrelationId: 321,
+      };
+      admin = user2;
+      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
+      await setUpContractsForPayments([payment]);
+      await setExecutorRole(admin);
+      await makePayments([payment]);
+      await clearPayments([payment], admin);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
+      await proveTx(cardPaymentProcessor.pause());
+      await expect(cardPaymentProcessor.connect(admin).unclearPayment(
+        authorizationId
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the executor role", async () => {
+      await expect(cardPaymentProcessor.connect(deployer).unclearPayment(
+        authorizationId
+      )).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+    });
+
+    it("Is reverted if the payment authorization ID is zero", async () => {
+      await expect(cardPaymentProcessor.connect(admin).unclearPayment(
+        ZERO_BYTES16_STRING
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
+      await expect(cardPaymentProcessor.connect(admin).unclearPayment(
+        createBytesString(payment.authorizationId + 1, BYTES16_LENGTH)
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+    });
+
+    it("Does not transfer tokens, emits the correct event, changes the state properly", async () => {
+      await checkCardPaymentProcessorState([payment]);
+      const expectedClearedBalance: number = 0;
+      const expectedUnclearedBalance: number = payment.amount;
+      await expect(cardPaymentProcessor.connect(admin).unclearPayment(
+        authorizationId
+      )).to.changeTokenBalances(
+        tokenMock,
+        [cardPaymentProcessor, payment.account],
+        [0, 0]
+      ).and.to.emit(
+        cardPaymentProcessor,
+        "UnclearPayment"
+      ).withArgs(
+        authorizationId,
+        payment.account.address,
+        payment.amount,
+        expectedClearedBalance,
+        expectedUnclearedBalance,
+        payment.revocationCounter || 0
+      );
+      payment.status = PaymentStatus.Uncleared;
+      await checkCardPaymentProcessorState([payment]);
+    });
+
+    it("Is reverted if the payment is uncleared", async () => {
+      await proveTx(cardPaymentProcessor.connect(admin).unclearPayment(
+        authorizationId
+      ));
+      await expect(cardPaymentProcessor.connect(admin).unclearPayment(
+        authorizationId
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_IS_UNCLEARED);
+    });
+  });
+
+  describe("Function 'unclearPayments()'", async () => {
+    let payments: TestPayment[];
+    let admin: SignerWithAddress;
+    let authorizationIds: string[];
+    let accountAddresses: string[];
+    let expectedClearedBalances: number[];
+    let expectedUnclearedBalances: number[];
+
+    beforeEach(async () => {
+      payments = [
+        {
+          authorizationId: 987,
+          account: user1,
+          amount: 876,
+          status: PaymentStatus.Nonexistent,
+          makingPaymentCorrelationId: 765,
+        },
+        {
+          authorizationId: 654,
+          account: user2,
+          amount: 543,
+          status: PaymentStatus.Nonexistent,
+          makingPaymentCorrelationId: 432,
+        },
+      ];
+      admin = user2;
+      authorizationIds = payments.map(
+        (payment: TestPayment) => createBytesString(payment.authorizationId, BYTES16_LENGTH)
+      );
+      accountAddresses = payments.map((payment: TestPayment) => payment.account.address);
+      expectedClearedBalances = payments.map(() => 0);
+      expectedUnclearedBalances = payments.map((payment: TestPayment) => payment.amount);
+      await setUpContractsForPayments(payments);
+      await setExecutorRole(admin);
+      await makePayments(payments);
+      await clearPayments(payments, admin);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
+      await proveTx(cardPaymentProcessor.pause());
+      await expect(cardPaymentProcessor.connect(admin).unclearPayments(
+        authorizationIds
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the executor role", async () => {
+      await expect(cardPaymentProcessor.connect(deployer).unclearPayments(
+        authorizationIds
+      )).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+    });
+
+    it("Is reverted if the payment authorization IDs array is empty", async () => {
+      await expect(cardPaymentProcessor.connect(admin).unclearPayments(
+        []
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
+    });
+
+    it("Is reverted if one of the payment authorization IDs is zero", async () => {
+      await expect(cardPaymentProcessor.connect(admin).unclearPayments(
+        [authorizationIds[0], ZERO_BYTES16_STRING]
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
+      await expect(cardPaymentProcessor.connect(admin).unclearPayments(
+        [
+          authorizationIds[0],
+          createBytesString(payments[payments.length - 1].authorizationId + 1, BYTES16_LENGTH)
+        ]
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+    });
+
+    it("Is reverted if one of the payments is uncleared", async () => {
+      await proveTx(cardPaymentProcessor.connect(admin).unclearPayment(
+        authorizationIds[0]
+      ));
+      await expect(cardPaymentProcessor.connect(admin).unclearPayments(
+        authorizationIds
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_IS_UNCLEARED);
+    });
+
+    it("Does not transfer tokens, emits the correct events, changes the state properly", async () => {
+      await checkCardPaymentProcessorState(payments);
+      await expect(cardPaymentProcessor.connect(admin).unclearPayments(
+        authorizationIds
+      )).to.changeTokenBalances(
+        tokenMock,
+        [cardPaymentProcessor, ...accountAddresses],
+        [0, ...accountAddresses.map(() => 0)]
+      ).and.to.emit(
+        cardPaymentProcessor,
+        "UnclearPayment"
+      ).withArgs(
+        authorizationIds[0],
+        payments[0].account.address,
+        payments[0].amount,
+        expectedClearedBalances[0],
+        expectedUnclearedBalances[0],
+        payments[0].revocationCounter || 0
+      ).and.to.emit(
+        cardPaymentProcessor,
+        "UnclearPayment"
+      ).withArgs(
+        authorizationIds[1],
+        payments[1].account.address,
+        payments[1].amount,
+        expectedClearedBalances[1],
+        expectedUnclearedBalances[1],
+        payments[1].revocationCounter || 0
+      );
+      payments.forEach((payment: TestPayment) => payment.status = PaymentStatus.Uncleared);
+      await checkCardPaymentProcessorState(payments);
+    });
+  });
+
+  describe("Function 'revokePayment()'", async () => {
+    const reversingPaymentCorrelationId: string = SOME_BYTES16_STRING;
+    const parentTxHash: string = SOME_BYTES32_STRING;
+
+    let payment: TestPayment;
+    let authorizationId: string;
+    let admin: SignerWithAddress;
+
+    beforeEach(async () => {
+      payment = {
+        authorizationId: 987,
+        account: user1,
+        amount: 876,
+        status: PaymentStatus.Nonexistent,
+        revocationCounter: 0,
+        makingPaymentCorrelationId: 765,
+        parentTxHash: parentTxHash,
+      };
+      admin = user2;
+      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
+      await setUpContractsForPayments([payment]);
+      await makePayments([payment]);
+      await setExecutorRole(admin);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
+      await proveTx(cardPaymentProcessor.pause());
+      await expect(cardPaymentProcessor.connect(admin).revokePayment(
+        authorizationId,
+        reversingPaymentCorrelationId,
+        parentTxHash
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the executor role", async () => {
+      await expect(cardPaymentProcessor.connect(deployer).revokePayment(
+        authorizationId,
+        reversingPaymentCorrelationId,
+        parentTxHash
+      )).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+    });
+
+    it("Is reverted if the payment authorization ID is zero", async () => {
+      await expect(cardPaymentProcessor.connect(admin).revokePayment(
+        ZERO_BYTES16_STRING,
+        reversingPaymentCorrelationId,
+        parentTxHash
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the parent transaction hash is zero", async () => {
+      await expect(cardPaymentProcessor.connect(admin).revokePayment(
+        authorizationId,
+        reversingPaymentCorrelationId,
+        ZERO_BYTES32_STRING,
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PARENT_TX_HASH_IS_ZERO);
+    });
+
+    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
+      await expect(cardPaymentProcessor.connect(admin).revokePayment(
+        createBytesString(payment.authorizationId + 1, BYTES16_LENGTH),
+        reversingPaymentCorrelationId,
+        parentTxHash
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+    });
+
+    describe("Transfers tokens as expected, emits the correct event, changes the state properly", async () => {
+      const expectedClearedBalance: number = 0;
+      const expectedUnclearedBalance: number = 0;
+      const expectedRevocationCounter: number = 1;
+
+      async function checkRevocation(wasPaymentCleared: boolean) {
+        await checkCardPaymentProcessorState([payment]);
+        await expect(cardPaymentProcessor.connect(admin).revokePayment(
+          authorizationId,
+          reversingPaymentCorrelationId,
+          parentTxHash
+        )).to.changeTokenBalances(
+          tokenMock,
+          [cardPaymentProcessor, payment.account],
+          [-payment.amount, +payment.amount]
+        ).and.to.emit(
+          cardPaymentProcessor,
+          "RevokePayment"
+        ).withArgs(
+          authorizationId,
+          reversingPaymentCorrelationId,
+          payment.account.address,
+          payment.amount,
+          expectedClearedBalance,
+          expectedUnclearedBalance,
+          wasPaymentCleared,
+          parentTxHash,
+          expectedRevocationCounter
+        );
+        payment.status = PaymentStatus.Revoked;
+        payment.revocationCounter = expectedRevocationCounter;
+        await checkCardPaymentProcessorState([payment]);
+      }
+
+      it("If payment is uncleared", async () => {
+        const wasPaymentCleared: boolean = false;
+        await checkRevocation(wasPaymentCleared);
+      });
+
+      it("If payment is cleared", async () => {
+        const wasPaymentCleared: boolean = true;
+        await clearPayments([payment], admin);
+        await checkRevocation(wasPaymentCleared);
+      });
+    });
+  });
+
+  describe("Function 'reversePayment()'", async () => {
+    const reversingPaymentCorrelationId: string = SOME_BYTES16_STRING;
+    const parentTxHash: string = SOME_BYTES32_STRING;
+
+    let payment: TestPayment;
+    let authorizationId: string;
+    let admin: SignerWithAddress;
+
+    beforeEach(async () => {
+      payment = {
+        authorizationId: 876,
+        account: user1,
+        amount: 765,
+        status: PaymentStatus.Nonexistent,
+        makingPaymentCorrelationId: 543,
+        parentTxHash: parentTxHash,
+      };
+      admin = user2;
+      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
+      await setUpContractsForPayments([payment]);
+      await makePayments([payment]);
+      await setExecutorRole(admin);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
+      await proveTx(cardPaymentProcessor.pause());
+      await expect(cardPaymentProcessor.connect(admin).reversePayment(
+        authorizationId,
+        reversingPaymentCorrelationId,
+        parentTxHash
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the executor role", async () => {
+      await expect(cardPaymentProcessor.connect(deployer).reversePayment(
+        authorizationId,
+        reversingPaymentCorrelationId,
+        parentTxHash
+      )).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+    });
+
+    it("Is reverted if the payment authorization ID is zero", async () => {
+      await expect(cardPaymentProcessor.connect(admin).reversePayment(
+        ZERO_BYTES16_STRING,
+        reversingPaymentCorrelationId,
+        parentTxHash
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the parent transaction hash is zero", async () => {
+      await expect(cardPaymentProcessor.connect(admin).reversePayment(
+        authorizationId,
+        reversingPaymentCorrelationId,
+        ZERO_BYTES32_STRING,
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PARENT_TX_HASH_IS_ZERO);
+    });
+
+    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
+      await expect(cardPaymentProcessor.connect(admin).reversePayment(
+        createBytesString(payment.authorizationId + 1, BYTES16_LENGTH),
+        reversingPaymentCorrelationId,
+        parentTxHash
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+    });
+
+    describe("Transfers tokens as expected, emits the correct event, changes the state properly", async () => {
+      const expectedClearedBalance: number = 0;
+      const expectedUnclearedBalance: number = 0;
+
+      async function checkReversion(wasPaymentCleared: boolean) {
+        await checkCardPaymentProcessorState([payment]);
+        await expect(cardPaymentProcessor.connect(admin).reversePayment(
+          authorizationId,
+          reversingPaymentCorrelationId,
+          parentTxHash
+        )).to.changeTokenBalances(
+          tokenMock,
+          [cardPaymentProcessor, payment.account],
+          [-payment.amount, +payment.amount]
+        ).and.to.emit(
+          cardPaymentProcessor,
+          "ReversePayment"
+        ).withArgs(
+          authorizationId,
+          reversingPaymentCorrelationId,
+          payment.account.address,
+          payment.amount,
+          expectedClearedBalance,
+          expectedUnclearedBalance,
+          wasPaymentCleared,
+          parentTxHash,
+          payment.revocationCounter || 0
+        );
+        payment.status = PaymentStatus.Reversed;
+        await checkCardPaymentProcessorState([payment]);
+      }
+
+      it("If payment is uncleared", async () => {
+        const wasPaymentCleared: boolean = false;
+        await checkReversion(wasPaymentCleared);
+      });
+
+      it("If payment is cleared", async () => {
+        const wasPaymentCleared: boolean = true;
+        await clearPayments([payment], admin);
+        await checkReversion(wasPaymentCleared);
+      });
+    });
+  });
+
+  describe("Function 'confirmPayment()'", async () => {
+    let payment: TestPayment;
+    let authorizationId: string;
+    let admin: SignerWithAddress;
+    let cashOutAccount: SignerWithAddress;
+
+    beforeEach(async () => {
+      payment = {
+        authorizationId: 123,
+        account: user1,
+        amount: 234,
+        status: PaymentStatus.Nonexistent,
+        makingPaymentCorrelationId: 345,
+      };
+      admin = user2;
+      cashOutAccount = deployer;
+      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
+      await setUpContractsForPayments([payment]);
+      await setExecutorRole(admin);
+      await makePayments([payment]);
+      await clearPayments([payment], admin);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
+      await proveTx(cardPaymentProcessor.pause());
+      await expect(cardPaymentProcessor.connect(admin).confirmPayment(
+        authorizationId,
+        cashOutAccount.address
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the executor role", async () => {
+      await expect(cardPaymentProcessor.connect(deployer).confirmPayment(
+        authorizationId,
+        cashOutAccount.address
+      )).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+    });
+
+    it("Is reverted if the payment authorization ID is zero", async () => {
+      await expect(cardPaymentProcessor.connect(admin).confirmPayment(
+        ZERO_BYTES16_STRING,
+        cashOutAccount.address
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the input cash out account is the zero address", async () => {
+      await expect(cardPaymentProcessor.connect(admin).confirmPayment(
+        authorizationId,
+        ethers.constants.AddressZero
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_CASH_OUT_ACCOUNT_IS_ZERO_ADDRESS);
+    });
+
+    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
+      await expect(cardPaymentProcessor.connect(admin).confirmPayment(
+        createBytesString(payment.authorizationId + 1, BYTES16_LENGTH),
+        cashOutAccount.address
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+    });
+
+    it("Is reverted if the payment is uncleared", async () => {
+      await proveTx(cardPaymentProcessor.connect(admin).unclearPayment(
+        authorizationId
+      ));
+      await expect(cardPaymentProcessor.connect(admin).confirmPayment(
+        authorizationId,
+        cashOutAccount.address
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_IS_UNCLEARED);
+    });
+
+    it("Transfers tokens as expected, emits the correct event, changes the state properly", async () => {
+      await checkCardPaymentProcessorState([payment]);
+      const expectedClearedBalance: number = 0;
+      await expect(cardPaymentProcessor.connect(admin).confirmPayment(
+        authorizationId,
+        cashOutAccount.address
+      )).to.changeTokenBalances(
+        tokenMock,
+        [cardPaymentProcessor, cashOutAccount, payment.account],
+        [-payment.amount, +payment.amount, 0]
+      ).and.to.emit(
+        cardPaymentProcessor,
+        "ConfirmPayment"
+      ).withArgs(
+        authorizationId,
+        payment.account.address,
+        payment.amount,
+        expectedClearedBalance,
+        payment.revocationCounter || 0
+      );
+      payment.status = PaymentStatus.Confirmed;
+      await checkCardPaymentProcessorState([payment]);
+    });
+  });
+
+  describe("Function 'confirmPayments()'", async () => {
+    let payments: TestPayment[];
+    let admin: SignerWithAddress;
+    let cashOutAccount: SignerWithAddress;
+    let authorizationIds: string[];
+    let accountAddresses: string[];
+    let totalAmount: number;
+
+    beforeEach(async () => {
+      payments = [
+        {
+          authorizationId: 123,
+          account: user1,
+          amount: 234,
+          status: PaymentStatus.Nonexistent,
+          makingPaymentCorrelationId: 345,
+        },
+        {
+          authorizationId: 456,
+          account: user2,
+          amount: 567,
+          status: PaymentStatus.Nonexistent,
+          makingPaymentCorrelationId: 789,
+        },
+      ];
+      admin = user2;
+      cashOutAccount = deployer;
+      authorizationIds = payments.map(
+        (payment: TestPayment) => createBytesString(payment.authorizationId, BYTES16_LENGTH)
+      );
+      accountAddresses = payments.map((payment: TestPayment) => payment.account.address);
+      totalAmount = countNumberArrayTotal(
+        payments.map(
+          function (payment: TestPayment): number {
+            return payment.amount;
+          }
+        )
+      );
+      await setUpContractsForPayments(payments);
+      await setExecutorRole(admin);
+      await makePayments(payments);
+      await clearPayments(payments, admin);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
+      await proveTx(cardPaymentProcessor.pause());
+      await expect(cardPaymentProcessor.connect(admin).confirmPayments(
+        authorizationIds,
+        cashOutAccount.address
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the executor role", async () => {
+      await expect(cardPaymentProcessor.connect(deployer).confirmPayments(
+        authorizationIds,
+        cashOutAccount.address
+      )).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+    });
+
+    it("Is reverted if the payment authorization IDs array is empty", async () => {
+      await expect(cardPaymentProcessor.connect(admin).confirmPayments(
+        [],
+        cashOutAccount.address
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
+    });
+
+    it("Is reverted if the input cash out account is the zero address", async () => {
+      await expect(cardPaymentProcessor.connect(admin).confirmPayments(
+        authorizationIds,
+        ethers.constants.AddressZero
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_CASH_OUT_ACCOUNT_IS_ZERO_ADDRESS);
+    });
+
+    it("Is reverted if one of the payment authorization IDs is zero", async () => {
+      await expect(cardPaymentProcessor.connect(admin).confirmPayments(
+        [authorizationIds[0], ZERO_BYTES16_STRING],
+        cashOutAccount.address
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
+      await expect(cardPaymentProcessor.connect(admin).confirmPayments(
+        [
+          authorizationIds[0],
+          createBytesString(payments[payments.length - 1].authorizationId + 1, BYTES16_LENGTH)
+        ],
+        cashOutAccount.address
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_DOES_NOT_EXIST);
+    });
+
+    it("Is reverted if one of the payments is uncleared", async () => {
+      await proveTx(cardPaymentProcessor.connect(admin).unclearPayment(
+        authorizationIds[1]
+      ));
+      await expect(cardPaymentProcessor.connect(admin).confirmPayments(
+        authorizationIds,
+        cashOutAccount.address
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_IS_UNCLEARED);
+    });
+
+    it("Transfer tokens, emits the correct events, changes the state properly", async () => {
+      const expectedClearedBalance: number = 0;
+      await checkCardPaymentProcessorState(payments);
+      await expect(cardPaymentProcessor.connect(admin).confirmPayments(
+        authorizationIds,
+        cashOutAccount.address
+      )).to.changeTokenBalances(
+        tokenMock,
+        [cardPaymentProcessor, cashOutAccount, ...accountAddresses],
+        [-totalAmount, +totalAmount, ...accountAddresses.map(() => 0)]
+      ).and.to.emit(
+        cardPaymentProcessor,
+        "ConfirmPayment"
+      ).withArgs(
+        authorizationIds[0],
+        payments[0].account.address,
+        payments[0].amount,
+        expectedClearedBalance,
+        payments[0].revocationCounter || 0
+      ).and.to.emit(
+        cardPaymentProcessor,
+        "ConfirmPayment"
+      ).withArgs(
+        authorizationIds[1],
+        payments[1].account.address,
+        payments[1].amount,
+        expectedClearedBalance,
+        payments[1].revocationCounter || 0
+      );
+      payments.forEach((payment: TestPayment) => payment.status = PaymentStatus.Confirmed);
+      await checkCardPaymentProcessorState(payments);
+    });
+  });
+
+  describe("Complex scenarios", async () => {
+    const someCorrelationId: string = SOME_BYTES16_STRING;
+    const someParentTxHash: string = SOME_BYTES32_STRING;
+
+    let payments: TestPayment[];
+    let admin: SignerWithAddress;
+    let cashOutAccount: SignerWithAddress;
+    let authorizationIds: string[];
+
+    async function checkRevertingOfAllPaymentProcessingFunctionsExceptMaking() {
+      await expect(cardPaymentProcessor.connect(admin).clearPayment(
+        authorizationIds[0],
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+
+      await expect(cardPaymentProcessor.connect(admin).clearPayments(
+        authorizationIds,
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+
+      await expect(cardPaymentProcessor.connect(admin).unclearPayment(
+        authorizationIds[0],
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+
+      await expect(cardPaymentProcessor.connect(admin).unclearPayments(
+        authorizationIds,
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+
+      await expect(cardPaymentProcessor.connect(admin).revokePayment(
+        authorizationIds[0],
+        someCorrelationId,
+        someParentTxHash
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+
+      await expect(cardPaymentProcessor.connect(admin).reversePayment(
+        authorizationIds[0],
+        someCorrelationId,
+        someParentTxHash
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+
+      await expect(cardPaymentProcessor.connect(admin).confirmPayment(
+        authorizationIds[0],
+        cashOutAccount.address
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+
+      await expect(cardPaymentProcessor.connect(admin).confirmPayments(
+        authorizationIds,
+        cashOutAccount.address
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
+    }
+
+    beforeEach(async () => {
+      payments = [
+        {
+          authorizationId: 1234,
+          account: user1,
+          amount: 2345,
+          status: PaymentStatus.Nonexistent,
+          makingPaymentCorrelationId: 3456,
+        },
+        {
+          authorizationId: 4567,
+          account: user2,
+          amount: 5678,
+          status: PaymentStatus.Nonexistent,
+          makingPaymentCorrelationId: 6789,
+        }
+      ];
+      admin = user2;
+      cashOutAccount = deployer;
+      authorizationIds = payments.map(
+        (payment: TestPayment) => createBytesString(payment.authorizationId, BYTES16_LENGTH)
+      );
+      await setUpContractsForPayments(payments);
+      await setExecutorRole(admin);
+    });
+
+    it("All payment processing functions except making are reverted if a payment was revoked", async () => {
+      await makePayments(payments);
+      await proveTx(cardPaymentProcessor.connect(admin).revokePayment(
+        authorizationIds[0],
+        someCorrelationId,
+        someParentTxHash
+      ));
+      payments[0].status = PaymentStatus.Revoked;
+      payments[0].revocationCounter = 1;
+
+      await checkCardPaymentProcessorState(payments);
+      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking();
+
+      await expect(cardPaymentProcessor.connect(payments[0].account).makePayment(
+        payments[0].amount,
+        authorizationIds[0],
+        someCorrelationId,
+      )).to.changeTokenBalances(
+        tokenMock,
+        [cardPaymentProcessor, payments[0].account],
+        [+payments[0].amount, -payments[0].amount]
+      ).and.to.emit(
+        cardPaymentProcessor,
+        "MakePayment"
+      ).withArgs(
+        authorizationIds[0],
+        someCorrelationId,
+        payments[0].account.address,
+        payments[0].amount,
+        payments[0].revocationCounter || 0
+      );
+      payments[0].status = PaymentStatus.Uncleared;
+
+      await checkCardPaymentProcessorState(payments);
+    });
+
+    it("All payment processing functions are reverted if a payment was reversed", async () => {
+      await makePayments(payments);
+      await proveTx(cardPaymentProcessor.connect(admin).reversePayment(
+        authorizationIds[0],
+        someCorrelationId,
+        someParentTxHash
+      ));
+      payments[0].status = PaymentStatus.Reversed;
+
+      await expect(cardPaymentProcessor.makePayment(
+        payments[0].amount,
+        authorizationIds[0],
+        createBytesString(payments[0].makingPaymentCorrelationId, BYTES16_LENGTH)
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_ALREADY_EXISTS);
+
+      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking();
+      await checkCardPaymentProcessorState(payments);
+    });
+
+    it("All payment processing functions are reverted if a payment was confirmed", async () => {
+      await makePayments(payments);
+      await clearPayments(payments, admin);
+      await proveTx(cardPaymentProcessor.connect(admin).confirmPayment(authorizationIds[0], cashOutAccount.address));
+      payments[0].status = PaymentStatus.Confirmed;
+
+      await expect(cardPaymentProcessor.makePayment(
+        payments[0].amount,
+        authorizationIds[0],
+        createBytesString(payments[0].makingPaymentCorrelationId, BYTES16_LENGTH)
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_ALREADY_EXISTS);
+
+      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking();
+      await checkCardPaymentProcessorState(payments);
+    });
+
+    it("Making payment function is reverted if the payment has the 'Cleared' status", async () => {
+      await makePayments([payments[0]]);
+      await clearPayments([payments[0]], admin);
+
+      await expect(cardPaymentProcessor.connect(payments[0].account).makePayment(
+        payments[0].amount,
+        authorizationIds[0],
+        someCorrelationId
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_AUTHORIZATION_ID_ALREADY_EXISTS);
+    });
+
+    it("Making payment function is reverted if the revocation counter has reached the maximum", async () => {
+      const revocationCounterMax: number = 1;
+
+      await proveTx(cardPaymentProcessor.setRevocationCounterMaximum(revocationCounterMax));
+      expect(await cardPaymentProcessor.revocationCounterMaximum()).to.equal(revocationCounterMax);
+
+      for (let relocationCounter = 0; relocationCounter < revocationCounterMax; ++relocationCounter) {
+        await makePayments([payments[0]]);
+        await proveTx(cardPaymentProcessor.connect(admin).revokePayment(
+          authorizationIds[0],
+          someCorrelationId,
+          someParentTxHash
+        ));
+        payments[0].status = PaymentStatus.Revoked;
+        payments[0].revocationCounter = relocationCounter + 1;
+        await checkCardPaymentProcessorState(payments);
+      }
+      await expect(cardPaymentProcessor.connect(payments[0].account).makePayment(
+        payments[0].amount,
+        authorizationIds[0],
+        someCorrelationId
+      )).to.be.revertedWith(REVERT_MESSAGE_IF_PAYMENT_REVOCATION_COUNTER_HAS_REACHED_MAXIMUM);
+    });
+  });
+});

--- a/test/base/PausableExUpgradeable.test.ts
+++ b/test/base/PausableExUpgradeable.test.ts
@@ -1,0 +1,83 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
+
+describe("Contract 'PausableExUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+
+  let pausableExMock: Contract;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+  let ownerRole: string;
+  let pauserRole: string;
+
+  beforeEach(async () => {
+    const PausableExMock: ContractFactory = await ethers.getContractFactory("PausableExUpgradeableMock");
+    pausableExMock = await upgrades.deployProxy(PausableExMock);
+    await pausableExMock.deployed();
+
+    [deployer, user] = await ethers.getSigners();
+
+    //Roles
+    ownerRole = (await pausableExMock.OWNER_ROLE()).toLowerCase();
+    pauserRole = (await pausableExMock.PAUSER_ROLE()).toLowerCase();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(pausableExMock.initialize())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initialize unchained function can't be called more than once", async () => {
+    await expect(pausableExMock.initialize_unchained())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Function 'pause()'", async () => {
+    beforeEach(async () => {
+      await proveTx(pausableExMock.grantRole(pauserRole, user.address));
+    });
+
+    it("Is reverted if is called by an account without the pauser role", async () => {
+      await expect(pausableExMock.pause())
+        .to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, pauserRole));
+    });
+
+    it("Executes successfully if is called by an account with the pauser role", async () => {
+      await proveTx(pausableExMock.connect(user).pause());
+      expect(await pausableExMock.paused()).to.equal(true);
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(pausableExMock.connect(user).pause())
+        .to.emit(pausableExMock, "Paused")
+        .withArgs(user.address);
+    });
+  });
+
+  describe("Function 'unpause()'", async () => {
+    beforeEach(async () => {
+      await proveTx(pausableExMock.grantRole(pauserRole, user.address));
+      await proveTx(pausableExMock.connect(user).pause());
+    });
+
+    it("Is reverted if is called by an account without the pauser role", async () => {
+      await expect(pausableExMock.unpause())
+        .to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, pauserRole));
+    });
+
+    it("Executes successfully if is called by an account with the pauser role", async () => {
+      await proveTx(pausableExMock.connect(user).unpause());
+      expect(await pausableExMock.paused()).to.equal(false);
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(pausableExMock.connect(user).unpause())
+        .to.emit(pausableExMock, "Unpaused")
+        .withArgs(user.address);
+    });
+  });
+});


### PR DESCRIPTION
### Main changes (in comparing with [PR#1](https://github.com/cloudwalk/brlc-periphery/pull/1)):
1. All revert messages in the card payment processor contract have been replaced with custom errors.

### Merging notes:
1. This PR should be merged after [PR#1](https://github.com/cloudwalk/brlc-periphery/pull/1).

### Testing and coverage
The updated and newly developed tests have been successfully run on the following blockchains:
1. Internal Hardhat net.
2. Substrate with Frontier layer built from the [cloudwalk-network](https://github.com/cloudwalk/cloudwalk-network) repo, branch [main](https://github.com/cloudwalk/cloudwalk-network), commit [350445547016ce83c5ce781ac8871194439b0e4f](https://github.com/cloudwalk/cloudwalk-network/commit/350445547016ce83c5ce781ac8871194439b0e4f).

_NOTE 1_: When running a local node of Substrate with Frontier layer for testing use the node in the archive mode like in the following command:
```bash
./target/release/cloudwalk-network-node --dev --tmp --pruning archive
```

Coverage:
![coverage_CPP_0 8 0](https://user-images.githubusercontent.com/97302011/183453234-6bde7115-2038-49fc-a2ba-92df1786788b.png)