### PR TITLE
Card payment processor. Add token rescue feature

### DIFF
--- a/contracts/CardPaymentProcessorUpgradeable.sol
+++ b/contracts/CardPaymentProcessorUpgradeable.sol
@@ -5,7 +5,9 @@ pragma solidity ^0.8.8;
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
 import { PauseControlUpgradeable } from "./base/PauseControlUpgradeable.sol";
+import { RescueControlUpgradeable } from "./base/RescueControlUpgradeable.sol";
 import { CardPaymentProcessorStorage } from "./CardPaymentProcessorStorage.sol";
 import { ICardPaymentProcessor } from "./interfaces/ICardPaymentProcessor.sol";
 
@@ -16,6 +18,7 @@ import { ICardPaymentProcessor } from "./interfaces/ICardPaymentProcessor.sol";
 contract CardPaymentProcessorUpgradeable is
     AccessControlUpgradeable,
     PauseControlUpgradeable,
+    RescueControlUpgradeable,
     CardPaymentProcessorStorage,
     ICardPaymentProcessor
 {
@@ -75,6 +78,7 @@ contract CardPaymentProcessorUpgradeable is
         __ERC165_init_unchained();
         __Pausable_init_unchained();
         __PauseControl_init_unchained(OWNER_ROLE);
+        __RescueControl_init_unchained(OWNER_ROLE);
 
         __CardPaymentProcessor_init_unchained(token_);
     }

--- a/contracts/base/PauseControlUpgradeable.sol
+++ b/contracts/base/PauseControlUpgradeable.sol
@@ -14,14 +14,14 @@ import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/securit
 abstract contract PauseControlUpgradeable is AccessControlUpgradeable, PausableUpgradeable {
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
-    function __PauseControl_init(bytes32 pauserRoleAdmin) internal initializer {
+    function __PauseControl_init(bytes32 pauserRoleAdmin) internal onlyInitializing {
         __Context_init_unchained();
         __ERC165_init_unchained();
         __Pausable_init_unchained();
         __PauseControl_init_unchained(pauserRoleAdmin);
     }
 
-    function __PauseControl_init_unchained(bytes32 pauserRoleAdmin) internal initializer {
+    function __PauseControl_init_unchained(bytes32 pauserRoleAdmin) internal onlyInitializing {
         _setRoleAdmin(PAUSER_ROLE, pauserRoleAdmin);
     }
 

--- a/contracts/base/RescueControlUpgradeable.sol
+++ b/contracts/base/RescueControlUpgradeable.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+/**
+ * @title RescueControlUpgradeable base contract
+ * @dev Allows to "rescue" tokens locked up in the contract by transferring to a specified address.
+ * Only accounts that have the {RESCUER_ROLE} role can execute token transferring operations.
+ * The admins of the {RESCUER_ROLE} roles are accounts with the role defined in the init() function.
+ */
+abstract contract RescueControlUpgradeable is AccessControlUpgradeable {
+    bytes32 public constant RESCUER_ROLE = keccak256("RESCUER_ROLE");
+
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    function __RescueControl_init(bytes32 rescuerRoleAdmin) internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __RescueControl_init_unchained(rescuerRoleAdmin);
+    }
+
+    function __RescueControl_init_unchained(bytes32 rescuerRoleAdmin) internal onlyInitializing {
+        _setRoleAdmin(RESCUER_ROLE, rescuerRoleAdmin);
+    }
+
+    /**
+     * @dev Rescue ERC20 tokens locked up in this contract.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {RESCUER_ROLE} role.
+     *
+     * @param tokenContract The ERC20 token contract address.
+     * @param to The recipient address.
+     * @param amount The amount to withdraw.
+     */
+    function rescueERC20(
+        IERC20Upgradeable tokenContract,
+        address to,
+        uint256 amount
+    ) external onlyRole(RESCUER_ROLE) {
+        tokenContract.safeTransfer(to, amount);
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[50] private __gap;
+}

--- a/contracts/mocks/base/PauseControlUpgradeableMock.sol
+++ b/contracts/mocks/base/PauseControlUpgradeableMock.sol
@@ -11,21 +11,22 @@ import { PauseControlUpgradeable } from "../../base/PauseControlUpgradeable.sol"
 contract PauseControlUpgradeableMock is PauseControlUpgradeable {
     bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
 
-    /**
-     * @dev The initialize function of the upgradable contract
-     * but without modifier {initializer} to test that the ancestor contract has it.
-     */
-    function initialize() public {
+    /// @dev The initialize function of the upgradable contract.
+    function initialize() public initializer{
         _setupRole(OWNER_ROLE, _msgSender());
         __PauseControl_init(OWNER_ROLE);
     }
 
+    /// @dev To check that the initialize function of the ancestor contract has the 'onlyInitializing' modifier.
+    function call_parent_initialize() public {
+        __PauseControl_init(OWNER_ROLE);
+    }
+
     /**
-     * @dev The unchained initialize function of the upgradable contract
-     * but without modifier {initializer} to test that the ancestor contract has it.
+     * @dev To check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
      */
-    function initialize_unchained() public {
-        _setupRole(OWNER_ROLE, _msgSender());
+    function call_parent_initialize_unchained() public {
         __PauseControl_init_unchained(OWNER_ROLE);
     }
 }

--- a/contracts/mocks/base/RescueControlUpgradeableMock.sol
+++ b/contracts/mocks/base/RescueControlUpgradeableMock.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { RescueControlUpgradeable } from "../../base/RescueControlUpgradeable.sol";
+
+/**
+ * @title RescueControlUpgradeableMock contract
+ * @dev An implementation of the {RescueControlUpgradeable} contract for test purposes.
+ */
+contract RescueControlUpgradeableMock is RescueControlUpgradeable {
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /// @dev The initialize function of the upgradable contract.
+    function initialize() public initializer{
+        _setupRole(OWNER_ROLE, _msgSender());
+        __RescueControl_init(OWNER_ROLE);
+    }
+
+    /// @dev To check that the initialize function of the ancestor contract has the 'onlyInitializing' modifier.
+    function call_parent_initialize() public {
+        __RescueControl_init(OWNER_ROLE);
+    }
+
+    /**
+     * @dev To check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize_unchained() public {
+        __RescueControl_init_unchained(OWNER_ROLE);
+    }
+}

--- a/test/CardPaymentProcessorUpgradeable.test.ts
+++ b/test/CardPaymentProcessorUpgradeable.test.ts
@@ -102,6 +102,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
   let user2: SignerWithAddress;
   let ownerRole: string;
   let pauserRole: string;
+  let rescuerRole: string;
   let executorRole: string;
 
   async function setUpContractsForPayments(payments: TestPayment[]) {
@@ -273,6 +274,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
     // Roles
     ownerRole = (await cardPaymentProcessor.OWNER_ROLE()).toLowerCase();
     pauserRole = (await cardPaymentProcessor.PAUSER_ROLE()).toLowerCase();
+    rescuerRole = (await cardPaymentProcessor.RESCUER_ROLE()).toLowerCase();
     executorRole = (await cardPaymentProcessor.EXECUTOR_ROLE()).toLowerCase();
   });
 
@@ -291,11 +293,13 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
     // The role admins
     expect(await cardPaymentProcessor.getRoleAdmin(ownerRole)).to.equal(ownerRole);
     expect(await cardPaymentProcessor.getRoleAdmin(pauserRole)).to.equal(ownerRole);
+    expect(await cardPaymentProcessor.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
     expect(await cardPaymentProcessor.getRoleAdmin(executorRole)).to.equal(ownerRole);
 
     // The deployer should have the owner role, but not the other roles
     expect(await cardPaymentProcessor.hasRole(ownerRole, deployer.address)).to.equal(true);
     expect(await cardPaymentProcessor.hasRole(pauserRole, deployer.address)).to.equal(false);
+    expect(await cardPaymentProcessor.hasRole(rescuerRole, deployer.address)).to.equal(false);
     expect(await cardPaymentProcessor.hasRole(executorRole, deployer.address)).to.equal(false);
   });
 

--- a/test/base/PauseControlUpgradeable.test.ts
+++ b/test/base/PauseControlUpgradeable.test.ts
@@ -7,6 +7,7 @@ import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
 
 describe("Contract 'PauseControlUpgradeable'", async () => {
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
 
   let pauseControlMock: Contract;
   let deployer: SignerWithAddress;
@@ -31,9 +32,14 @@ describe("Contract 'PauseControlUpgradeable'", async () => {
       .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
   });
 
-  it("The initialize unchained function can't be called more than once", async () => {
-    await expect(pauseControlMock.initialize_unchained())
-      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  it("The init function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(pauseControlMock.call_parent_initialize())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+  });
+
+  it("The init unchained function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(pauseControlMock.call_parent_initialize_unchained())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
   });
 
   it("The initial contract configuration should be as expected", async () => {

--- a/test/base/RescueControlUpgradeable.test.ts
+++ b/test/base/RescueControlUpgradeable.test.ts
@@ -1,0 +1,99 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
+
+describe("Contract 'RescueControlUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+
+  let rescueControlMock: Contract;
+  let tokenMock: Contract;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+  let ownerRole: string;
+  let rescuerRole: string;
+
+  beforeEach(async () => {
+    // Deploy the token mock contract
+    const TokenMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    tokenMock = await upgrades.deployProxy(TokenMock, ["BRL Coin", "BRLC"]);
+    await tokenMock.deployed();
+
+    // Deploy the contract under test
+    const RescueControlMock: ContractFactory = await ethers.getContractFactory("RescueControlUpgradeableMock");
+    rescueControlMock = await upgrades.deployProxy(RescueControlMock);
+    await rescueControlMock.deployed();
+
+    [deployer, user] = await ethers.getSigners();
+
+    // Roles
+    ownerRole = (await rescueControlMock.OWNER_ROLE()).toLowerCase();
+    rescuerRole = (await rescueControlMock.RESCUER_ROLE()).toLowerCase();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(rescueControlMock.initialize())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The init function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(rescueControlMock.call_parent_initialize())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+  });
+
+  it("The init unchained function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(rescueControlMock.call_parent_initialize_unchained())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+  });
+
+  it("The initial contract configuration should be as expected", async () => {
+    // The role admins
+    expect(await rescueControlMock.getRoleAdmin(ownerRole)).to.equal(ethers.constants.HashZero);
+    expect(await rescueControlMock.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
+
+    // The deployer should have the owner role, but not the other roles
+    expect(await rescueControlMock.hasRole(ownerRole, deployer.address)).to.equal(true);
+    expect(await rescueControlMock.hasRole(rescuerRole, deployer.address)).to.equal(false);
+  });
+
+  describe("Function 'rescueERC20()'", async () => {
+    const tokenAmount = 123;
+
+    beforeEach(async () => {
+      await proveTx(tokenMock.mint(rescueControlMock.address, tokenAmount));
+      await proveTx(rescueControlMock.grantRole(rescuerRole, user.address));
+    });
+
+    it("Is reverted if is called by an account without the rescuer role", async () => {
+      await expect(
+        rescueControlMock.rescueERC20(
+          tokenMock.address,
+          deployer.address,
+          tokenAmount
+        )
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, rescuerRole));
+    });
+
+    it("Executes successfully if is called by an account with the rescuer role", async () => {
+      await expect(rescueControlMock.connect(user).rescueERC20(
+        tokenMock.address,
+        deployer.address,
+        tokenAmount
+      )).to.changeTokenBalances(
+        tokenMock,
+        [rescueControlMock, deployer, user],
+        [-tokenAmount, +tokenAmount, 0]
+      ).and.to.emit(
+        tokenMock,
+        "Transfer"
+      ).withArgs(
+        rescueControlMock.address,
+        deployer.address,
+        tokenAmount
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Main changes
1. Implement the abstract contract to rescue the tokens locked in the inherited contract.
2. Add the `RESCUER` role.
3. Make CPP contract inherited  from the token rescue contract.

### Merging notes
1. The code in this PR is based on the changes from the [PR#12](https://github.com/cloudwalk/brlc-periphery/pull/12).
2. This PR should be merged after the [PR#12](https://github.com/cloudwalk/brlc-periphery/pull/12).

### Testing and coverage
The updated and newly developed tests have been successfully run on the following blockchains:
1. Internal Hardhat net.
2. Substrate with Frontier layer built from the [cloudwalk-network](https://github.com/cloudwalk/cloudwalk-network) repo, commit [4dc01c8b358f0748bc2f964a006200b3cc748f5b](https://github.com/cloudwalk/cloudwalk-network/commit/4dc01c8b358f0748bc2f964a006200b3cc748f5b).

_NOTE 1_: When running a local node of Substrate with Frontier layer for testing use the node in the archive mode like in the following command:
```bash
./target/release/cloudwalk-network-node --dev --tmp --pruning archive
```

Coverage:
![Screenshot from 2022-08-15 23-39-25](https://user-images.githubusercontent.com/97302011/184677453-08f9eadb-b9ec-4789-9c14-25d6602eb325.png)
