### PR TITLE
Token distributor contract

### DIFF
--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -10,10 +10,10 @@ import { CardPaymentProcessorStorage } from "./CardPaymentProcessorStorage.sol";
 import { ICardPaymentProcessor } from "./interfaces/ICardPaymentProcessor.sol";
 
 /**
- * @title CardPaymentProcessorUpgradeable contract
+ * @title CardPaymentProcessor contract
  * @dev Wrapper for the card payment operations.
  */
-contract CardPaymentProcessorUpgradeable is
+contract CardPaymentProcessor is
     AccessControlUpgradeable,
     PauseControlUpgradeable,
     CardPaymentProcessorStorage,

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -5,9 +5,13 @@ pragma solidity ^0.8.8;
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+import { BlacklistControlUpgradeable } from "./base/BlacklistControlUpgradeable.sol";
 import { PauseControlUpgradeable } from "./base/PauseControlUpgradeable.sol";
+import { RescueControlUpgradeable } from "./base/RescueControlUpgradeable.sol";
 import { CardPaymentProcessorStorage } from "./CardPaymentProcessorStorage.sol";
 import { ICardPaymentProcessor } from "./interfaces/ICardPaymentProcessor.sol";
+import { StoragePlaceholder200 } from "./base/StoragePlaceholder.sol";
 
 /**
  * @title CardPaymentProcessor contract
@@ -15,7 +19,10 @@ import { ICardPaymentProcessor } from "./interfaces/ICardPaymentProcessor.sol";
  */
 contract CardPaymentProcessor is
     AccessControlUpgradeable,
+    BlacklistControlUpgradeable,
     PauseControlUpgradeable,
+    RescueControlUpgradeable,
+    StoragePlaceholder200,
     CardPaymentProcessorStorage,
     ICardPaymentProcessor
 {
@@ -24,7 +31,11 @@ contract CardPaymentProcessor is
 
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
+    // -------------------- Events -----------------------------------
+
     event SetRevocationLimit(uint8 oldLimit, uint8 newLimit);
+
+    // -------------------- Errors -----------------------------------
 
     /// @dev Zero amount of tokens has been passed when making a payment.
     error ZeroPaymentAmount();
@@ -65,6 +76,8 @@ contract CardPaymentProcessor is
      */
     error RevocationLimitReached(uint8 configuredRevocationLimit);
 
+    // ------------------- Functions ---------------------------------
+
     function initialize(address token_) public initializer {
         __CardPaymentProcessor_init(token_);
     }
@@ -74,7 +87,9 @@ contract CardPaymentProcessor is
         __Context_init_unchained();
         __ERC165_init_unchained();
         __Pausable_init_unchained();
+        __BlacklistControl_init_unchained(OWNER_ROLE);
         __PauseControl_init_unchained(OWNER_ROLE);
+        __RescueControl_init_unchained(OWNER_ROLE);
 
         __CardPaymentProcessor_init_unchained(token_);
     }
@@ -155,15 +170,21 @@ contract CardPaymentProcessor is
     /**
      * @dev See {ICardPaymentProcessor-makePayment}.
      *
-     * Additional requirements:
+     * Requirements:
      *
      * - The contract must not be paused.
+     * - The caller must must not be blacklisted.
+     * - The amount of tokens must be greater then zero.
+     * - The authorization ID of the payment must not be zero.
+     * - The payment with the authorization ID must not exist or be revoked.
+     * - The payment's revocation counter must be less then the configured revocation limit of payments or equals zero.
+     *
      */
     function makePayment(
         uint256 amount,
         bytes16 authorizationId,
         bytes16 correlationId
-    ) external whenNotPaused {
+    ) external whenNotPaused notBlacklisted(_msgSender()) {
         Payment storage payment = _payments[authorizationId];
         address sender = _msgSender();
 
@@ -202,10 +223,12 @@ contract CardPaymentProcessor is
     /**
      * @dev See {ICardPaymentProcessor-clearPayment}.
      *
-     * Additional requirements:
+     * Requirements:
      *
      * - The contract must not be paused.
      * - The caller must have the {EXECUTOR_ROLE} role.
+     * - The payment must have the "uncleared" status.
+     * - The input authorization ID of the payment must not be zero.
      */
     function clearPayment(bytes16 authorizationId) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
         uint256 amount = clearPaymentInternal(authorizationId);
@@ -217,10 +240,13 @@ contract CardPaymentProcessor is
     /**
      * @dev See {ICardPaymentProcessor-clearPayments}.
      *
-     * Additional requirements:
+     * Requirements:
      *
      * - The contract must not be paused.
      * - The caller must have the {EXECUTOR_ROLE} role.
+     * - Each payment must have the "uncleared" status or the call will be reverted.
+     * - The input array of the the authorization IDs must not be empty.
+     * - All the authorization IDs of the payments must not be zero.
      */
     function clearPayments(bytes16[] memory authorizationIds) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
         if (authorizationIds.length == 0) {
@@ -238,10 +264,12 @@ contract CardPaymentProcessor is
     /**
      * @dev See {ICardPaymentProcessor-unclearPayment}.
      *
-     * Additional requirements:
+     * Requirements:
      *
      * - The contract must not be paused.
      * - The caller must have the {EXECUTOR_ROLE} role.
+     * - The payment must have the "cleared" status or the call will be reverted.
+     * - The input authorization ID of the payment must not be zero.
      */
     function unclearPayment(bytes16 authorizationId) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
         uint256 amount = unclearPaymentInternal(authorizationId);
@@ -253,10 +281,13 @@ contract CardPaymentProcessor is
     /**
      * @dev See {ICardPaymentProcessor-unclearPayments}.
      *
-     * Additional requirements:
+     * Requirements:
      *
      * - The contract must not be paused.
      * - The caller must have the {EXECUTOR_ROLE} role.
+     * - Each payment must have the "cleared" status or the call will be reverted.
+     * - The input array of the the authorization IDs must not be empty.
+     * - All the authorization IDs of the payments must not be zero.
      */
     function unclearPayments(bytes16[] memory authorizationIds) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
         if (authorizationIds.length == 0) {
@@ -274,10 +305,12 @@ contract CardPaymentProcessor is
     /**
      * @dev See {ICardPaymentProcessor-reversePayment}.
      *
-     * Additional requirements:
+     * Requirements:
      *
      * - The contract must not be paused.
      * - The caller must have the {EXECUTOR_ROLE} role.
+     * - The payment must have "cleared" or "uncleared" statuses.
+     * - The input authorization ID and parent transaction hash of the payment must not be zero.
      */
     function reversePayment(
         bytes16 authorizationId,
@@ -295,10 +328,13 @@ contract CardPaymentProcessor is
     /**
      * @dev See {ICardPaymentProcessor-revokePayment}.
      *
-     * Additional requirements:
+     * Requirements:
      *
      * - The contract must not be paused.
      * - The caller must have the {EXECUTOR_ROLE} role.
+     * - The payment must have "cleared" or "uncleared" statuses.
+     * - The input authorization ID and parent transaction hash of the payment must not be zero.
+     * - The revocation limit of payments should not be zero.
      */
     function revokePayment(
         bytes16 authorizationId,
@@ -319,10 +355,12 @@ contract CardPaymentProcessor is
     /**
      * @dev See {ICardPaymentProcessor-confirmPayment}.
      *
-     * Additional requirements:
+     * Requirements:
      *
      * - The contract must not be paused.
      * - The caller must have the {EXECUTOR_ROLE} role.
+     * - The payment must have the "cleared" status.
+     * - The input authorization ID and cash out account of the payment must not be zero.
      */
     function confirmPayment(bytes16 authorizationId, address cashOutAccount)
         external
@@ -341,10 +379,11 @@ contract CardPaymentProcessor is
     /**
      * @dev See {ICardPaymentProcessor-confirmPayments}.
      *
-     * Additional requirements:
+     * Requirements:
      *
      * - The contract must not be paused.
      * - The caller must have the {EXECUTOR_ROLE} role.
+     * - Each payment must have the "cleared" status or the call will be reverted.
      */
     function confirmPayments(bytes16[] memory authorizationIds, address cashOutAccount)
         external

--- a/contracts/CardPaymentProcessorStorage.sol
+++ b/contracts/CardPaymentProcessorStorage.sol
@@ -38,13 +38,13 @@ abstract contract CardPaymentProcessorStorageV1 is ICardPaymentProcessorTypes {
 
 /**
  * @title CardPaymentProcessor storage
- * @dev Contains storage variables of the {CardPaymentProcessor} contract
+ * @dev Contains storage variables of the {CardPaymentProcessor} contract.
  *
  * We are following Compound's approach of upgrading new contract implementations.
  * See https://github.com/compound-finance/compound-protocol.
  * When we need to add new storage variables, we create a new version of CardPaymentProcessorStorage
  * e.g. CardPaymentProcessorStorage<versionNumber>, so finally it would look like
- * "contract CardPaymentProcessorStorage is CardPaymentProcessorStorageV1, CardPaymentProcessorStorageV2"
+ * "contract CardPaymentProcessorStorage is CardPaymentProcessorStorageV1, CardPaymentProcessorStorageV2".
  */
 abstract contract CardPaymentProcessorStorage is CardPaymentProcessorStorageV1 {
 

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+import { BlacklistControlUpgradeable } from "./base/BlacklistControlUpgradeable.sol";
+import { IERC20Mintable } from "./interfaces/IERC20Mintable.sol";
+import { IPixCashier } from "./interfaces/IPixCashier.sol";
+import { PauseControlUpgradeable } from "./base/PauseControlUpgradeable.sol";
+import { PixCashierStorage } from "./PixCashierStorage.sol";
+import { RescueControlUpgradeable } from "./base/RescueControlUpgradeable.sol";
+import { StoragePlaceholder200 } from "./base/StoragePlaceholder.sol";
+
+/**
+ * @title PixCashier contract
+ * @dev Wrapper for PIX cash-in and cash-out transactions.
+ *
+ * Only accounts that have {CASHIER_ROLE} role can execute the cash-in operations.
+ * About roles see https://docs.openzeppelin.com/contracts/4.x/api/access#AccessControl.
+ */
+contract PixCashier is
+    AccessControlUpgradeable,
+    BlacklistControlUpgradeable,
+    PauseControlUpgradeable,
+    RescueControlUpgradeable,
+    StoragePlaceholder200,
+    PixCashierStorage,
+    IPixCashier
+{
+    /// @dev The role of this contract owner.
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /// @dev The role of cashier that is allowed to execute the cash-in operations.
+    bytes32 public constant CASHIER_ROLE = keccak256("CASHIER_ROLE");
+
+    /// @dev The zero account has been provided as a function parameter.
+    error ZeroAccount();
+
+    /// @dev The zero token amount has been provided as a function parameter.
+    error ZeroAmount();
+
+    /// @dev The zero off-chain transaction identifier has been provided as a function parameter.
+    error ZeroTxId();
+
+    /// @dev The cash-out balance of the caller is not enough to execute the function.
+    error InsufficientCashOutBalance();
+
+    /**
+     * @dev The initialize function of the upgradable contract.
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
+     */
+    function initialize(address token_) public initializer {
+        __PixCashier_init(token_);
+    }
+
+    function __PixCashier_init(address token_) internal onlyInitializing {
+        __AccessControl_init_unchained();
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __Pausable_init_unchained();
+        __BlacklistControl_init_unchained(OWNER_ROLE);
+        __PauseControl_init_unchained(OWNER_ROLE);
+        __RescueControl_init_unchained(OWNER_ROLE);
+
+        __PixCashier_init_unchained(token_);
+    }
+
+    function __PixCashier_init_unchained(address token_) internal onlyInitializing {
+        _token = token_;
+
+        _setRoleAdmin(OWNER_ROLE, OWNER_ROLE);
+        _setRoleAdmin(CASHIER_ROLE, OWNER_ROLE);
+
+        _setupRole(OWNER_ROLE, _msgSender());
+    }
+
+    /// @dev See {IPixCashier-underlyingToken}.
+    function underlyingToken() external view returns (address) {
+        return _token;
+    }
+
+    /// @dev See {IPixCashier-cashOutBalanceOf}.
+    function cashOutBalanceOf(address account) external view returns (uint256) {
+        return _cashOutBalances[account];
+    }
+
+    /**
+     * @dev See {IPixCashier-cashIn}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {CASHIER_ROLE} role.
+     * - The provided `account`, `amount`, `txId` values must not be zero.
+     * - Requirements to the `account` and `amount` values of the underlying token's `mint()` function.
+     */
+    function cashIn(
+        address account,
+        uint256 amount,
+        bytes32 txId
+    ) external whenNotPaused onlyRole(CASHIER_ROLE) {
+        if (account == address(0)) {
+            revert ZeroAccount();
+        }
+        if (amount == 0) {
+            revert ZeroAmount();
+        }
+        if (txId == 0) {
+            revert ZeroTxId();
+        }
+        IERC20Mintable(_token).mint(account, amount);
+        emit CashIn(account, amount, txId);
+    }
+
+    /**
+     * @dev See {IPixCashier-cashOut}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must must not be blacklisted.
+     * - The provided `amount`, `txId` values must not be zero.
+     * - Requirements to the `_msgSender()` and `amount` values of the underlying token's `transferFrom()` function.
+     */
+    function cashOut(uint256 amount, bytes32 txId) external whenNotPaused notBlacklisted(_msgSender()) {
+        if (amount == 0) {
+            revert ZeroAmount();
+        }
+        if (txId == 0) {
+            revert ZeroTxId();
+        }
+        address sender = _msgSender();
+        IERC20Upgradeable(_token).transferFrom(
+            sender,
+            address(this),
+            amount
+        );
+        uint256 newCashOutBalance = _cashOutBalances[_msgSender()] + amount;
+        _cashOutBalances[_msgSender()] = newCashOutBalance;
+        emit CashOut(
+            sender,
+            amount,
+            newCashOutBalance,
+            txId
+        );
+    }
+
+    /**
+     * @dev See {IPixCashier-cashOutConfirm}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must must not be blacklisted.
+     * - The provided `amount`, `txId` values must not be zero.
+     * - The cash-out balance of the caller must be not less then the provided `amount` value.
+     * - Requirements to the `amount` value of the underlying token's `burn()` function.
+     */
+    function cashOutConfirm(uint256 amount, bytes32 txId) external whenNotPaused notBlacklisted(_msgSender()) {
+        if (amount == 0) {
+            revert ZeroAmount();
+        }
+        if (txId == 0) {
+            revert ZeroTxId();
+        }
+        address sender = _msgSender();
+        uint256 cashOutBalance = _cashOutBalances[sender];
+        if (cashOutBalance < amount) {
+            revert InsufficientCashOutBalance();
+        }
+        IERC20Mintable(_token).burn(amount);
+        cashOutBalance -= amount;
+        _cashOutBalances[sender] = cashOutBalance;
+        emit CashOutConfirm(
+            sender,
+            amount,
+            cashOutBalance,
+            txId
+        );
+    }
+
+    /**
+     * @dev See {IPixCashier-cashOutReverse}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must must not be blacklisted.
+     * - The provided `amount`, `txId` values must not be zero.
+     * - The cash-out balance of the caller must be not less than the provided `amount` value.
+     * - Requirements to the `_msgSender()` and `amount` values of the underlying token's `transfer()` function.
+     */
+    function cashOutReverse(uint256 amount, bytes32 txId) external whenNotPaused notBlacklisted(_msgSender()) {
+        if (amount == 0) {
+            revert ZeroAmount();
+        }
+        if (txId == 0) {
+            revert ZeroTxId();
+        }
+        address sender = _msgSender();
+        uint256 cashOutBalance = _cashOutBalances[sender];
+        if (cashOutBalance < amount) {
+            revert InsufficientCashOutBalance();
+        }
+        IERC20Upgradeable(_token).transfer(sender, amount);
+        cashOutBalance -= amount;
+        _cashOutBalances[sender] = cashOutBalance;
+        emit CashOutReverse(
+            sender,
+            amount,
+            cashOutBalance,
+            txId
+        );
+    }
+}

--- a/contracts/PixCashierStorage.sol
+++ b/contracts/PixCashierStorage.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+/**
+ * @title PixCashier storage version 1
+ */
+abstract contract PixCashierStorageV1 {
+    /// @dev The address of the underlying token.
+    address internal _token;
+
+    /// @dev Mapping of a cash-out token balance for a given account. These balances are parts of the contract balance.
+    mapping(address => uint256) internal _cashOutBalances;
+}
+
+/**
+ * @title PixCashier storage
+ * @dev Contains storage variables of the {PixCashier} contract.
+ *
+ * We are following Compound's approach of upgrading new contract implementations.
+ * See https://github.com/compound-finance/compound-protocol.
+ * When we need to add new storage variables, we create a new version of PixCashierStorage
+ * e.g. PixCashierStorage<versionNumber>, so finally it would look like
+ * "contract PixCashierStorage is PixCashierStorageV1, PixCashierStorageV2".
+ */
+abstract contract PixCashierStorage is PixCashierStorageV1 {
+
+}

--- a/contracts/TokenDistributor.sol
+++ b/contracts/TokenDistributor.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+import { ITokenDistributor } from "./interfaces/ITokenDistributor.sol";
+import { PauseControlUpgradeable } from "./base/PauseControlUpgradeable.sol";
+import { RescueControlUpgradeable } from "./base/RescueControlUpgradeable.sol";
+import { StoragePlaceholder200 } from "./base/StoragePlaceholder.sol";
+
+/**
+ * @title TokenDistributor contract
+ * @dev The contract for token distribution among multiple accounts.
+ *
+ * Only accounts that have {DISTRIBUTOR_ROLE} role can execute the distribution operations.
+ * About roles see https://docs.openzeppelin.com/contracts/4.x/api/access#AccessControl.
+ */
+contract TokenDistributor is
+    AccessControlUpgradeable,
+    PauseControlUpgradeable,
+    RescueControlUpgradeable,
+    StoragePlaceholder200,
+    ITokenDistributor
+{
+    /// @dev The role of this contract owner.
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /// @dev The role of distributor that is allowed to execute the distribution operations.
+    bytes32 public constant DISTRIBUTOR_ROLE = keccak256("DISTRIBUTOR_ROLE");
+
+    /// @dev The zero token contract address has been provided as a function parameter.
+    error ZeroToken();
+
+    /// @dev Empty array of recipients has been passed as a function argument.
+    error EmptyRecipientsArray();
+
+    /// @dev The length of the array of balances is mismatched with the one of the recipients array.
+    error BalancesArrayLengthMismatch();
+
+    /// @dev The zero recipient address has been found in the input array of the recipients.
+    error ZeroRecipient();
+
+    /// @dev The zero balance has been found in the input array of the balances.
+    error ZeroBalance();
+
+    /**
+     * @dev The initialize function of the upgradable contract.
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
+     */
+    function initialize() public initializer {
+        __TokenDistributor_init();
+    }
+
+    function __TokenDistributor_init() internal onlyInitializing {
+        __AccessControl_init_unchained();
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __Pausable_init_unchained();
+        __PauseControl_init_unchained(OWNER_ROLE);
+        __RescueControl_init_unchained(OWNER_ROLE);
+
+        __TokenDistributor_init_unchained();
+    }
+
+    function __TokenDistributor_init_unchained() internal onlyInitializing {
+        _setRoleAdmin(OWNER_ROLE, OWNER_ROLE);
+        _setRoleAdmin(DISTRIBUTOR_ROLE, OWNER_ROLE);
+
+        _setupRole(OWNER_ROLE, _msgSender());
+    }
+
+    /**
+     * @dev See {ITokenDistributor-distributeTokens}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {DISTRIBUTOR_ROLE} role.
+     * - The provided `token` argument must not be zero.
+     * - The provided `recipients`, `balances` arrays must not be empty and each of their element must not be zero.
+     * - The length of the `recipients`, `balances` arrays must be the same.
+     */
+    function distributeTokens(
+        address token,
+        address[] memory recipients,
+        uint256[] memory balances
+    ) external whenNotPaused onlyRole(DISTRIBUTOR_ROLE) {
+        if (token == address(0)) {
+            revert ZeroToken();
+        }
+        if (recipients.length == 0) {
+            revert EmptyRecipientsArray();
+        }
+        if (recipients.length != balances.length) {
+            revert BalancesArrayLengthMismatch();
+        }
+
+        IERC20Upgradeable erc20 = IERC20Upgradeable(token);
+        uint256 total = 0;
+
+        for (uint8 i = 0; i < recipients.length; i++) {
+            address recipient = recipients[i];
+            uint256 balance = balances[i];
+
+            if (recipient == address(0)) {
+                revert ZeroRecipient();
+            }
+            if (balance == 0) {
+                revert ZeroBalance();
+            }
+
+            erc20.transfer(recipient, balance);
+            total += balance;
+        }
+        emit DistributeTokens(token, total);
+    }
+}

--- a/contracts/base/BlacklistControlUpgradeable.sol
+++ b/contracts/base/BlacklistControlUpgradeable.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+/**
+ * @title BlacklistControlUpgradeable base contract
+ * @dev Allows to blacklist/unblacklist accounts using the {BLACKLISTER_ROLE} role.
+ *
+ * This contract is used through inheritance. It will make available the modifier `notBlacklisted`,
+ * which can be applied to functions to restrict their usage to not blacklisted accounts only.
+ *
+ * The admins of the {BLACKLISTER_ROLE} role are accounts with the role defined in the init() function.
+ *
+ * There is also a possibility to any account to blacklist itself.
+ */
+abstract contract BlacklistControlUpgradeable is AccessControlUpgradeable {
+    bytes32 public constant BLACKLISTER_ROLE = keccak256("BLACKLISTER_ROLE");
+
+    /// @dev Mapping of presence in the blacklist for a given address.
+    mapping(address => bool) private _blacklisted;
+
+    // -------------------- Events -----------------------------------
+
+    /// @dev Emitted when an account is blacklisted.
+    event Blacklisted(address indexed account);
+
+    /// @dev Emitted when an account is unblacklisted.
+    event UnBlacklisted(address indexed account);
+
+    /// @dev Emitted when an account is self blacklisted.
+    event SelfBlacklisted(address indexed account);
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev The transaction sender is blacklisted.
+    error BlacklistedAccount(address account);
+
+    // ------------------- Functions ---------------------------------
+
+    function __BlacklistControl_init(bytes32 blacklisterRoleAdmin) internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __BlacklistControl_init_unchained(blacklisterRoleAdmin);
+    }
+
+    function __BlacklistControl_init_unchained(bytes32 blacklisterRoleAdmin) internal onlyInitializing {
+        _setRoleAdmin(BLACKLISTER_ROLE, blacklisterRoleAdmin);
+    }
+
+    /**
+     * @dev Throws if called by a blacklisted account.
+     * @param account The address to check for presence in the blacklist.
+     */
+    modifier notBlacklisted(address account) {
+        if (_blacklisted[account]) {
+            revert BlacklistedAccount(account);
+        }
+        _;
+    }
+
+    /**
+     * @dev Checks if the account is blacklisted.
+     * @param account The address to check for presence in the blacklist.
+     * @return True if the account is present in the blacklist.
+     */
+    function isBlacklisted(address account) public view returns (bool) {
+        return _blacklisted[account];
+    }
+
+    /**
+     * @dev Adds the account to the blacklist.
+     *
+     * Requirements:
+     * - The caller must have the {BLACKLISTER_ROLE} role.
+     * - The account must not be already blacklisted.
+     *
+     * Emits a {Blacklisted} event.
+     *
+     * @param account The address to blacklist.
+     */
+    function blacklist(address account) external onlyRole(BLACKLISTER_ROLE) {
+        if (_blacklisted[account]) {
+            return;
+        }
+        _blacklisted[account] = true;
+        emit Blacklisted(account);
+    }
+
+    /**
+     * @dev Removes the account from the blacklist.
+     *
+     * Requirements:
+     * - The caller must have the {BLACKLISTER_ROLE} role.
+     * - The account must not be already unblacklisted.
+     *
+     * Emits a {UnBlacklisted} event.
+     *
+     * @param account The address to remove from the blacklist.
+     */
+    function unBlacklist(address account) external onlyRole(BLACKLISTER_ROLE) {
+        if (!_blacklisted[account]) {
+            return;
+        }
+        _blacklisted[account] = false;
+        emit UnBlacklisted(account);
+    }
+
+    /**
+     * @dev Adds the transaction sender to the blacklist.
+     *
+     * Requirements:
+     * - The caller must not be already blacklisted.
+     *
+     * Emits a {SelfBlacklisted} event.
+     * Emits a {Blacklisted} event.
+     */
+    function selfBlacklist() external {
+        if (_blacklisted[_msgSender()]) {
+            return;
+        }
+        _blacklisted[_msgSender()] = true;
+        emit SelfBlacklisted(_msgSender());
+        emit Blacklisted(_msgSender());
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[49] private __gap;
+}

--- a/contracts/base/PauseControlUpgradeable.sol
+++ b/contracts/base/PauseControlUpgradeable.sol
@@ -14,14 +14,14 @@ import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/securit
 abstract contract PauseControlUpgradeable is AccessControlUpgradeable, PausableUpgradeable {
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
-    function __PauseControl_init(bytes32 pauserRoleAdmin) internal initializer {
+    function __PauseControl_init(bytes32 pauserRoleAdmin) internal onlyInitializing {
         __Context_init_unchained();
         __ERC165_init_unchained();
         __Pausable_init_unchained();
         __PauseControl_init_unchained(pauserRoleAdmin);
     }
 
-    function __PauseControl_init_unchained(bytes32 pauserRoleAdmin) internal initializer {
+    function __PauseControl_init_unchained(bytes32 pauserRoleAdmin) internal onlyInitializing {
         _setRoleAdmin(PAUSER_ROLE, pauserRoleAdmin);
     }
 

--- a/contracts/base/RescueControlUpgradeable.sol
+++ b/contracts/base/RescueControlUpgradeable.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+/**
+ * @title RescueControlUpgradeable base contract
+ * @dev Allows to "rescue" tokens locked up in the contract by transferring to a specified address.
+ * Only accounts that have the {RESCUER_ROLE} role can execute token transferring operations.
+ * The admins of the {RESCUER_ROLE} roles are accounts with the role defined in the init() function.
+ */
+abstract contract RescueControlUpgradeable is AccessControlUpgradeable {
+    bytes32 public constant RESCUER_ROLE = keccak256("RESCUER_ROLE");
+
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    function __RescueControl_init(bytes32 rescuerRoleAdmin) internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __RescueControl_init_unchained(rescuerRoleAdmin);
+    }
+
+    function __RescueControl_init_unchained(bytes32 rescuerRoleAdmin) internal onlyInitializing {
+        _setRoleAdmin(RESCUER_ROLE, rescuerRoleAdmin);
+    }
+
+    /**
+     * @dev Rescue ERC20 tokens locked up in this contract.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {RESCUER_ROLE} role.
+     *
+     * @param tokenContract The ERC20 token contract address.
+     * @param to The recipient address.
+     * @param amount The amount to withdraw.
+     */
+    function rescueERC20(
+        IERC20Upgradeable tokenContract,
+        address to,
+        uint256 amount
+    ) external onlyRole(RESCUER_ROLE) {
+        tokenContract.safeTransfer(to, amount);
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[50] private __gap;
+}

--- a/contracts/base/StoragePlaceholder.sol
+++ b/contracts/base/StoragePlaceholder.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.9.0;
+
+/**
+ * @title StoragePlaceholder150 abstract contract
+ * @dev Reserves 200 storage slots.
+ * Such a storage placeholder contract allows future replacement of it with other contracts
+ * without shifting down storage in the inheritance chain.
+ *
+ * E.g. the following code:
+ * ```
+ * abstract contract StoragePlaceholder200 {
+ *     uint256[200] private __gap;
+ * }
+ *
+ * contract A is B, StoragePlaceholder200, C {
+ *     //Some implementation
+ * }
+ * ```
+ * can be replaced with the following code without a storage shifting issue:
+ * ```
+ * abstract contract StoragePlaceholder150 {
+ *     uint256[150] private __gap;
+ * }
+ *
+ * abstract contract X {
+ *     uint256[50] public values;
+ *     // No more storage variables. Some set of functions should be here.
+ * }
+ *
+ * contract A is B, X, StoragePlaceholder150, C {
+ *     //Some implementation
+ * }
+ * ```
+ */
+abstract contract StoragePlaceholder200 {
+    uint256[200] private __gap;
+}

--- a/contracts/interfaces/IERC20Mintable.sol
+++ b/contracts/interfaces/IERC20Mintable.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title IERC20Mintable interface
+ * @dev The interface of a token that supports mint and burn operations.
+ */
+interface IERC20Mintable {
+    /// @dev Emitted when the master minter is changed.
+    event MasterMinterChanged(address indexed newMasterMinter);
+
+    /// @dev Emitted when a minter account is configured.
+    event MinterConfigured(address indexed minter, uint256 mintAllowance);
+
+    /// @dev Emitted when a minter account is removed.
+    event MinterRemoved(address indexed oldMinter);
+
+    /// @dev Emitted when tokens are minted.
+    event Mint(address indexed minter, address indexed to, uint256 amount);
+
+    /// @dev Emitted when tokens are burned.
+    event Burn(address indexed burner, uint256 amount);
+
+    /**
+     * @dev Returns the master minter address.
+     */
+    function masterMinter() external view returns (address);
+
+    /**
+     * @dev Checks if the account is configured as a minter.
+     * @param account The address to check.
+     * @return True if the account is a minter.
+     */
+    function isMinter(address account) external view returns (bool);
+
+    /**
+     * @dev Returns a mint allowance of the minter.
+     * @param minter The minter to check.
+     * @return The mint allowance of the minter.
+     */
+    function minterAllowance(address minter) external view returns (uint256);
+
+    /**
+     * @dev Updates the master minter address.
+     *
+     * Emits a {MasterMinterChanged} event.
+     *
+     * @param newMasterMinter The address of a new master minter.
+     */
+    function updateMasterMinter(address newMasterMinter) external;
+
+    /**
+     * @dev Configures the minter.
+     *
+     * Emits a {MinterConfigured} event.
+     *
+     * @param minter The address of the minter to configure.
+     * @param mintAllowance The mint allowance.
+     * @return True if the operation was successful.
+     */
+    function configureMinter(address minter, uint256 mintAllowance) external returns (bool);
+
+    /**
+     * @dev Removes the minter.
+     *
+     * Emits a {MinterRemoved} event.
+     *
+     * @param minter The address of the minter to remove.
+     * @return True if the operation was successful.
+     */
+    function removeMinter(address minter) external returns (bool);
+
+    /**
+     * @dev Mints tokens.
+     *
+     * Emits a {Mint} event.
+     *
+     * @param account The address of tokens recipient.
+     * @param amount The amount of tokens to mint.
+     * @return True if the operation was successful.
+     */
+    function mint(address account, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Burns tokens.
+     *
+     * Emits a {Burn} event.
+     *
+     * @param amount The amount of tokens to burn.
+     */
+    function burn(uint256 amount) external;
+}

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+/**
+ * @title PixCashier interface
+ * @dev The interface of the wrapper contract for PIX cash-in and cash-out transactions.
+ */
+interface IPixCashier {
+    /// @dev Emitted when a new cash-in transaction is executed.
+    event CashIn(
+        address indexed account, // The account that receives tokens.
+        uint256 amount,          // The amount of tokens to receive.
+        bytes32 indexed txId     // The off-chain transaction identifier.
+    );
+
+    /// @dev Emitted when a new cash-out transaction is initiated.
+    event CashOut(
+        address indexed account, // The account whose tokens are cash-outed.
+        uint256 amount,          // The amount of tokens to cash-out.
+        uint256 balance,         // The account's new cash-out token balance as a part of the contract balance.
+        bytes32 indexed txId     // The off-chain transaction identifier.
+    );
+
+    /// @dev Emitted when a cash-out transaction is confirmed.
+    event CashOutConfirm(
+        address indexed account, // The account whose tokens are cash-outed.
+        uint256 amount,          // The amount of tokens to cash-out.
+        uint256 balance,         // The account's new cash-out token balance as a part of the contract balance.
+        bytes32 indexed txId     // The off-chain transaction identifier.
+    );
+
+    /// @dev Emitted when a cash-out transaction is reversed.
+    event CashOutReverse(
+        address indexed account, // The account whose tokens are cash-outed.
+        uint256 amount,          // The amount of tokens to cash-out.
+        uint256 balance,         // The account's new cash-out token balance as a part of the contract balance.
+        bytes32 indexed txId     // The off-chain transaction identifier.
+    );
+
+    /// @dev Returns the address of the underlying token contract.
+    function underlyingToken() external view returns (address);
+
+    /**
+     * @dev Returns the balance of tokens to cash-out for an account as a part of the contract balance.
+     * @param account The address of a tokens owner.
+     */
+    function cashOutBalanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Executes a cash-in transaction.
+     *
+     * This function can be called by a limited number of accounts that are allowed to execute cash-in transactions.
+     *
+     * Emits a {CashIn} event.
+     *
+     * @param account An address that will receive tokens.
+     * @param amount The amount of tokens to be received.
+     * @param txId The off-chain transaction identifier.
+     */
+    function cashIn(
+        address account,
+        uint256 amount,
+        bytes32 txId
+    ) external;
+
+    /**
+     * @dev Initiates a cash-out transaction.
+     *
+     * Transfers tokens from the caller to the contract.
+     * This function is expected to be called by any account.
+     *
+     * Emits a {CashOut} event.
+     *
+     * @param amount The amount of tokens to be cash-outed.
+     * @param txId The off-chain transaction identifier.
+     */
+    function cashOut(uint256 amount, bytes32 txId) external;
+
+    /**
+     * @dev Confirms a cash-out transaction.
+     *
+     * Burns tokens previously transferred to the contract during execution of the `cashOut()` function.
+     * This function is expected to be called by any account.
+     *
+     * Emits a {CashOutConfirm} event.
+     *
+     * @param amount The amount of tokens to be burned.
+     * @param txId The off-chain transaction identifier.
+     */
+    function cashOutConfirm(uint256 amount, bytes32 txId) external;
+
+    /**
+     * @dev Reverts a cash-out transaction.
+     *
+     * Transfers tokens back from the contract to the caller.
+     * This function is expected to be called by any account.
+     *
+     * Emits a {CashOutReverse} event.
+     *
+     * @param amount The amount of tokens to be transferred back.
+     * @param txId The off-chain transaction identifier.
+     */
+    function cashOutReverse(uint256 amount, bytes32 txId) external;
+}

--- a/contracts/interfaces/ITokenDistributor.sol
+++ b/contracts/interfaces/ITokenDistributor.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+/**
+ * @title TokenDistributor interface
+ * @dev The interface of the contract for token distribution among multiple accounts.
+ */
+interface ITokenDistributor {
+    /// @dev Emitted when a new token distribution is executed.
+    event DistributeTokens(
+        address indexed token, // The address of the token contract whose coins has been distributed.
+        uint256 total          // The total amount of distributed tokens.
+    );
+
+    /**
+     * @dev Executes token distribution/airdrop among multiple accounts.
+     *
+     * Emits a {DistributeTokens} event.
+     *
+     * @param token The address of the token contract whose coins are being distributed.
+     * @param recipients Token recipient addresses.
+     * @param balances Token recipient target balances.
+     */
+    function distributeTokens(
+        address token,
+        address[] memory recipients,
+        uint256[] memory balances
+    ) external;
+}

--- a/contracts/mocks/base/BlacklistControlUpgradeableMock.sol
+++ b/contracts/mocks/base/BlacklistControlUpgradeableMock.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { BlacklistControlUpgradeable } from "../../base/BlacklistControlUpgradeable.sol";
+
+/**
+ * @title BlacklistControlUpgradeableMock contract
+ * @dev An implementation of the {BlacklistControlUpgradeable} contract for test purposes.
+ */
+contract BlacklistControlUpgradeableMock is BlacklistControlUpgradeable {
+    /// @dev The role of this contract owner
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /// @dev Emitted when a test function of the `notBlacklisted` modifier executes successfully
+    event TestNotBlacklistedModifierSucceeded();
+
+    /// @dev The initialize function of the upgradable contract.
+    function initialize() public initializer {
+        _setupRole(OWNER_ROLE, _msgSender());
+        __BlacklistControl_init(OWNER_ROLE);
+    }
+
+    /// @dev To check that the initialize function of the ancestor contract has the 'onlyInitializing' modifier.
+    function call_parent_initialize() public {
+        __BlacklistControl_init(OWNER_ROLE);
+    }
+
+    /**
+     * @dev To check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize_unchained() public {
+        __BlacklistControl_init_unchained(OWNER_ROLE);
+    }
+
+    /**
+     * @dev Checks the execution of the {notBlacklisted} modifier.
+     * If that modifier executed without reverting emits an event {TestNotBlacklistedModifierSucceeded}.
+     */
+    function testNotBlacklistedModifier() external notBlacklisted(_msgSender()) {
+        emit TestNotBlacklistedModifierSucceeded();
+    }
+}

--- a/contracts/mocks/base/RescueControlUpgradeableMock.sol
+++ b/contracts/mocks/base/RescueControlUpgradeableMock.sol
@@ -2,25 +2,25 @@
 
 pragma solidity ^0.8.8;
 
-import { PauseControlUpgradeable } from "../../base/PauseControlUpgradeable.sol";
+import { RescueControlUpgradeable } from "../../base/RescueControlUpgradeable.sol";
 
 /**
- * @title PauseControlUpgradeableMock contract
- * @dev An implementation of the {PauseControlUpgradeable} contract for test purposes.
+ * @title RescueControlUpgradeableMock contract
+ * @dev An implementation of the {RescueControlUpgradeable} contract for test purposes.
  */
-contract PauseControlUpgradeableMock is PauseControlUpgradeable {
+contract RescueControlUpgradeableMock is RescueControlUpgradeable {
     /// @dev The role of this contract owner
     bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
 
     /// @dev The initialize function of the upgradable contract.
     function initialize() public initializer {
         _setupRole(OWNER_ROLE, _msgSender());
-        __PauseControl_init(OWNER_ROLE);
+        __RescueControl_init(OWNER_ROLE);
     }
 
     /// @dev To check that the initialize function of the ancestor contract has the 'onlyInitializing' modifier.
     function call_parent_initialize() public {
-        __PauseControl_init(OWNER_ROLE);
+        __RescueControl_init(OWNER_ROLE);
     }
 
     /**
@@ -28,6 +28,6 @@ contract PauseControlUpgradeableMock is PauseControlUpgradeable {
      * has the 'onlyInitializing' modifier.
      */
     function call_parent_initialize_unchained() public {
-        __PauseControl_init_unchained(OWNER_ROLE);
+        __RescueControl_init_unchained(OWNER_ROLE);
     }
 }

--- a/contracts/mocks/tokens/ERC20UpgradeableMock.sol
+++ b/contracts/mocks/tokens/ERC20UpgradeableMock.sol
@@ -27,4 +27,12 @@ contract ERC20UpgradeableMock is ERC20Upgradeable {
         _mint(account, amount);
         return true;
     }
+
+    /**
+     * @dev Cals the appropriate internal function to burn needed amount of tokens.
+     * @param amount The amount of tokens of this contract to burn.
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
 }

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -78,7 +78,7 @@ function checkEquality(
   }
 }
 
-describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
+describe("Contract 'CardPaymentProcessor'", async () => {
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
   const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
   const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
@@ -263,7 +263,7 @@ describe("Contract 'CardPaymentProcessorUpgradeable'", async () => {
     await tokenMock.deployed();
 
     // Deploy the being tested contract
-    const CardPaymentProcessor: ContractFactory = await ethers.getContractFactory("CardPaymentProcessorUpgradeable");
+    const CardPaymentProcessor: ContractFactory = await ethers.getContractFactory("CardPaymentProcessor");
     cardPaymentProcessor = await upgrades.deployProxy(CardPaymentProcessor, [tokenMock.address]);
     await cardPaymentProcessor.deployed();
 

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -1,0 +1,364 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../test-utils/eth";
+import { createRevertMessageDueToMissingRole } from "../test-utils/misc";
+
+describe("Contract 'PixCashierUpgradeable'", async () => {
+  const TRANSACTION_ID = ethers.utils.formatBytes32String("MOCK_TRANSACTION_ID");
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+  const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
+
+  const REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED = "BlacklistedAccount";
+  const REVERT_ERROR_IF_ACCOUNT_IS_ZERO = "ZeroAccount";
+  const REVERT_ERROR_IF_AMOUNT_IS_ZERO = "ZeroAmount";
+  const REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO = "ZeroTxId";
+  const REVERT_ERROR_IF_BALANCE_IS_INSUFFICIENT = "InsufficientCashOutBalance";
+
+  let pixCashier: Contract;
+  let tokenMock: Contract;
+  let deployer: SignerWithAddress;
+  let cashier: SignerWithAddress;
+  let user: SignerWithAddress;
+  let ownerRole: string;
+  let blacklisterRole: string;
+  let pauserRole: string;
+  let rescuerRole: string;
+  let cashierRole: string;
+
+  beforeEach(async () => {
+    // Deploy the token mock contract
+    const TokenMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    tokenMock = await TokenMock.deploy();
+    await tokenMock.deployed();
+    await proveTx(tokenMock.initialize("BRL Coin", "BRLC"));
+
+    // Deploy the being tested contract
+    const PixCashier: ContractFactory = await ethers.getContractFactory("PixCashier");
+    pixCashier = await PixCashier.deploy();
+    await pixCashier.deployed();
+    await proveTx(pixCashier.initialize(tokenMock.address));
+
+    // Accounts
+    [deployer, cashier, user] = await ethers.getSigners();
+
+    // Roles
+    ownerRole = (await pixCashier.OWNER_ROLE()).toLowerCase();
+    blacklisterRole = (await pixCashier.BLACKLISTER_ROLE()).toLowerCase();
+    pauserRole = (await pixCashier.PAUSER_ROLE()).toLowerCase();
+    rescuerRole = (await pixCashier.RESCUER_ROLE()).toLowerCase();
+    cashierRole = (await pixCashier.CASHIER_ROLE()).toLowerCase();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(
+      pixCashier.initialize(tokenMock.address)
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initial contract configuration should be as expected", async () => {
+    // The underlying contract address
+    expect(await pixCashier.underlyingToken()).to.equal(tokenMock.address);
+
+    // The role admins
+    expect(await pixCashier.getRoleAdmin(ownerRole)).to.equal(ownerRole);
+    expect(await pixCashier.getRoleAdmin(blacklisterRole)).to.equal(ownerRole);
+    expect(await pixCashier.getRoleAdmin(pauserRole)).to.equal(ownerRole);
+    expect(await pixCashier.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
+    expect(await pixCashier.getRoleAdmin(cashierRole)).to.equal(ownerRole);
+
+    // The deployer should have the owner role, but not the other roles
+    expect(await pixCashier.hasRole(ownerRole, deployer.address)).to.equal(true);
+    expect(await pixCashier.hasRole(blacklisterRole, deployer.address)).to.equal(false);
+    expect(await pixCashier.hasRole(pauserRole, deployer.address)).to.equal(false);
+    expect(await pixCashier.hasRole(rescuerRole, deployer.address)).to.equal(false);
+    expect(await pixCashier.hasRole(cashierRole, deployer.address)).to.equal(false);
+
+    // The initial contract state is unpaused
+    expect(await pixCashier.paused()).to.equal(false);
+  });
+
+  describe("Function 'cashIn()'", async () => {
+    const tokenAmount: number = 100;
+
+    beforeEach(async () => {
+      await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(
+        pixCashier.connect(cashier).cashIn(user.address, tokenAmount, TRANSACTION_ID)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the cashier role", async () => {
+      await expect(
+        pixCashier.connect(deployer).cashIn(user.address, tokenAmount, TRANSACTION_ID)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
+    });
+
+    it("Is reverted if the account address is zero", async () => {
+      await expect(
+        pixCashier.connect(cashier).cashIn(ethers.constants.AddressZero, tokenAmount, TRANSACTION_ID)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_ZERO);
+    });
+
+    it("Is reverted if the token amount is zero", async () => {
+      await expect(
+        pixCashier.connect(cashier).cashIn(user.address, 0, TRANSACTION_ID)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_AMOUNT_IS_ZERO);
+    });
+
+    it("Is reverted if the off-chain transaction ID is zero", async () => {
+      await expect(
+        pixCashier.connect(cashier).cashIn(user.address, tokenAmount, ethers.constants.HashZero)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
+    });
+
+    it("Mints correct amount of tokens and emits the correct event", async () => {
+      await expect(
+        pixCashier.connect(cashier).cashIn(user.address, tokenAmount, TRANSACTION_ID)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [user, pixCashier],
+        [+tokenAmount, 0]
+      ).and.to.emit(
+        pixCashier,
+        "CashIn"
+      ).withArgs(
+        user.address,
+        tokenAmount,
+        TRANSACTION_ID
+      );
+    });
+  });
+
+  describe("Function 'cashOut()'", async () => {
+    const tokenAmount: number = 100;
+
+    beforeEach(async () => {
+      await proveTx(tokenMock.connect(user).approve(pixCashier.address, ethers.constants.MaxUint256));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(
+        pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller is blacklisted", async () => {
+      await proveTx(pixCashier.grantRole(blacklisterRole, deployer.address));
+      await proveTx(pixCashier.blacklist(user.address));
+      await expect(
+        pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Is reverted if the token amount is zero", async () => {
+      await expect(
+        pixCashier.connect(user).cashOut(0, TRANSACTION_ID)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_AMOUNT_IS_ZERO);
+    });
+
+    it("Is reverted if the off-chain transaction ID is zero", async () => {
+      await proveTx(tokenMock.mint(user.address, tokenAmount));
+      await expect(
+        pixCashier.connect(user).cashOut(tokenAmount, ethers.constants.HashZero)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the user has not enough tokens", async () => {
+      await proveTx(tokenMock.mint(user.address, tokenAmount - 1));
+      await expect(pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfers tokens as expected, emits the correct event, changes cash-out balances accordingly", async () => {
+      await proveTx(tokenMock.mint(user.address, tokenAmount));
+      const oldCashOutBalance: number = await pixCashier.cashOutBalanceOf(user.address);
+      await expect(
+        pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [user, pixCashier],
+        [-tokenAmount, +tokenAmount]
+      ).and.to.emit(
+        pixCashier,
+        "CashOut"
+      ).withArgs(
+        user.address,
+        tokenAmount,
+        tokenAmount,
+        TRANSACTION_ID
+      );
+      const newCashOutBalance: number = await pixCashier.cashOutBalanceOf(user.address);
+      expect(newCashOutBalance - oldCashOutBalance).to.equal(tokenAmount);
+    });
+  });
+
+  describe("Function 'cashOutConfirm()'", async () => {
+    const tokenAmount: number = 100;
+
+    beforeEach(async () => {
+      await proveTx(tokenMock.connect(user).approve(pixCashier.address, ethers.constants.MaxUint256));
+      await proveTx(tokenMock.mint(user.address, tokenAmount));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(
+        pixCashier.connect(user).cashOutConfirm(tokenAmount, TRANSACTION_ID)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller is blacklisted", async () => {
+      await proveTx(pixCashier.grantRole(blacklisterRole, deployer.address));
+      await proveTx(pixCashier.blacklist(user.address));
+      await expect(
+        pixCashier.connect(user).cashOutConfirm(tokenAmount, TRANSACTION_ID)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Is reverted if the token amount is zero", async () => {
+      await expect(
+        pixCashier.connect(user).cashOutConfirm(0, TRANSACTION_ID)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_AMOUNT_IS_ZERO);
+    });
+
+    it("Is reverted if the off-chain transaction ID is zero", async () => {
+      await proveTx(pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID));
+      await expect(
+        pixCashier.connect(user).cashOutConfirm(tokenAmount, ethers.constants.HashZero)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the user's cash-out balance is not enough", async () => {
+      await proveTx(pixCashier.connect(user).cashOut(tokenAmount - 1, TRANSACTION_ID));
+      await expect(
+        pixCashier.connect(user).cashOutConfirm(tokenAmount, TRANSACTION_ID)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_BALANCE_IS_INSUFFICIENT);
+    });
+
+    it("Burns tokens as expected, emits the correct event, changes cash-out balances accordingly", async () => {
+      await proveTx(pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID));
+      const oldCashOutBalance: number = await pixCashier.cashOutBalanceOf(user.address);
+      await expect(
+        pixCashier.connect(user).cashOutConfirm(tokenAmount, TRANSACTION_ID)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [pixCashier, user],
+        [-tokenAmount, 0]
+      ).and.to.emit(
+        pixCashier,
+        "CashOutConfirm"
+      ).withArgs(
+        user.address,
+        tokenAmount,
+        0,
+        TRANSACTION_ID
+      );
+      const newCashOutBalance: number = await pixCashier.cashOutBalanceOf(user.address);
+      expect(newCashOutBalance - oldCashOutBalance).to.equal(-tokenAmount);
+    });
+  });
+
+  describe("Function 'cashOutReverse()'", async () => {
+    const tokenAmount: number = 100;
+
+    beforeEach(async () => {
+      await proveTx(tokenMock.connect(user).approve(pixCashier.address, ethers.constants.MaxUint256));
+      await proveTx(tokenMock.mint(user.address, tokenAmount));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(
+        pixCashier.connect(user).cashOutReverse(tokenAmount, TRANSACTION_ID)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller is blacklisted", async () => {
+      await proveTx(pixCashier.grantRole(blacklisterRole, deployer.address));
+      await proveTx(pixCashier.blacklist(user.address));
+      await expect(
+        pixCashier.connect(user).cashOutReverse(tokenAmount, TRANSACTION_ID)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Is reverted if the token amount is zero", async () => {
+      await expect(
+        pixCashier.connect(user).cashOutReverse(0, TRANSACTION_ID)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_AMOUNT_IS_ZERO);
+    });
+
+    it("Is reverted if the off-chain transaction ID is zero", async () => {
+      await proveTx(pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID));
+      await expect(
+        pixCashier.connect(user).cashOutReverse(tokenAmount, ethers.constants.HashZero)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the user's cash-out balance is not enough", async () => {
+      await proveTx(pixCashier.connect(user).cashOut(tokenAmount - 1, TRANSACTION_ID));
+      await expect(
+        pixCashier.connect(user).cashOutReverse(tokenAmount, TRANSACTION_ID)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_BALANCE_IS_INSUFFICIENT);
+    });
+
+    it("Transfers tokens as expected, emits the correct event, changes cash-out balances accordingly", async () => {
+      await proveTx(pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID));
+      const oldCashOutBalance: number = await pixCashier.cashOutBalanceOf(user.address);
+      await expect(
+        pixCashier.connect(user).cashOutReverse(tokenAmount, TRANSACTION_ID)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [user, pixCashier],
+        [+tokenAmount, -tokenAmount]
+      ).and.to.emit(
+        pixCashier,
+        "CashOutReverse"
+      ).withArgs(
+        user.address,
+        tokenAmount,
+        0,
+        TRANSACTION_ID
+      );
+      const newCashOutBalance: number = await pixCashier.cashOutBalanceOf(user.address);
+      expect(newCashOutBalance - oldCashOutBalance).to.equal(-tokenAmount);
+    });
+  });
+
+  describe("Complex scenario", async () => {
+    const cashInTokenAmount: number = 100;
+    const cashOutTokenAmount: number = 80;
+    const cashOutReverseTokenAmount: number = 20;
+    const cashOutConfirmTokenAmount: number = 50;
+    const userFinalTokenBalance: number = cashInTokenAmount - cashOutTokenAmount + cashOutReverseTokenAmount;
+    const userFinalCashOutBalance: number =
+      cashOutTokenAmount - cashOutReverseTokenAmount - cashOutConfirmTokenAmount;
+
+    beforeEach(async () => {
+      await proveTx(tokenMock.connect(user).approve(pixCashier.address, ethers.constants.MaxUint256));
+    });
+
+    it("Leads to correct balances when using several functions", async () => {
+      await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
+      await proveTx(pixCashier.connect(cashier).cashIn(user.address, cashInTokenAmount, TRANSACTION_ID));
+      await proveTx(pixCashier.connect(user).cashOut(cashOutTokenAmount, TRANSACTION_ID));
+      await proveTx(pixCashier.connect(user).cashOutReverse(cashOutReverseTokenAmount, TRANSACTION_ID));
+      await proveTx(pixCashier.connect(user).cashOutConfirm(cashOutConfirmTokenAmount, TRANSACTION_ID));
+      expect(await tokenMock.balanceOf(user.address)).to.equal(userFinalTokenBalance);
+      expect(await pixCashier.cashOutBalanceOf(user.address)).to.equal(userFinalCashOutBalance);
+      expect(await tokenMock.balanceOf(pixCashier.address)).to.equal(userFinalCashOutBalance);
+    });
+  });
+});

--- a/test/TokenDistributor.test.ts
+++ b/test/TokenDistributor.test.ts
@@ -1,0 +1,196 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../test-utils/eth";
+import { countNumberArrayTotal, createRevertMessageDueToMissingRole } from "../test-utils/misc";
+
+describe("Contract 'PixCashierUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+  const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
+
+  const REVERT_ERROR_IF_TOKEN_IS_ZERO = "ZeroToken";
+  const REVERT_ERROR_IF_RECIPIENTS_ARRAY_IS_EMPTY = "EmptyRecipientsArray";
+  const REVERT_ERROR_IF_BALANCES_ARRAY_LENGTH_MISMATCH = "BalancesArrayLengthMismatch";
+  const REVERT_ERROR_IF_RECIPIENT_IS_ZERO = "ZeroRecipient";
+  const REVERT_ERROR_IF_BALANCE_IS_ZERO = "ZeroBalance";
+
+  let tokenDistributor: Contract;
+  let tokenMock: Contract;
+  let deployer: SignerWithAddress;
+  let distributor: SignerWithAddress;
+  let user: SignerWithAddress;
+  let ownerRole: string;
+  let pauserRole: string;
+  let rescuerRole: string;
+  let distributorRole: string;
+
+  beforeEach(async () => {
+    // Deploy the token mock contract
+    const TokenMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    tokenMock = await TokenMock.deploy();
+    await tokenMock.deployed();
+    await proveTx(tokenMock.initialize("BRL Coin", "BRLC"));
+
+    // Deploy the being tested contract
+    const TokenDistributor: ContractFactory = await ethers.getContractFactory("TokenDistributor");
+    tokenDistributor = await TokenDistributor.deploy();
+    await tokenDistributor.deployed();
+    await proveTx(tokenDistributor.initialize());
+
+    // Accounts
+    [deployer, distributor, user] = await ethers.getSigners();
+
+    // Roles
+    ownerRole = (await tokenDistributor.OWNER_ROLE()).toLowerCase();
+    pauserRole = (await tokenDistributor.PAUSER_ROLE()).toLowerCase();
+    rescuerRole = (await tokenDistributor.RESCUER_ROLE()).toLowerCase();
+    distributorRole = (await tokenDistributor.DISTRIBUTOR_ROLE()).toLowerCase();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(
+      tokenDistributor.initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initial contract configuration should be as expected", async () => {
+    // The role admins
+    expect(await tokenDistributor.getRoleAdmin(ownerRole)).to.equal(ownerRole);
+    expect(await tokenDistributor.getRoleAdmin(pauserRole)).to.equal(ownerRole);
+    expect(await tokenDistributor.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
+    expect(await tokenDistributor.getRoleAdmin(distributorRole)).to.equal(ownerRole);
+
+    // The deployer should have the owner role, but not the other roles
+    expect(await tokenDistributor.hasRole(ownerRole, deployer.address)).to.equal(true);
+    expect(await tokenDistributor.hasRole(pauserRole, deployer.address)).to.equal(false);
+    expect(await tokenDistributor.hasRole(rescuerRole, deployer.address)).to.equal(false);
+    expect(await tokenDistributor.hasRole(distributorRole, deployer.address)).to.equal(false);
+
+    // The initial contract state is unpaused
+    expect(await tokenDistributor.paused()).to.equal(false);
+  });
+
+  describe("Function 'distributeToken()'", async () => {
+    let recipientAddresses: string[];
+    const balances: number[] = [10, 20];
+    const balanceTotal: number = countNumberArrayTotal(balances);
+
+    beforeEach(async () => {
+      recipientAddresses = [deployer.address, user.address];
+      await proveTx(tokenDistributor.grantRole(distributorRole, distributor.address));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(tokenDistributor.grantRole(pauserRole, deployer.address));
+      await proveTx(tokenDistributor.pause());
+      await expect(
+        tokenDistributor.connect(distributor).distributeTokens(
+          tokenMock.address,
+          recipientAddresses,
+          balances
+        )
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the distributor role", async () => {
+      await expect(
+        tokenDistributor.connect(deployer).distributeTokens(
+          tokenMock.address,
+          recipientAddresses,
+          balances
+        )
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, distributorRole));
+    });
+
+    it("Is reverted if the token contract address is zero", async () => {
+      await expect(
+        tokenDistributor.connect(distributor).distributeTokens(
+          ethers.constants.AddressZero,
+          recipientAddresses,
+          balances
+        )
+      ).to.be.revertedWithCustomError(tokenDistributor, REVERT_ERROR_IF_TOKEN_IS_ZERO);
+    });
+
+    it("Is reverted if the array of recipients is empty", async () => {
+      await expect(
+        tokenDistributor.connect(distributor).distributeTokens(
+          tokenMock.address,
+          [],
+          balances
+        )
+      ).to.be.revertedWithCustomError(tokenDistributor, REVERT_ERROR_IF_RECIPIENTS_ARRAY_IS_EMPTY);
+    });
+
+    it("Is reverted if the recipients array differs in length from the balances array", async () => {
+      let badBalances = [...balances];
+      badBalances.pop();
+      await expect(
+        tokenDistributor.connect(distributor).distributeTokens(
+          tokenMock.address,
+          recipientAddresses,
+          badBalances
+        )
+      ).to.be.revertedWithCustomError(tokenDistributor, REVERT_ERROR_IF_BALANCES_ARRAY_LENGTH_MISMATCH);
+    });
+
+    it("Is reverted if the address of one of the recipients is zero", async () => {
+      await proveTx(tokenMock.mint(tokenDistributor.address, balanceTotal));
+      recipientAddresses[recipientAddresses.length - 1] = ethers.constants.AddressZero;
+      await expect(
+        tokenDistributor.connect(distributor).distributeTokens(
+          tokenMock.address,
+          recipientAddresses,
+          balances
+        )
+      ).to.be.revertedWithCustomError(tokenDistributor, REVERT_ERROR_IF_RECIPIENT_IS_ZERO);
+    });
+
+    it("Is reverted if one of the values in balances array is zero", async () => {
+      await proveTx(tokenMock.mint(tokenDistributor.address, balanceTotal));
+      let badBalances = [...balances];
+      badBalances[badBalances.length - 1] = 0;
+      await expect(
+        tokenDistributor.connect(distributor).distributeTokens(
+          tokenMock.address,
+          recipientAddresses,
+          badBalances
+        )
+      ).to.be.revertedWithCustomError(tokenDistributor, REVERT_ERROR_IF_BALANCE_IS_ZERO);
+    });
+
+    it("Is reverted if the contract has not enough tokens to execute all transfers", async () => {
+      await proveTx(tokenMock.mint(tokenDistributor.address, balanceTotal - balances[0]));
+      await expect(
+        tokenDistributor.connect(distributor).distributeTokens(
+          tokenMock.address,
+          recipientAddresses,
+          balances
+        )
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfers correct amount of tokens and emits the correct event", async () => {
+      await proveTx(tokenMock.mint(tokenDistributor.address, balanceTotal));
+      await expect(
+        tokenDistributor.connect(distributor).distributeTokens(
+          tokenMock.address,
+          recipientAddresses,
+          balances
+        )
+      ).to.changeTokenBalances(
+        tokenMock,
+        [tokenDistributor, distributor, ...recipientAddresses],
+        [-balanceTotal, 0, ...balances]
+      ).and.to.emit(
+        tokenDistributor,
+        "DistributeTokens"
+      ).withArgs(
+        tokenMock.address,
+        balanceTotal
+      );
+    });
+  });
+});

--- a/test/base/BlacklistControlUpgradeable.test.ts
+++ b/test/base/BlacklistControlUpgradeable.test.ts
@@ -1,0 +1,160 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
+
+describe("Contract 'BlacklistControlUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+
+  const REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED = "BlacklistedAccount";
+
+  let blacklistControlMock: Contract;
+  let deployer: SignerWithAddress;
+  let blacklister: SignerWithAddress;
+  let user: SignerWithAddress;
+  let ownerRole: string;
+  let blacklisterRole: string;
+
+  beforeEach(async () => {
+    // Deploy the contract under test
+    const BlacklistControlMock: ContractFactory = await ethers.getContractFactory("BlacklistControlUpgradeableMock");
+    blacklistControlMock = await BlacklistControlMock.deploy();
+    await blacklistControlMock.deployed();
+    await proveTx(blacklistControlMock.initialize());
+
+    // Accounts
+    [deployer, blacklister, user] = await ethers.getSigners();
+
+    // Roles
+    ownerRole = (await blacklistControlMock.OWNER_ROLE()).toLowerCase();
+    blacklisterRole = (await blacklistControlMock.BLACKLISTER_ROLE()).toLowerCase();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(
+      blacklistControlMock.initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The init function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(
+      blacklistControlMock.call_parent_initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+  });
+
+  it("The init unchained function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(
+      blacklistControlMock.call_parent_initialize_unchained()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+  });
+
+  it("The initial contract configuration should be as expected", async () => {
+    // The role admins
+    expect(await blacklistControlMock.getRoleAdmin(ownerRole)).to.equal(ethers.constants.HashZero);
+    expect(await blacklistControlMock.getRoleAdmin(blacklisterRole)).to.equal(ownerRole);
+
+    // The deployer should have the owner role, but not the other roles
+    expect(await blacklistControlMock.hasRole(ownerRole, deployer.address)).to.equal(true);
+    expect(await blacklistControlMock.hasRole(blacklisterRole, deployer.address)).to.equal(false);
+  });
+
+  describe("Function 'blacklist()'", async () => {
+    beforeEach(async () => {
+      await proveTx(blacklistControlMock.grantRole(blacklisterRole, blacklister.address));
+    });
+
+    it("Is reverted if is called by an account without the blacklister role", async () => {
+      await expect(
+        blacklistControlMock.blacklist(deployer.address)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, blacklisterRole));
+    });
+
+    it("Executes successfully and emits the correct event", async () => {
+      expect(await blacklistControlMock.isBlacklisted(user.address)).to.equal(false);
+      await expect(
+        blacklistControlMock.connect(blacklister).blacklist(user.address)
+      ).to.emit(
+        blacklistControlMock,
+        "Blacklisted"
+      ).withArgs(user.address);
+      expect(await blacklistControlMock.isBlacklisted(user.address)).to.equal(true);
+
+      // Second call with the same argument should not emit an event
+      await expect(
+        blacklistControlMock.connect(blacklister).blacklist(user.address)
+      ).not.to.emit(blacklistControlMock, "Blacklisted");
+    });
+  });
+
+  describe("Function 'unBlacklist()'", async () => {
+    beforeEach(async () => {
+      await proveTx(blacklistControlMock.grantRole(blacklisterRole, blacklister.address));
+      await proveTx(blacklistControlMock.connect(blacklister).blacklist(user.address));
+    });
+
+    it("Is reverted if is called by an account without the blacklister role", async () => {
+      await expect(
+        blacklistControlMock.unBlacklist(user.address)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, blacklisterRole));
+    });
+
+    it("Executes successfully and emits the correct event", async () => {
+      expect(await blacklistControlMock.isBlacklisted(user.address)).to.equal(true);
+      await expect(
+        blacklistControlMock.connect(blacklister).unBlacklist(user.address)
+      ).to.emit(
+        blacklistControlMock,
+        "UnBlacklisted"
+      ).withArgs(user.address);
+      expect(await blacklistControlMock.isBlacklisted(user.address)).to.equal(false);
+
+      // Second call with the same argument should not emit an event
+      await expect(
+        blacklistControlMock.connect(blacklister).unBlacklist(user.address)
+      ).not.to.emit(blacklistControlMock, "UnBlacklisted");
+    });
+  });
+
+  describe("Function 'selfBlacklist()'", async () => {
+    it("Executes successfully and emits the correct events if is called by any account", async () => {
+      expect(await blacklistControlMock.isBlacklisted(blacklister.address)).to.equal(false);
+      await expect(
+        blacklistControlMock.connect(blacklister).selfBlacklist()
+      ).to.emit(
+        blacklistControlMock,
+        "Blacklisted"
+      ).withArgs(
+        blacklister.address
+      ).and.to.emit(
+        blacklistControlMock, "SelfBlacklisted"
+      ).withArgs(
+        blacklister.address
+      );
+      expect(await blacklistControlMock.isBlacklisted(blacklister.address)).to.equal(true);
+
+      // Second call should not emit an event
+      await expect(
+        blacklistControlMock.connect(blacklister).selfBlacklist()
+      ).not.to.emit(blacklistControlMock, "SelfBlacklisted");
+    });
+  });
+
+  describe("Modifier 'notBlacklisted'", async () => {
+    it("Reverts the target function if the caller is blacklisted", async () => {
+      await proveTx(blacklistControlMock.grantRole(blacklisterRole, blacklister.address));
+      await proveTx(blacklistControlMock.connect(blacklister).blacklist(deployer.address));
+      await expect(
+        blacklistControlMock.testNotBlacklistedModifier()
+      ).to.be.revertedWithCustomError(blacklistControlMock, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Does not revert the target function if the caller is not blacklisted", async () => {
+      await expect(
+        blacklistControlMock.connect(user).testNotBlacklistedModifier()
+      ).to.emit(blacklistControlMock, "TestNotBlacklistedModifierSucceeded");
+    });
+  });
+});

--- a/test/base/PauseControlUpgradeable.test.ts
+++ b/test/base/PauseControlUpgradeable.test.ts
@@ -1,4 +1,4 @@
-import { ethers, upgrades } from "hardhat";
+import { ethers } from "hardhat";
 import { expect } from "chai";
 import { Contract, ContractFactory } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
@@ -7,6 +7,7 @@ import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
 
 describe("Contract 'PauseControlUpgradeable'", async () => {
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
 
   let pauseControlMock: Contract;
   let deployer: SignerWithAddress;
@@ -15,10 +16,13 @@ describe("Contract 'PauseControlUpgradeable'", async () => {
   let pauserRole: string;
 
   beforeEach(async () => {
+    // Deploy the contract under test
     const PauseControlMock: ContractFactory = await ethers.getContractFactory("PauseControlUpgradeableMock");
-    pauseControlMock = await upgrades.deployProxy(PauseControlMock);
+    pauseControlMock = await PauseControlMock.deploy();
     await pauseControlMock.deployed();
+    await proveTx(pauseControlMock.initialize());
 
+    // Accounts
     [deployer, user] = await ethers.getSigners();
 
     // Roles
@@ -27,13 +31,21 @@ describe("Contract 'PauseControlUpgradeable'", async () => {
   });
 
   it("The initialize function can't be called more than once", async () => {
-    await expect(pauseControlMock.initialize())
-      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    await expect(
+      pauseControlMock.initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
   });
 
-  it("The initialize unchained function can't be called more than once", async () => {
-    await expect(pauseControlMock.initialize_unchained())
-      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  it("The init function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(
+      pauseControlMock.call_parent_initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+  });
+
+  it("The init unchained function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(
+      pauseControlMock.call_parent_initialize_unchained()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
   });
 
   it("The initial contract configuration should be as expected", async () => {
@@ -44,6 +56,9 @@ describe("Contract 'PauseControlUpgradeable'", async () => {
     // The deployer should have the owner role, but not the other roles
     expect(await pauseControlMock.hasRole(ownerRole, deployer.address)).to.equal(true);
     expect(await pauseControlMock.hasRole(pauserRole, deployer.address)).to.equal(false);
+
+    // The initial contract state is unpaused
+    expect(await pauseControlMock.paused()).to.equal(false);
   });
 
   describe("Function 'pause()'", async () => {
@@ -52,19 +67,19 @@ describe("Contract 'PauseControlUpgradeable'", async () => {
     });
 
     it("Is reverted if is called by an account without the pauser role", async () => {
-      await expect(pauseControlMock.pause())
-        .to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, pauserRole));
+      await expect(
+        pauseControlMock.pause()
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, pauserRole));
     });
 
-    it("Executes successfully if is called by an account with the pauser role", async () => {
-      await proveTx(pauseControlMock.connect(user).pause());
+    it("Executes successfully and emits the correct event", async () => {
+      await expect(
+        pauseControlMock.connect(user).pause()
+      ).to.emit(
+        pauseControlMock,
+        "Paused"
+      ).withArgs(user.address);
       expect(await pauseControlMock.paused()).to.equal(true);
-    });
-
-    it("Emits the correct event", async () => {
-      await expect(pauseControlMock.connect(user).pause())
-        .to.emit(pauseControlMock, "Paused")
-        .withArgs(user.address);
     });
   });
 
@@ -75,19 +90,19 @@ describe("Contract 'PauseControlUpgradeable'", async () => {
     });
 
     it("Is reverted if is called by an account without the pauser role", async () => {
-      await expect(pauseControlMock.unpause())
-        .to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, pauserRole));
+      await expect(
+        pauseControlMock.unpause()
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, pauserRole));
     });
 
-    it("Executes successfully if is called by an account with the pauser role", async () => {
-      await proveTx(pauseControlMock.connect(user).unpause());
+    it("Executes successfully and emits the correct event", async () => {
+      await expect(
+        pauseControlMock.connect(user).unpause()
+      ).to.emit(
+        pauseControlMock,
+        "Unpaused"
+      ).withArgs(user.address);
       expect(await pauseControlMock.paused()).to.equal(false);
-    });
-
-    it("Emits the correct event", async () => {
-      await expect(pauseControlMock.connect(user).unpause())
-        .to.emit(pauseControlMock, "Unpaused")
-        .withArgs(user.address);
     });
   });
 });

--- a/test/base/RescueControlUpgradeable.test.ts
+++ b/test/base/RescueControlUpgradeable.test.ts
@@ -1,0 +1,107 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
+
+describe("Contract 'RescueControlUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+
+  let rescueControlMock: Contract;
+  let tokenMock: Contract;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+  let ownerRole: string;
+  let rescuerRole: string;
+
+  beforeEach(async () => {
+    // Deploy the token mock contract
+    const TokenMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    tokenMock = await TokenMock.deploy();
+    await tokenMock.deployed();
+    await proveTx(tokenMock.initialize("BRL Coin", "BRLC"));
+
+    // Deploy the contract under test
+    const RescueControlMock: ContractFactory = await ethers.getContractFactory("RescueControlUpgradeableMock");
+    rescueControlMock = await RescueControlMock.deploy();
+    await rescueControlMock.deployed();
+    await proveTx(rescueControlMock.initialize());
+
+    // Accounts
+    [deployer, user] = await ethers.getSigners();
+
+    // Roles
+    ownerRole = (await rescueControlMock.OWNER_ROLE()).toLowerCase();
+    rescuerRole = (await rescueControlMock.RESCUER_ROLE()).toLowerCase();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(
+      rescueControlMock.initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The init function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(
+      rescueControlMock.call_parent_initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+  });
+
+  it("The init unchained function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(
+      rescueControlMock.call_parent_initialize_unchained()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+  });
+
+  it("The initial contract configuration should be as expected", async () => {
+    // The role admins
+    expect(await rescueControlMock.getRoleAdmin(ownerRole)).to.equal(ethers.constants.HashZero);
+    expect(await rescueControlMock.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
+
+    // The deployer should have the owner role, but not the other roles
+    expect(await rescueControlMock.hasRole(ownerRole, deployer.address)).to.equal(true);
+    expect(await rescueControlMock.hasRole(rescuerRole, deployer.address)).to.equal(false);
+  });
+
+  describe("Function 'rescueERC20()'", async () => {
+    const tokenAmount = 123;
+
+    beforeEach(async () => {
+      await proveTx(tokenMock.mint(rescueControlMock.address, tokenAmount));
+      await proveTx(rescueControlMock.grantRole(rescuerRole, user.address));
+    });
+
+    it("Is reverted if is called by an account without the rescuer role", async () => {
+      await expect(
+        rescueControlMock.rescueERC20(
+          tokenMock.address,
+          deployer.address,
+          tokenAmount
+        )
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, rescuerRole));
+    });
+
+    it("Executes successfully, transfers tokens as expected, emits the correct event", async () => {
+      await expect(
+        rescueControlMock.connect(user).rescueERC20(
+          tokenMock.address,
+          deployer.address,
+          tokenAmount
+        )
+      ).to.changeTokenBalances(
+        tokenMock,
+        [rescueControlMock, deployer, user],
+        [-tokenAmount, +tokenAmount, 0]
+      ).and.to.emit(
+        tokenMock,
+        "Transfer"
+      ).withArgs(
+        rescueControlMock.address,
+        deployer.address,
+        tokenAmount
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Main changes
1.  The Multisend contract has been rewritten to Solidity 0.8.x based on the code from 
[brlc-token](https://github.com/cloudwalk/brlc-token) repo. Version 0.8.15 was used for compilation and testing.
2. The contract has been renamed to `TokenDistributor`.
3.  Instead of using the whitelist and pauser the appropriate roles have been introduced based on the [OpenZeppelin access control contracts](https://docs.openzeppelin.com/contracts/4.x/access-control).
4. Inheritance from the `StoragePlaceholder200` contract has been used to reserve 200 storage slots for the future possible improvements of the contract.
5. The following roles are currently used in the contract:
    * `OWNER_ROLE` -- an account with this role owns the contract and can grant and remove other roles to/from accounts. 
    * `PAUSER_ROLE` -- an account with this role is allowed to pause and unpause the contract.
    * `RESCUER_ROLE` -- an account with this role is allowed to withdraw tokens from the contract's account.
    * `DISTRIBUTOR_ROLE` -- an account with this role is allowed to execute functions of the contract.
6. The deployer is automatically granted with the `OWNER_ROLE`. The other roles are not assigned by default and should be granted by calling the appropriate function of the `AccessControlUpgradeable` contract.
7. The tests have been renovated too.

### Merge sequence
The current pull-request should be merged after the [PR#15](https://github.com/cloudwalk/brlc-periphery/pull/15).

### Testing and coverage
The updated and newly developed tests have been successfully run on the following blockchains:
1. Internal Hardhat net.
2. Substrate with Frontier layer built from the [cloudwalk-network](https://github.com/cloudwalk/cloudwalk-network) repo, commit [350445547016ce83c5ce781ac8871194439b0e4f](https://github.com/cloudwalk/cloudwalk-network/commit/350445547016ce83c5ce781ac8871194439b0e4f) with tag `mainnet-v1.0.2`.

_NOTE 1_: When running a local node of Substrate with Frontier layer for testing use the node in the archive mode like in the following command:
```bash
./target/release/cloudwalk-network-node --dev --tmp --pruning archive
```
Coverage:
![image](https://user-images.githubusercontent.com/97302011/189305926-d94ae9c7-49eb-442a-80ca-8e1633290e56.png)