### PR TITLE
Card payment processor. Fixes for initialize functions

### DIFF
--- a/contracts/base/PauseControlUpgradeable.sol
+++ b/contracts/base/PauseControlUpgradeable.sol
@@ -14,14 +14,14 @@ import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/securit
 abstract contract PauseControlUpgradeable is AccessControlUpgradeable, PausableUpgradeable {
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
-    function __PauseControl_init(bytes32 pauserRoleAdmin) internal initializer {
+    function __PauseControl_init(bytes32 pauserRoleAdmin) internal onlyInitializing {
         __Context_init_unchained();
         __ERC165_init_unchained();
         __Pausable_init_unchained();
         __PauseControl_init_unchained(pauserRoleAdmin);
     }
 
-    function __PauseControl_init_unchained(bytes32 pauserRoleAdmin) internal initializer {
+    function __PauseControl_init_unchained(bytes32 pauserRoleAdmin) internal onlyInitializing {
         _setRoleAdmin(PAUSER_ROLE, pauserRoleAdmin);
     }
 

--- a/contracts/mocks/base/PauseControlUpgradeableMock.sol
+++ b/contracts/mocks/base/PauseControlUpgradeableMock.sol
@@ -11,21 +11,22 @@ import { PauseControlUpgradeable } from "../../base/PauseControlUpgradeable.sol"
 contract PauseControlUpgradeableMock is PauseControlUpgradeable {
     bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
 
-    /**
-     * @dev The initialize function of the upgradable contract
-     * but without modifier {initializer} to test that the ancestor contract has it.
-     */
-    function initialize() public {
+    /// @dev The initialize function of the upgradable contract.
+    function initialize() public initializer{
         _setupRole(OWNER_ROLE, _msgSender());
         __PauseControl_init(OWNER_ROLE);
     }
 
+    /// @dev To check that the initialize function of the ancestor contract has the 'onlyInitializing' modifier.
+    function call_parent_initialize() public {
+        __PauseControl_init(OWNER_ROLE);
+    }
+
     /**
-     * @dev The unchained initialize function of the upgradable contract
-     * but without modifier {initializer} to test that the ancestor contract has it.
+     * @dev To check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
      */
-    function initialize_unchained() public {
-        _setupRole(OWNER_ROLE, _msgSender());
+    function call_parent_initialize_unchained() public {
         __PauseControl_init_unchained(OWNER_ROLE);
     }
 }

--- a/test/base/PauseControlUpgradeable.test.ts
+++ b/test/base/PauseControlUpgradeable.test.ts
@@ -7,6 +7,7 @@ import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
 
 describe("Contract 'PauseControlUpgradeable'", async () => {
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
 
   let pauseControlMock: Contract;
   let deployer: SignerWithAddress;
@@ -31,9 +32,14 @@ describe("Contract 'PauseControlUpgradeable'", async () => {
       .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
   });
 
-  it("The initialize unchained function can't be called more than once", async () => {
-    await expect(pauseControlMock.initialize_unchained())
-      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  it("The init function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(pauseControlMock.call_parent_initialize())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+  });
+
+  it("The init unchained function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(pauseControlMock.call_parent_initialize_unchained())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
   });
 
   it("The initial contract configuration should be as expected", async () => {


### PR DESCRIPTION
The main change is the following replacement of modifiers in the `PauseControlUpgradeable` contract: `initializer` => `onlyInitializing`.

Motivation: see [this](https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#initializers) section of the OpenZeppeling docs. The citation: "Note that the `initializer` modifier can only be called once even when using inheritance, so parent contracts should use the `onlyInitializing` modifier..."