### PR TITLE
Refund and cashback

### DIFF
--- a/contracts/CardPaymentProcessorStorage.sol
+++ b/contracts/CardPaymentProcessorStorage.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.8.16;
 
 import { ICardPaymentProcessorTypes } from "./interfaces/ICardPaymentProcessor.sol";
+import { ICardPaymentCashbackTypes } from "./interfaces/ICardPaymentCashback.sol";
 
 /**
  * @title CardPaymentProcessor storage version 1
@@ -37,6 +38,31 @@ abstract contract CardPaymentProcessorStorageV1 is ICardPaymentProcessorTypes {
 }
 
 /**
+ * @title CardPaymentProcessor storage version 2
+ */
+abstract contract CardPaymentProcessorStorageV2 {
+    /// @dev The account to transfer cleared tokens to.
+    address internal _cashOutAccount;
+}
+
+/**
+ * @title CardPaymentProcessor storage version 3
+ */
+abstract contract CardPaymentProcessorStorageV3 is ICardPaymentCashbackTypes {
+    /// @dev The enable flag of the cashback operations.
+    bool internal _cashbackEnabled;
+
+    /// @dev The address of the cashback distributor contract.
+    address internal _cashbackDistributor;
+
+    /// @dev The current cashback rate in permil (parts per thousand).
+    uint16 internal _cashbackRateInPermil;
+
+    /// @dev Mapping of a structure with cashback data for a given authorization ID.
+    mapping(bytes16 => Cashback) internal _cashbacks;
+}
+
+/**
  * @title CardPaymentProcessor storage
  * @dev Contains storage variables of the {CardPaymentProcessor} contract.
  *
@@ -46,6 +72,9 @@ abstract contract CardPaymentProcessorStorageV1 is ICardPaymentProcessorTypes {
  * e.g. CardPaymentProcessorStorage<versionNumber>, so finally it would look like
  * "contract CardPaymentProcessorStorage is CardPaymentProcessorStorageV1, CardPaymentProcessorStorageV2".
  */
-abstract contract CardPaymentProcessorStorage is CardPaymentProcessorStorageV1 {
+abstract contract CardPaymentProcessorStorage is
+    CardPaymentProcessorStorageV1,
+    CardPaymentProcessorStorageV2,
+    CardPaymentProcessorStorageV3 {
 
 }

--- a/contracts/CashbackDistributor.sol
+++ b/contracts/CashbackDistributor.sol
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { EnumerableSetUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/structs/EnumerableSetUpgradeable.sol";
+import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+import { BlacklistControlUpgradeable } from "./base/BlacklistControlUpgradeable.sol";
+import { PauseControlUpgradeable } from "./base/PauseControlUpgradeable.sol";
+import { RescueControlUpgradeable } from "./base/RescueControlUpgradeable.sol";
+import { CashbackDistributorStorage } from "./CashbackDistributorStorage.sol";
+import { StoragePlaceholder200 } from "./base/StoragePlaceholder.sol";
+import { ICashbackDistributor } from "./interfaces/ICashbackDistributor.sol";
+
+/**
+ * @title CashbackDistributor contract
+ * @dev Wrapper contract for the cashback operations.
+ */
+contract CashbackDistributor is
+    AccessControlUpgradeable,
+    BlacklistControlUpgradeable,
+    PauseControlUpgradeable,
+    RescueControlUpgradeable,
+    StoragePlaceholder200,
+    CashbackDistributorStorage,
+    ICashbackDistributor
+{
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using EnumerableSetUpgradeable for EnumerableSetUpgradeable.Bytes32Set;
+
+    /// @dev The role of this contract owner.
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /// @dev The role of distributor that is allowed to execute the cashback operations.
+    bytes32 public constant DISTRIBUTOR_ROLE = keccak256("DISTRIBUTOR_ROLE");
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev The cashback operations are already enabled.
+    error CashbackAlreadyEnabled();
+
+    /// @dev The cashback operations are already disabled.
+    error CashbackAlreadyDisabled();
+
+    /// @dev The zero token address has been passed as a function argument.
+    error ZeroTokenAddress();
+
+    /// @dev Zero external identifier has been passed as a function argument.
+    error ZeroExternalId();
+
+    /// @dev The zero account address has been passed as a function argument.
+    error ZeroRecipientAddress();
+
+    // ------------------- Functions ---------------------------------
+
+    /**
+     * @dev The initialize function of the upgradable contract.
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
+     */
+    function initialize() external initializer {
+        __CashbackDistributor_init();
+    }
+
+    function __CashbackDistributor_init() internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __AccessControl_init_unchained();
+        __BlacklistControl_init_unchained(OWNER_ROLE);
+        __Pausable_init_unchained();
+        __PauseControl_init_unchained(OWNER_ROLE);
+        __RescueControl_init_unchained(OWNER_ROLE);
+
+        __CashbackDistributor_init_unchained();
+    }
+
+    function __CashbackDistributor_init_unchained() internal onlyInitializing {
+        _nextNonce = 1;
+
+        _setRoleAdmin(OWNER_ROLE, OWNER_ROLE);
+        _setRoleAdmin(DISTRIBUTOR_ROLE, OWNER_ROLE);
+
+        _setupRole(OWNER_ROLE, _msgSender());
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-sendCashback}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {DISTRIBUTOR_ROLE} role.
+     * - The external cashback identifier must not be zero.
+     * - The cashback recipient address must not be zero.
+     * - The token contract address must not be zero.
+     */
+    function sendCashback(
+        address token,
+        CashbackKind kind,
+        bytes32 externalId,
+        address recipient,
+        uint256 amount
+    ) external whenNotPaused onlyRole(DISTRIBUTOR_ROLE) returns (bool success, uint256 nonce) {
+        if (token == address(0)) {
+            revert ZeroTokenAddress();
+        }
+        if (recipient == address(0)) {
+            revert ZeroRecipientAddress();
+        }
+        if (externalId == 0) {
+            revert ZeroExternalId();
+        }
+
+        CashbackStatus status = CashbackStatus.Success;
+
+        if (!_enabled) {
+            status = CashbackStatus.Disabled;
+        } else if (isBlacklisted(recipient)) {
+            status = CashbackStatus.Blacklisted;
+        } else if (IERC20Upgradeable(token).balanceOf(address(this)) < amount) {
+            status = CashbackStatus.OutOfFunds;
+        }
+
+        address sender = _msgSender();
+        nonce = _nextNonce++;
+
+        Cashback storage cashback = _cashbacks[nonce];
+        cashback.token = token;
+        cashback.kind = kind;
+        cashback.status = status;
+        cashback.externalId = externalId;
+        cashback.recipient = recipient;
+        cashback.amount = amount;
+        cashback.sender = sender;
+
+        _nonceCollectionByExternalId[externalId].push(nonce);
+
+        emit SendCashback(
+            token,
+            kind,
+            status,
+            externalId,
+            recipient,
+            amount,
+            sender,
+            nonce
+        );
+
+        if (status == CashbackStatus.Success) {
+            _totalCashbackByTokenAndRecipient[token][recipient] += amount;
+            _totalCashbackByTokenAndExternalId[token][externalId] += amount;
+            IERC20Upgradeable(token).safeTransfer(recipient, amount);
+            success = true;
+        }
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-revokeCashback}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {DISTRIBUTOR_ROLE} role.
+     */
+    function revokeCashback(
+        uint256 nonce,
+        uint256 amount
+    ) external whenNotPaused onlyRole(DISTRIBUTOR_ROLE) returns (bool success) {
+        Cashback storage cashback = _cashbacks[nonce];
+
+        address sender = _msgSender();
+        RevocationStatus revocationStatus = RevocationStatus.Success;
+
+        if (cashback.status != CashbackStatus.Success) {
+            revocationStatus = RevocationStatus.Inapplicable;
+        } else if (amount > IERC20Upgradeable(cashback.token).balanceOf(sender)) {
+            revocationStatus = RevocationStatus.OutOfFunds;
+        } else if (amount > IERC20Upgradeable(cashback.token).allowance(sender, address(this))) {
+            revocationStatus = RevocationStatus.OutOfAllowance;
+        } else if (amount > cashback.amount - cashback.revokedAmount) {
+            revocationStatus = RevocationStatus.OutOfBalance;
+        }
+
+        emit RevokeCashback(
+            cashback.token,
+            cashback.kind,
+            cashback.status,
+            revocationStatus,
+            cashback.externalId,
+            cashback.recipient,
+            amount,
+            sender,
+            nonce
+        );
+
+        if (revocationStatus == RevocationStatus.Success) {
+            cashback.revokedAmount += amount;
+            _totalCashbackByTokenAndRecipient[cashback.token][cashback.recipient] -= amount;
+            _totalCashbackByTokenAndExternalId[cashback.token][cashback.externalId] -= amount;
+            IERC20Upgradeable(cashback.token).safeTransferFrom(sender, address(this), amount);
+            success = true;
+        }
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-enable}.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {OWNER_ROLE} role.
+     */
+    function enable() external onlyRole(OWNER_ROLE) {
+        if (_enabled) {
+            revert CashbackAlreadyEnabled();
+        }
+
+        _enabled = true;
+
+        emit Enable(_msgSender());
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-disable}.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {OWNER_ROLE} role.
+     */
+    function disable() external onlyRole(OWNER_ROLE) {
+        if (!_enabled) {
+            revert CashbackAlreadyDisabled();
+        }
+
+        _enabled = false;
+
+        emit Disable(_msgSender());
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-enabled}.
+     */
+    function enabled() external view returns (bool) {
+        return _enabled;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-nextNonce}.
+     */
+    function nextNonce() external view returns (uint256) {
+        return _nextNonce;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getCashback}.
+     */
+    function getCashback(uint256 nonce) external view returns (Cashback memory cashback) {
+        cashback = _cashbacks[nonce];
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getCashbacks}.
+     */
+    function getCashbacks(uint256[] calldata nonces) external view returns (Cashback[] memory cashbacks) {
+        uint256 len = nonces.length;
+        cashbacks = new Cashback[](len);
+        for (uint256 i = 0; i < len; i++) {
+            cashbacks[i] = _cashbacks[nonces[i]];
+        }
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getCashbackNonces}.
+     */
+    function getCashbackNonces(
+        bytes32 externalId,
+        uint256 index,
+        uint256 limit
+    ) external view returns (uint256[] memory nonces) {
+        uint256[] storage nonceArray = _nonceCollectionByExternalId[externalId];
+        uint256 len = nonceArray.length;
+        if (len <= index || limit == 0) {
+            nonces = new uint256[](0);
+        } else {
+            len -= index;
+            if (len > limit) {
+                len = limit;
+            }
+            nonces = new uint256[](len);
+            for (uint256 i = 0; i < len; i++) {
+                nonces[i] = nonceArray[index];
+                index++;
+            }
+        }
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getTotalCashbackByTokenAndExternalId}.
+     */
+    function getTotalCashbackByTokenAndExternalId(address token, bytes32 externalId) external view returns (uint256) {
+        return _totalCashbackByTokenAndExternalId[token][externalId];
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getTotalCashbackByTokenAndRecipient}.
+     */
+    function getTotalCashbackByTokenAndRecipient(address token, address recipient) external view returns (uint256){
+        return _totalCashbackByTokenAndRecipient[token][recipient];
+    }
+
+    /**
+     * @dev Service function.
+     */
+    function updateRevokeAmount(uint256 fromNonce, uint256 count) external onlyRole(OWNER_ROLE) {
+        uint256 len = fromNonce + count;
+        for (uint256 i = fromNonce; i < len; ++i) {
+            Cashback storage cashback = _cashbacks[i];
+            if (cashback.status == CashbackStatus.Revoked) {
+                cashback.status = CashbackStatus.Success;
+                cashback.revokedAmount = cashback.amount;
+            }
+        }
+    }
+}

--- a/contracts/CashbackDistributorStorage.sol
+++ b/contracts/CashbackDistributorStorage.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { EnumerableSetUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/structs/EnumerableSetUpgradeable.sol";
+import { ICashbackDistributorTypes } from "./interfaces/ICashbackDistributor.sol";
+
+/**
+ * @title CashbackDistributor storage version 1
+ */
+abstract contract CashbackDistributorStorageV1 is ICashbackDistributorTypes {
+    /// @dev The enable flag of the cashback operations.
+    bool internal _enabled;
+
+    /// @dev The nonce of the next cashback operation.
+    uint256 internal _nextNonce;
+
+    /// @dev The mapping of a cashback structure for a given cashback nonce.
+    mapping(uint256 => Cashback) internal _cashbacks;
+
+    /// @dev Mapping of a nonce collection of all the cashback operations for a given external cashback identifier.
+    mapping(bytes32 => uint256[]) internal _nonceCollectionByExternalId;
+
+    // Obsolete
+    mapping(bytes32 => uint256) private _totalAmountByExternalId;
+
+    // Obsolete
+    mapping(address => uint256) private _totalAmountByRecipient;
+
+    /// @dev Mapping of a total amount of success cashback operations for a given token and an external identifier.
+    mapping(address => mapping(bytes32 => uint256)) internal _totalCashbackByTokenAndExternalId;
+
+    /// @dev Mapping of a total amount of success cashback operations for a given token and an recipient address.
+    mapping(address => mapping(address => uint256)) internal _totalCashbackByTokenAndRecipient;
+}
+
+/**
+ * @title CashbackDistributor storage
+ * @dev Contains storage variables of the {CashbackDistributor} contract.
+ *
+ * We are following Compound's approach of upgrading new contract implementations.
+ * See https://github.com/compound-finance/compound-protocol.
+ * When we need to add new storage variables, we create a new version of CashbackDistributorStorage
+ * e.g. CashbackDistributorStorage<versionNumber>, so finally it would look like
+ * "contract CashbackDistributorStorage is CashbackDistributorStorageV1, CashbackDistributorStorageV2".
+ */
+abstract contract CashbackDistributorStorage is CashbackDistributorStorageV1 {
+
+}

--- a/contracts/interfaces/ICardPaymentCashback.sol
+++ b/contracts/interfaces/ICardPaymentCashback.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+/**
+ * @title CardPaymentCashback types interface
+ */
+interface ICardPaymentCashbackTypes {
+    /// @dev Structure with data of a single cashback operation.
+    struct Cashback {
+        uint256 lastCashbackNonce; // The nonce of the last cashback operation.
+    }
+}
+
+/**
+ * @title CardPaymentCashback interface
+ * @dev The interface of the wrapper contract for the card payment cashback operations.
+ */
+interface ICardPaymentCashback is ICardPaymentCashbackTypes {
+    /**
+     * @dev Emitted when the cashback distributor is changed.
+     * @param oldDistributor The address of the old cashback distributor contract.
+     * @param newDistributor The address of the new cashback distributor contract.
+     */
+    event SetCashbackDistributor(address oldDistributor, address newDistributor);
+
+    /**
+     * @dev Emitted when the cashback rate is changed.
+     * @param oldRateInPermil The value of the old cashback rate in permil.
+     * @param newRateInPermil The value of the new cashback rate in permil.
+     */
+    event SetCashbackRate(uint16 oldRateInPermil, uint16 newRateInPermil);
+
+    /**
+     * @dev Emitted when a cashback send request succeeded.
+     * @param cashbackDistributor The address of the cashback distributor.
+     * @param amount The amount of the cashback.
+     * @param nonce The nonce of the cashback.
+     */
+    event SendCashbackSuccess(address indexed cashbackDistributor, uint256 amount, uint256 nonce);
+
+    /**
+     * @dev Emitted when a cashback send request failed.
+     * @param cashbackDistributor The address of the cashback distributor.
+     * @param nonce The nonce of the cashback.
+     */
+    event SendCashbackFailure(address indexed cashbackDistributor, uint256 amount, uint256 nonce);
+
+    /**
+     * @dev Emitted when a cashback revoke request succeeded.
+     * @param cashbackDistributor The address of the cashback distributor.
+     * @param amount The amount of the revoked cashback.
+     * @param nonce The nonce of the cashback.
+     */
+    event RevokeCashbackSuccess(address indexed cashbackDistributor, uint256 amount, uint256 nonce);
+
+    /**
+     * @dev Emitted when a cashback revoke request failed.
+     * @param cashbackDistributor The address of the cashback distributor.
+     * @param amount The amount of the revoked cashback.
+     * @param nonce The nonce of the cashback.
+     */
+    event RevokeCashbackFailure(address indexed cashbackDistributor, uint256 amount, uint256 nonce);
+
+    /// @dev Emitted when cashback operations are enabled.
+    event EnableCashback();
+
+    /// @dev Emitted when cashback operations are disabled.
+    event DisableCashback();
+
+    /**
+     * @dev Returns the address of the cashback distributor contract.
+     */
+    function cashbackDistributor() external view returns (address);
+
+    /**
+     * @dev Checks if the cashback operations are enabled.
+     */
+    function cashbackEnabled() external view returns (bool);
+
+    /**
+     * @dev Returns the current cashback rate in permil.
+     */
+    function cashbackRate() external view returns (uint256);
+
+    /**
+     * @dev Returns the cashback details for the transaction authorization ID.
+     * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
+     */
+    function getCashback(bytes16 authorizationId) external view returns (Cashback memory);
+
+    /**
+     * @dev Sets a new address of the cashback distributor contract.
+     *
+     * Emits a {SetCashbackDistributor} event.
+     *
+     * @param newCashbackDistributor The address of the new cashback distributor contract.
+     */
+    function setCashbackDistributor(address newCashbackDistributor) external;
+
+    /**
+     * @dev Sets a new cashback rate.
+     *
+     * Emits a {SetCashbackRate} event.
+     *
+     * @param newCashbackRateInPermil The value of the new cashback rate in permil.
+     */
+    function setCashbackRate(uint16 newCashbackRateInPermil) external;
+
+    /**
+     * @dev Enables the cashback operations.
+     *
+     * Emits a {EnableCashback} event.
+     */
+    function enableCashback() external;
+
+    /**
+     * @dev Disables the cashback operations.
+     *
+     * Emits a {DisableCashback} event.
+     */
+    function disableCashback() external;
+}

--- a/contracts/interfaces/ICashbackDistributor.sol
+++ b/contracts/interfaces/ICashbackDistributor.sol
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+/**
+ * @title CashbackDistributor types interface
+ */
+interface ICashbackDistributorTypes {
+    /**
+     * @dev Kinds of a cashback operation as an enum.
+     *
+     * The possible values:
+     * - Manual ------ The cashback is sent manually (the default value).
+     * - CardPayment - The cashback is sent through the CardPaymentProcessor contract.
+     */
+    enum CashbackKind {
+        Manual,     // 0
+        CardPayment // 1
+    }
+
+    /**
+     * @dev Statuses of a cashback operation as an enum.
+     *
+     * The possible values:
+     * - Nonexistent - The cashback operation does not exist (the default value).
+     * - Success ----- The cashback operation has been successfully sent.
+     * - Blacklisted - The cashback operation has been refused because the target account is blacklisted.
+     * - OutOfFunds -- The cashback operation has been refused because the contract has not enough tokens.
+     * - Disabled ---- The cashback operation has been refused because the cashback operations are disabled.
+     * - Revoked ----- Obsolete and not in use anymore.
+     */
+    enum CashbackStatus {
+        Nonexistent, // 0
+        Success,     // 1
+        Blacklisted, // 2
+        OutOfFunds,  // 3
+        Disabled,    // 4
+        Revoked      // 5
+    }
+
+    /**
+     * @dev Statuses of a cashback revocation operation as an enum.
+     *
+     * The possible values:
+     * - Unknown -------- The operation has not been initiated (the default value).
+     * - Success -------- The operation has been successfully executed.
+     * - Inapplicable --- The operation has been failed because the cashback has not relevant status.
+     * - OutOfFunds ----- The operation has been failed because the caller has not enough tokens.
+     * - OutOfAllowance - The operation has been failed because the caller has not enough allowance for the contract.
+     * - OutOfBalance --- The operation has been failed because the revocation amount is greater than the cashback amount.
+     */
+    enum RevocationStatus {
+        Unknown,        // 0
+        Success,        // 1
+        Inapplicable,   // 2
+        OutOfFunds,     // 3
+        OutOfAllowance, // 4
+        OutOfBalance    // 5
+    }
+
+    /// @dev Structure with data of a single cashback operation.
+    struct Cashback {
+        address token;
+        CashbackKind kind;
+        CashbackStatus status;
+        bytes32 externalId;
+        address recipient;
+        uint256 amount;
+        address sender;
+        uint256 revokedAmount;
+    }
+}
+
+/**
+ * @title CashbackDistributor interface
+ * @dev The interface of the wrapper contract for the cashback operations.
+ */
+interface ICashbackDistributor is ICashbackDistributorTypes {
+    /**
+     * @dev Emitted when a cashback operation is executed.
+     * @param token The token contract of the cashback operation.
+     * @param kind The kind of the cashback operation.
+     * @param status The result of the cashback operation.
+     * @param externalId The external identifier of the cashback operation.
+     * @param recipient The account to which the cashback is intended.
+     * @param amount The amount of the cashback.
+     * @param sender The account that initiated the cashback operation.
+     * @param nonce The nonce of the cashback operation internally assigned by the contract.
+     */
+    event SendCashback(
+        address token,
+        CashbackKind kind,
+        CashbackStatus indexed status,
+        bytes32 indexed externalId,
+        address indexed recipient,
+        uint256 amount,
+        address sender,
+        uint256 nonce
+    );
+
+    /**
+     * @dev Emitted when a cashback operation is revoked.
+     * @param token The token contract of the cashback operation.
+     * @param cashbackKind The kind of the cashback operation.
+     * @param cashbackStatus The status of the cashback operation before the revocation.
+     * @param status The status of the revocation.
+     * @param externalId The external identifier of the cashback operation.
+     * @param recipient The account that received the cashback.
+     * @param amount The amount of the revoked cashback.
+     * @param sender The account that initiated the cashback revocation operation.
+     * @param nonce The nonce of the cashback operation.
+     */
+    event RevokeCashback(
+        address token,
+        CashbackKind cashbackKind,
+        CashbackStatus cashbackStatus,
+        RevocationStatus indexed status,
+        bytes32 indexed externalId,
+        address indexed recipient,
+        uint256 amount,
+        address sender,
+        uint256 nonce
+    );
+
+    /**
+     * @dev Emitted when cashback operations are enabled.
+     * @param sender The account that enabled the operations.
+     */
+    event Enable(address sender);
+
+    /**
+     * @dev Emitted when cashback operations are disabled.
+     * @param sender The account that disabled the operations.
+     */
+    event Disable(address sender);
+
+    /**
+     * @dev Sends a cashback to a recipient.
+     *
+     * Transfers the underlying tokens from the contract to the recipient if there are appropriate conditions.
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to execute cashback operations.
+     *
+     * Emits a {SendCashback} event.
+     *
+     * @param token The address of the cashback token.
+     * @param kind The kind of the cashback operation.
+     * @param externalId The external identifier of the cashback operation.
+     * @param recipient The account to which the cashback is intended.
+     * @param amount The amount of tokens to send.
+     * @return success True if the cashback has been successfully sent.
+     * @return nonce The nonce of the newly created cashback operation.
+     */
+    function sendCashback(
+        address token,
+        CashbackKind kind,
+        bytes32 externalId,
+        address recipient,
+        uint256 amount
+    ) external returns (bool success, uint256 nonce);
+
+    /**
+     * @dev Revokes a previously sent cashback.
+     *
+     * Transfers the underlying tokens from the caller to the contract.
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to execute cashback operations.
+     *
+     * Emits a {RevokeCashback} event if the cashback is successfully revoked.
+     *
+     * @param nonce The nonce of the cashback operation to revoke.
+     * @param amount The amount of tokens to revoke during the operation.
+     * @return success True if the cashback revocation was successful.
+     */
+    function revokeCashback(uint256 nonce, uint256 amount) external returns (bool success);
+
+    /**
+     * @dev Enables the cashback operations.
+     *
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to control cashback operations.
+     *
+     * Emits a {EnableCashback} event.
+     */
+    function enable() external;
+
+    /**
+     * @dev Disables the cashback operations.
+     *
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to control cashback operations.
+     *
+     * Emits a {DisableCashback} event.
+     */
+    function disable() external;
+
+    /**
+     * @dev Checks if the cashback operations are enabled.
+     */
+    function enabled() external view returns (bool);
+
+    /**
+     * @dev Returns the nonce of the next cashback operation.
+     */
+    function nextNonce() external view returns (uint256);
+
+    /**
+     * @dev Returns the data of a cashback operation by its nonce.
+     * @param nonce The nonce of the cashback operation to return.
+     */
+    function getCashback(uint256 nonce) external view returns (Cashback memory cashback);
+
+    /**
+     * @dev Returns the data of cashback operations by their nonces.
+     * @param nonces The array of nonces of cashback operations to return.
+     */
+    function getCashbacks(uint256[] calldata nonces) external view returns (Cashback[] memory cashbacks);
+
+    /**
+     * @dev Returns an array of cashback nonces associated with an external identifier.
+     * @param externalId The external cashback identifier to return nonces.
+     * @param index The index of the first nonce in the range to return.
+     * @param limit The max number of nonces in the range to return.
+     */
+    function getCashbackNonces(
+        bytes32 externalId,
+        uint256 index,
+        uint256 limit
+    ) external view returns (uint256[] memory);
+
+    /**
+     * @dev Returns the total amount of all the success cashback operations associated with a token and an external ID.
+     * @param token The token contract address of the cashback operations to define the returned total amount.
+     * @param externalId The external identifier of the cashback operations to define the returned total amount.
+     */
+    function getTotalCashbackByTokenAndExternalId(address token, bytes32 externalId) external view returns (uint256);
+
+    /**
+     * @dev Returns the total amount of all the success cashback operations associated with a token and a recipient.
+     * @param token The token contract address of the cashback operations to define the returned total amount.
+     * @param recipient The recipient address of the cashback operations to define the returned total amount.
+     */
+    function getTotalCashbackByTokenAndRecipient(address token, address recipient) external view returns (uint256);
+}

--- a/contracts/mocks/CashbackDistributorMock.sol
+++ b/contracts/mocks/CashbackDistributorMock.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { ICashbackDistributor } from "../interfaces/ICashbackDistributor.sol";
+
+/**
+ * @title CashbackDistributor contract
+ * @dev An implementation of the {ICashbackDistributor} interface for test purposes.
+ */
+contract CashbackDistributorMock is ICashbackDistributor {
+    /// @dev The success part of the `sendCashback()` function result to return next time.
+    bool public sendCashbackSuccessResult;
+
+    /// @dev The nonce part of the `sendCashback()` function result to return next time.
+    uint256 public sendCashbackNonceResult;
+
+    /// @dev The success part of the `revokeCashback()` function result to return next time.
+    bool public revokeCashbackSuccessResult;
+
+    /**
+     * @dev Emitted when the 'sendCashback()' function is called
+     */
+    event SendCashbackMock(
+        address sender,
+        address token,
+        CashbackKind kind,
+        bytes32 indexed externalId,
+        address indexed recipient,
+        uint256 amount
+    );
+
+    /**
+     * @dev Emitted when the 'revokeCashback()' function is called
+     */
+    event RevokeCashbackMock(address sender, uint256 nonce, uint256 amount);
+
+    /**
+     * @dev Constructor that simply set values of all storage variables.
+     */
+    constructor(
+        bool sendCashbackSuccessResult_,
+        uint256 sendCashbackNonceResult_,
+        bool revokeCashbackSuccessResult_
+    ) {
+        sendCashbackSuccessResult = sendCashbackSuccessResult_;
+        sendCashbackNonceResult = sendCashbackNonceResult_;
+        revokeCashbackSuccessResult = revokeCashbackSuccessResult_;
+
+        // Calling stub functions just to provide 100% coverage
+        enabled();
+        nextNonce();
+        getCashback(0);
+        getCashbacks(new uint256[](0));
+        getCashbackNonces(bytes32(0), 0, 0);
+        getTotalCashbackByTokenAndExternalId(address(0), bytes32(0));
+        getTotalCashbackByTokenAndRecipient(address(0), address(0));
+        enable();
+        disable();
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-revokeCashback}.
+     *
+     * Just a stub for testing. Always returns `true`.
+     */
+    function enabled() public pure returns (bool) {
+        return true;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-nextNonce}.
+     *
+     * Just a stub for testing. Always returns `true`.
+     */
+    function nextNonce() public pure returns (uint256) {
+        return 0;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getCashback}.
+     *
+     * Just a stub for testing. Always returns an empty structure.
+     */
+    function getCashback(uint256 nonce) public pure returns (Cashback memory cashback) {
+        cashback = (new Cashback[](1))[0];
+        nonce;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getCashbacks}.
+     *
+     * Just a stub for testing. Always returns an empty array.
+     */
+    function getCashbacks(uint256[] memory nonces) public pure returns (Cashback[] memory cashbacks) {
+        cashbacks = new Cashback[](0);
+        nonces;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getCashbackNonces}.
+     *
+     * Just a stub for testing. Always returns an empty array.
+     */
+    function getCashbackNonces(
+        bytes32 externalId,
+        uint256 index,
+        uint256 limit
+    ) public pure returns (uint256[] memory nonces) {
+        nonces = new uint256[](0);
+        externalId;
+        index;
+        limit;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getTotalCashbackByTokenAndExternalId}.
+     *
+     * Just a stub for testing. Always returns zero.
+     */
+    function getTotalCashbackByTokenAndExternalId(address token, bytes32 externalId) public pure returns (uint256) {
+        token;
+        externalId;
+        return 0;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getTotalCashbackByTokenAndRecipient}.
+     *
+     * Just a stub for testing. Always returns zero.
+     */
+    function getTotalCashbackByTokenAndRecipient(address token, address recipient) public pure returns (uint256) {
+        token;
+        recipient;
+        return 0;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-enable}.
+     *
+     * Just a stub for testing. Does nothing.
+     */
+    function enable() public {}
+
+    /**
+     * @dev See {ICashbackDistributor-disable}.
+     *
+     * Just a stub for testing. Does nothing.
+     */
+    function disable() public {}
+
+    /**
+     * @dev See {ICashbackDistributor-sendCashback}.
+     *
+     * Just a stub for testing. Returns the previously set values and emits an event with provided arguments.
+     */
+    function sendCashback(
+        address token,
+        CashbackKind kind,
+        bytes32 externalId,
+        address recipient,
+        uint256 amount
+    ) external returns (bool success, uint256 nonce) {
+        success = sendCashbackSuccessResult;
+        nonce = sendCashbackNonceResult;
+        emit SendCashbackMock(msg.sender, token, kind, externalId, recipient, amount);
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-revokeCashback}.
+     *
+     * Just a stub for testing. Returns the previously set value and emits an event with provided arguments.
+     */
+    function revokeCashback(uint256 nonce, uint256 amount) external returns (bool success) {
+        success = revokeCashbackSuccessResult;
+        emit RevokeCashbackMock(msg.sender, nonce, amount);
+    }
+
+    /**
+     * @dev Sets a new value for the success part of the `sendCashback()` function result.
+     */
+    function setSendCashbackSuccessResult(bool newSendCashbackSuccessResult) external {
+        sendCashbackSuccessResult = newSendCashbackSuccessResult;
+    }
+
+    /**
+     * @dev Sets a new value for the success part of the `revokeCashback()` function result.
+     */
+    function setRevokeCashbackSuccessResult(bool newRevokeCashbackSuccessResult) external {
+        revokeCashbackSuccessResult = newRevokeCashbackSuccessResult;
+    }
+}

--- a/test/CashbackDistributor.test.ts
+++ b/test/CashbackDistributor.test.ts
@@ -1,0 +1,907 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../test-utils/eth";
+import { createBytesString, createRevertMessageDueToMissingRole } from "../test-utils/misc";
+
+const BYTES32_LENGTH: number = 32;
+const CASHBACK_EXTERNAL_ID_STUB1 = createBytesString("01", BYTES32_LENGTH);
+const CASHBACK_EXTERNAL_ID_STUB2 = createBytesString("02", BYTES32_LENGTH);
+const TOKEN_ADDRESS_STUB = "0x0000000000000000000000000000000000000001";
+
+enum CashbackStatus {
+  Nonexistent = 0,
+  Success = 1,
+  Blacklisted = 2,
+  OutOfFunds = 3,
+  Disabled = 4,
+  Revoked = 5,
+}
+
+enum RevocationStatus {
+  Success = 1,
+  Inapplicable = 2,
+  OutOfFunds = 3,
+  OutOfAllowance = 4,
+  OutOfBalance = 5
+}
+
+enum CashbackKind {
+  Manual = 0,
+  CardPayment = 1,
+}
+
+interface TestCashback {
+  token: Contract;
+  kind: CashbackKind;
+  status: CashbackStatus;
+  externalId: string;
+  recipient: SignerWithAddress;
+  amount: number;
+  sender: SignerWithAddress;
+  nonce: number;
+  revokedAmount?: number;
+}
+
+function checkNonexistentCashback(
+  actualOnChainCashback: any,
+  cashbackNonce: number
+) {
+  expect(actualOnChainCashback.token).to.equal(
+    ethers.constants.AddressZero,
+    `cashback[${cashbackNonce}].token is incorrect`
+  );
+  expect(actualOnChainCashback.kind).to.equal(
+    CashbackKind.Manual,
+    `cashback[${cashbackNonce}].account is incorrect`
+  );
+  expect(actualOnChainCashback.status).to.equal(
+    CashbackStatus.Nonexistent,
+    `cashback[${cashbackNonce}].status is incorrect`
+  );
+  expect(actualOnChainCashback.externalId).to.equal(
+    ethers.constants.HashZero,
+    `cashback[${cashbackNonce}].externalId is incorrect`
+  );
+  expect(actualOnChainCashback.recipient).to.equal(
+    ethers.constants.AddressZero,
+    `cashback[${cashbackNonce}].recipient is incorrect`
+  );
+  expect(actualOnChainCashback.amount).to.equal(
+    0,
+    `cashback[${cashbackNonce}].amount is incorrect`
+  );
+  expect(actualOnChainCashback.sender).to.equal(
+    ethers.constants.AddressZero,
+    `cashback[${cashbackNonce}].sender is incorrect`
+  );
+  expect(actualOnChainCashback.revokedAmount).to.equal(
+    0,
+    `cashback[${cashbackNonce}].revokedAmount is incorrect`
+  );
+}
+
+function checkEquality(
+  actualOnChainCashback: any,
+  expectedCashback: TestCashback,
+) {
+  if (expectedCashback.status == CashbackStatus.Nonexistent) {
+    checkNonexistentCashback(actualOnChainCashback, expectedCashback.nonce);
+  } else {
+    expect(actualOnChainCashback.token).to.equal(
+      expectedCashback.token.address,
+      `cashback[${expectedCashback.nonce}].token is incorrect`
+    );
+    expect(actualOnChainCashback.kind).to.equal(
+      expectedCashback.kind,
+      `cashback[${expectedCashback.nonce}].account is incorrect`
+    );
+    expect(actualOnChainCashback.status).to.equal(
+      expectedCashback.status,
+      `cashback[${expectedCashback.nonce}].status is incorrect`
+    );
+    expect(actualOnChainCashback.externalId).to.equal(
+      expectedCashback.externalId,
+      `cashback[${expectedCashback.nonce}].externalId is incorrect`
+    );
+    expect(actualOnChainCashback.recipient).to.equal(
+      expectedCashback.recipient.address,
+      `cashback[${expectedCashback.nonce}].recipient is incorrect`
+    );
+    expect(actualOnChainCashback.amount).to.equal(
+      expectedCashback.amount,
+      `cashback[${expectedCashback.nonce}].amount is incorrect`
+    );
+    expect(actualOnChainCashback.sender).to.equal(
+      expectedCashback.sender.address,
+      `cashback[${expectedCashback.nonce}].sender is incorrect`
+    );
+    expect(actualOnChainCashback.revokedAmount).to.equal(
+      expectedCashback.revokedAmount || 0,
+      `cashback[${expectedCashback.nonce}].revokedAmount is incorrect`
+    );
+  }
+}
+
+async function deployTokenMock(symbol: string = "TEST"): Promise<Contract> {
+  const tokenMockFactory: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+  const tokenMock = await tokenMockFactory.deploy();
+  await tokenMock.deployed();
+  await proveTx(tokenMock.initialize("ERC20 Test", symbol));
+
+  return tokenMock;
+}
+
+describe("Contract 'CashbackDistributor'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+
+  const REVERT_ERROR_IF_CASHBACK_ALREADY_ENABLED = "CashbackAlreadyEnabled";
+  const REVERT_ERROR_IF_CASHBACK_ALREADY_DISABLED = "CashbackAlreadyDisabled";
+  const REVERT_ERROR_IF_TOKEN_ADDRESS_IS_ZERO = "ZeroTokenAddress";
+  const REVERT_ERROR_IF_RECIPIENT_ADDRESS_IS_ZERO = "ZeroRecipientAddress";
+  const REVERT_ERROR_IF_EXTERNAL_ID_IS_ZERO = "ZeroExternalId";
+
+  let cashbackDistributorFactory: ContractFactory;
+  let cashbackDistributor: Contract;
+  let tokenMockFactory: ContractFactory;
+
+  let deployer: SignerWithAddress;
+  let distributor: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  let ownerRole: string;
+  let blacklisterRole: string;
+  let pauserRole: string;
+  let rescuerRole: string;
+  let distributorRole: string;
+
+  beforeEach(async () => {
+    // Token mock factory
+    tokenMockFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+
+    // Deploy the contract under test
+    cashbackDistributorFactory = await ethers.getContractFactory("CashbackDistributor");
+    cashbackDistributor = await cashbackDistributorFactory.deploy();
+    await cashbackDistributor.deployed();
+    await proveTx(cashbackDistributor.initialize());
+
+    // Accounts
+    [deployer, distributor, user] = await ethers.getSigners();
+
+    // Roles
+    ownerRole = (await cashbackDistributor.OWNER_ROLE()).toLowerCase();
+    blacklisterRole = (await cashbackDistributor.BLACKLISTER_ROLE()).toLowerCase();
+    pauserRole = (await cashbackDistributor.PAUSER_ROLE()).toLowerCase();
+    rescuerRole = (await cashbackDistributor.RESCUER_ROLE()).toLowerCase();
+    distributorRole = (await cashbackDistributor.DISTRIBUTOR_ROLE()).toLowerCase();
+  });
+
+  async function setUpContractsForSendingCashbacks(cashbacks: TestCashback[]): Promise<Map<Contract, number>> {
+    const cashbackDistributorBalanceByToken: Map<Contract, number> = new Map<Contract, number>();
+    cashbacks.forEach(cashback => {
+      let totalCashbackAmount: number = cashbackDistributorBalanceByToken.get(cashback.token) || 0;
+      totalCashbackAmount += cashback.amount;
+      cashbackDistributorBalanceByToken.set(cashback.token, totalCashbackAmount);
+    });
+    for (let [token, totalCashbackAmount] of cashbackDistributorBalanceByToken.entries()) {
+      await proveTx(token.mint(cashbackDistributor.address, totalCashbackAmount));
+    }
+    return cashbackDistributorBalanceByToken;
+  }
+
+  async function sendCashbacks(cashbacks: TestCashback[], targetStatus: CashbackStatus) {
+    for (let cashback of cashbacks) {
+      await proveTx(
+        cashbackDistributor.connect(cashback.sender).sendCashback(
+          cashback.token.address,
+          cashback.kind,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount
+        )
+      );
+      expect(
+        (await cashbackDistributor.getCashback(cashback.nonce)).status
+      ).to.equal(
+        targetStatus,
+        "The sent cashback has unexpected status"
+      );
+      cashback.status = targetStatus;
+    }
+  }
+
+  async function checkCashbackStructures(cashbacks: TestCashback[]) {
+    // The cashback structure with the zero nonce must be always nonexistent one.
+    checkNonexistentCashback(await cashbackDistributor.getCashback(0), 0);
+
+    // Check other structures
+    for (let cashback of cashbacks) {
+      const actualCashback = await cashbackDistributor.getCashback(cashback.nonce);
+      checkEquality(actualCashback, cashback);
+    }
+
+    // Check the cashback structure after the last expected one. It must be nonexistent one.
+    if (cashbacks.length > 0) {
+      checkNonexistentCashback(await cashbackDistributor.getCashback(0), cashbacks[cashbacks.length - 1].nonce);
+    }
+  }
+
+  async function checkCashbackNonceByExternalId(cashbacks: TestCashback[]) {
+    const expectedMap = new Map<string, BigNumber[]>();
+    cashbacks.forEach(cashback => {
+      const nonces: BigNumber[] = expectedMap.get(cashback.externalId) || [];
+      nonces.push(BigNumber.from(cashback.nonce));
+      expectedMap.set(cashback.externalId, nonces);
+    });
+
+    for (let [externalId, expectedNonces] of expectedMap) {
+      expect(
+        await cashbackDistributor.getCashbackNonces(externalId, 0, 50)
+      ).to.deep.equal(
+        expectedNonces,
+        `Wrong array of nonces for the external ID ${externalId}`
+      );
+    }
+  }
+
+  async function checkTotalCashbackByTokenAndExternalId(cashbacks: TestCashback[]) {
+    const expectedMap = new Map<Contract, Map<string, number>>();
+    cashbacks.forEach(cashback => {
+      const totalCashbackMap: Map<string, number> = expectedMap.get(cashback.token) || new Map<string, number>();
+      let totalCashback: number = totalCashbackMap.get(cashback.externalId) || 0;
+      if (cashback.status == CashbackStatus.Success) {
+        totalCashback += cashback.amount - (cashback.revokedAmount || 0);
+      }
+      totalCashbackMap.set(cashback.externalId, totalCashback);
+      expectedMap.set(cashback.token, totalCashbackMap);
+    });
+
+    for (let [token, expectedTotalCashbackByExternalId] of expectedMap) {
+      for (let [externalId, expectedTotalCashback] of expectedTotalCashbackByExternalId) {
+        expect(
+          await cashbackDistributor.getTotalCashbackByTokenAndExternalId(token.address, externalId)
+        ).to.equal(
+          expectedTotalCashback,
+          `Wrong total cashback for the token with symbol ${await token.symbol()} and external ID ${externalId}`
+        );
+      }
+    }
+  }
+
+  async function checkTotalCashbackByTokenAndRecipient(cashbacks: TestCashback[]) {
+    const expectedMap = new Map<Contract, Map<string, number>>();
+    cashbacks.forEach(cashback => {
+      const recipientAddress: string = cashback.recipient.address;
+      const totalCashbackMap: Map<string, number> = expectedMap.get(cashback.token) || new Map<string, number>();
+      let totalCashback: number = totalCashbackMap.get(recipientAddress) || 0;
+      if (cashback.status == CashbackStatus.Success) {
+        totalCashback += cashback.amount - (cashback.revokedAmount || 0);
+      }
+      totalCashbackMap.set(recipientAddress, totalCashback);
+      expectedMap.set(cashback.token, totalCashbackMap);
+    });
+
+    for (let [token, expectedTotalCashbackByRecipient] of expectedMap) {
+      const tokenSymbol: string = await token.symbol();
+      for (let [recipientAddress, expectedTotalCashback] of expectedTotalCashbackByRecipient) {
+        expect(
+          await cashbackDistributor.getTotalCashbackByTokenAndRecipient(token.address, recipientAddress)
+        ).to.equal(
+          expectedTotalCashback,
+          `Wrong total cashback for the token with symbol "${tokenSymbol}" and recipient address ${recipientAddress}`
+        );
+      }
+    }
+  }
+
+  async function checkCashbackDistributorBalanceByTokens(
+    cashbacks: TestCashback[],
+    cashbackDistributorInitialBalanceByToken: Map<Contract, number>
+  ) {
+    const expectedMap = new Map<Contract, number>();
+    cashbacks.forEach(cashback => {
+      let balance: number = expectedMap.get(cashback.token)
+        || (cashbackDistributorInitialBalanceByToken.get(cashback.token) || 0);
+      if (cashback.status == CashbackStatus.Success) {
+        balance -= cashback.amount - (cashback.revokedAmount || 0);
+      }
+      expectedMap.set(cashback.token, balance);
+    });
+
+    for (let [token, expectedBalance] of expectedMap) {
+      const tokenSymbol: string = await token.symbol();
+      expect(
+        await token.balanceOf(cashbackDistributor.address)
+      ).to.equal(
+        expectedBalance,
+        `Wrong balance of the cashback distributor for token address with symbol "${tokenSymbol}"`
+      );
+    }
+  }
+
+  async function checkCashbackDistributorState(
+    cashbacks: TestCashback[],
+    cashbackDistributorInitialBalanceByToken: Map<Contract, number>
+  ) {
+    await checkCashbackStructures(cashbacks);
+    await checkCashbackNonceByExternalId(cashbacks);
+    await checkTotalCashbackByTokenAndExternalId(cashbacks);
+    await checkTotalCashbackByTokenAndRecipient(cashbacks);
+    await checkCashbackDistributorBalanceByTokens(cashbacks, cashbackDistributorInitialBalanceByToken);
+  }
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(
+      cashbackDistributor.initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initial contract configuration should be as expected", async () => {
+    // The admins of roles
+    expect(await cashbackDistributor.getRoleAdmin(ownerRole)).to.equal(ownerRole);
+    expect(await cashbackDistributor.getRoleAdmin(blacklisterRole)).to.equal(ownerRole);
+    expect(await cashbackDistributor.getRoleAdmin(pauserRole)).to.equal(ownerRole);
+    expect(await cashbackDistributor.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
+    expect(await cashbackDistributor.getRoleAdmin(distributorRole)).to.equal(ownerRole);
+
+    // The deployer should have the owner role, but not the other roles
+    expect(await cashbackDistributor.hasRole(ownerRole, deployer.address)).to.equal(true);
+    expect(await cashbackDistributor.hasRole(blacklisterRole, deployer.address)).to.equal(false);
+    expect(await cashbackDistributor.hasRole(pauserRole, deployer.address)).to.equal(false);
+    expect(await cashbackDistributor.hasRole(rescuerRole, deployer.address)).to.equal(false);
+    expect(await cashbackDistributor.hasRole(distributorRole, deployer.address)).to.equal(false);
+
+    // The initial contract state is unpaused
+    expect(await cashbackDistributor.paused()).to.equal(false);
+
+    // Cashback related values
+    expect(await cashbackDistributor.enabled()).to.equal(false);
+    expect(await cashbackDistributor.nextNonce()).to.equal(1);
+    const cashbackDistributorInitialBalanceByToken = new Map<Contract, number>();
+    await checkCashbackDistributorState([], cashbackDistributorInitialBalanceByToken);
+  });
+
+  describe("Function 'enable()'", async () => {
+    it("Is reverted if the caller does not have the owner role", async () => {
+      await expect(
+        cashbackDistributor.connect(user).enable()
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user.address, ownerRole));
+    });
+
+    it("Executes as expected and emits the correct event", async () => {
+      await expect(
+        cashbackDistributor.enable()
+      ).to.emit(
+        cashbackDistributor,
+        "Enable"
+      ).withArgs(
+        deployer.address
+      );
+      expect(await cashbackDistributor.enabled()).to.equal(true);
+    });
+
+    it("Is reverted if cashback operations are already enabled", async () => {
+      await proveTx(cashbackDistributor.enable());
+      await expect(
+        cashbackDistributor.enable()
+      ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_CASHBACK_ALREADY_ENABLED);
+    });
+  });
+
+  describe("Function 'disable()'", async () => {
+    it("Is reverted if the caller does not have the owner role", async () => {
+      await expect(
+        cashbackDistributor.connect(user).disable()
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user.address, ownerRole));
+    });
+
+    it("Is reverted if cashback operations are already disabled", async () => {
+      await expect(
+        cashbackDistributor.disable()
+      ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_CASHBACK_ALREADY_DISABLED);
+    });
+
+    it("Executes as expected and emits the correct event", async () => {
+      await proveTx(cashbackDistributor.enable());
+      expect(await cashbackDistributor.enabled()).to.equal(true);
+      await expect(
+        cashbackDistributor.disable()
+      ).to.emit(
+        cashbackDistributor,
+        "Disable"
+      ).withArgs(
+        deployer.address
+      );
+      expect(await cashbackDistributor.enabled()).to.equal(false);
+    });
+  });
+
+  describe("Function 'sendCashback()'", async () => {
+    let cashback: TestCashback;
+
+    beforeEach(async () => {
+      cashback = {
+        token: tokenMockFactory.attach(TOKEN_ADDRESS_STUB),
+        kind: CashbackKind.CardPayment,
+        status: CashbackStatus.Nonexistent,
+        externalId: CASHBACK_EXTERNAL_ID_STUB1,
+        recipient: user,
+        amount: 123,
+        sender: distributor,
+        nonce: 1,
+      };
+      await proveTx(cashbackDistributor.grantRole(distributorRole, distributor.address));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(cashbackDistributor.grantRole(pauserRole, deployer.address));
+      await proveTx(cashbackDistributor.pause());
+      await expect(
+        cashbackDistributor.connect(cashback.sender).sendCashback(
+          cashback.token.address,
+          cashback.kind,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount
+        )
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the distributor role", async () => {
+      await expect(
+        cashbackDistributor.sendCashback(
+          cashback.token.address,
+          cashback.kind,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount
+        )
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, distributorRole));
+    });
+
+    it("Is reverted if the token address is zero", async () => {
+      await expect(
+        cashbackDistributor.connect(cashback.sender).sendCashback(
+          ethers.constants.AddressZero,
+          cashback.kind,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount
+        )
+      ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_TOKEN_ADDRESS_IS_ZERO);
+    });
+
+    it("Is reverted if the recipient address is zero", async () => {
+      await expect(
+        cashbackDistributor.connect(cashback.sender).sendCashback(
+          cashback.token.address,
+          cashback.kind,
+          cashback.externalId,
+          ethers.constants.AddressZero,
+          cashback.amount
+        )
+      ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_RECIPIENT_ADDRESS_IS_ZERO);
+    });
+
+    it("Is reverted if the cashback external ID is zero", async () => {
+      cashback.externalId = ethers.constants.HashZero;
+      await expect(
+        cashbackDistributor.connect(cashback.sender).sendCashback(
+          cashback.token.address,
+          cashback.kind,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount
+        )
+      ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_EXTERNAL_ID_IS_ZERO);
+    });
+
+    describe("Executes as expected and emits the correct event if the sending succeeds and", async () => {
+      let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
+
+      beforeEach(async () => {
+        cashback.token = await deployTokenMock();
+        cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks([cashback]);
+      });
+
+      async function checkSuccessfulCashbackSending() {
+        await proveTx(cashbackDistributor.enable());
+        cashback.status = CashbackStatus.Success;
+        await expect(
+          cashbackDistributor.connect(cashback.sender).sendCashback(
+            cashback.token.address,
+            cashback.kind,
+            cashback.externalId,
+            cashback.recipient.address,
+            cashback.amount
+          )
+        ).to.changeTokenBalances(
+          cashback.token,
+          [cashbackDistributor, cashback.recipient, cashback.sender],
+          [-cashback.amount, +cashback.amount, 0]
+        ).and.to.emit(
+          cashbackDistributor,
+          "SendCashback"
+        ).withArgs(
+          cashback.token.address,
+          cashback.kind,
+          cashback.status,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount,
+          cashback.sender.address,
+          cashback.nonce,
+        );
+        await checkCashbackDistributorState([cashback], cashbackDistributorInitialBalanceByToken);
+      }
+
+      it("The cashback amount is nonzero", async () => {
+        await checkSuccessfulCashbackSending();
+      });
+
+      it("The cashback amount is zero", async () => {
+        cashback.amount = 0;
+        await checkSuccessfulCashbackSending();
+      });
+    });
+
+    describe("Executes as expected and emits the correct event if the sending fails because", async () => {
+      let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
+
+      beforeEach(async () => {
+        cashback.token = await deployTokenMock();
+        cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks([cashback]);
+      });
+
+      async function checkUnsuccessfulCashbackSending() {
+        await expect(
+          cashbackDistributor.connect(cashback.sender).sendCashback(
+            cashback.token.address,
+            cashback.kind,
+            cashback.externalId,
+            cashback.recipient.address,
+            cashback.amount
+          )
+        ).to.changeTokenBalances(
+          cashback.token,
+          [cashbackDistributor, cashback.recipient, cashback.sender],
+          [0, 0, 0]
+        ).and.to.emit(
+          cashbackDistributor,
+          "SendCashback"
+        ).withArgs(
+          cashback.token.address,
+          cashback.kind,
+          cashback.status,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount,
+          cashback.sender.address,
+          cashback.nonce,
+        );
+        await checkCashbackDistributorState([cashback], cashbackDistributorInitialBalanceByToken);
+      }
+
+      it("Cashback operations are disabled", async () => {
+        cashback.status = CashbackStatus.Disabled;
+        await checkUnsuccessfulCashbackSending();
+      });
+
+      it("The cashback distributor contract has not enough balance", async () => {
+        await proveTx(cashbackDistributor.enable());
+        cashback.amount = cashback.amount + 1;
+        cashback.status = CashbackStatus.OutOfFunds;
+        await checkUnsuccessfulCashbackSending();
+      });
+
+      it("The cashback recipient is blacklisted", async () => {
+        await proveTx(cashbackDistributor.enable());
+        await proveTx(cashbackDistributor.grantRole(blacklisterRole, deployer.address));
+        await proveTx(cashbackDistributor.blacklist(cashback.recipient.address));
+        cashback.status = CashbackStatus.Blacklisted;
+        await checkUnsuccessfulCashbackSending();
+      });
+    });
+  });
+
+  describe("Function 'revokeCashback()'", async () => {
+    let cashback: TestCashback;
+
+    beforeEach(async () => {
+      cashback = {
+        token: tokenMockFactory.attach(TOKEN_ADDRESS_STUB),
+        kind: CashbackKind.CardPayment,
+        status: CashbackStatus.Nonexistent,
+        externalId: CASHBACK_EXTERNAL_ID_STUB1,
+        recipient: user,
+        amount: 123,
+        sender: distributor,
+        nonce: 1,
+        revokedAmount: 12,
+      };
+      await proveTx(cashbackDistributor.grantRole(distributorRole, distributor.address));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(cashbackDistributor.grantRole(pauserRole, deployer.address));
+      await proveTx(cashbackDistributor.pause());
+      await expect(
+        cashbackDistributor.connect(cashback.sender).revokeCashback(cashback.nonce, cashback.revokedAmount)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the distributor role", async () => {
+      await expect(
+        cashbackDistributor.revokeCashback(cashback.nonce, cashback.revokedAmount)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, distributorRole));
+    });
+
+    describe("Executes as expected and emits the correct event if the revocation succeeds and", async () => {
+      let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
+
+      beforeEach(async () => {
+        cashback.token = await deployTokenMock();
+        cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks([cashback]);
+      });
+
+      async function checkRevokingOfSuccessfulCashback() {
+        await proveTx(cashbackDistributor.enable());
+        await sendCashbacks([cashback], CashbackStatus.Success);
+        await proveTx(cashback.token.mint(cashback.sender.address, cashback.revokedAmount));
+        await proveTx(cashback.token.connect(cashback.sender).approve(
+          cashbackDistributor.address,
+          ethers.constants.MaxUint256
+        ));
+
+        await expect(
+          cashbackDistributor.connect(cashback.sender).revokeCashback(cashback.nonce, cashback.revokedAmount)
+        ).to.changeTokenBalances(
+          cashback.token,
+          [cashbackDistributor, cashback.recipient, cashback.sender],
+          [+(cashback.revokedAmount || 0), 0, -(cashback.revokedAmount || 0)]
+        ).and.to.emit(
+          cashbackDistributor,
+          "RevokeCashback"
+        ).withArgs(
+          cashback.token.address,
+          cashback.kind,
+          cashback.status,
+          RevocationStatus.Success,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.revokedAmount,
+          cashback.sender.address,
+          cashback.nonce,
+        );
+        await checkCashbackDistributorState([cashback], cashbackDistributorInitialBalanceByToken);
+      }
+
+      it("The revocation amount is less than the initial cashback amount", async () => {
+        await checkRevokingOfSuccessfulCashback();
+      });
+
+      it("The revocation amount equals the initial cashback amount", async () => {
+        cashback.revokedAmount = cashback.amount;
+        await checkRevokingOfSuccessfulCashback();
+      });
+
+      it("The revocation amount is zero", async () => {
+        cashback.revokedAmount = 0;
+        await checkRevokingOfSuccessfulCashback();
+      });
+    });
+
+    describe("Executes as expected and emits the correct event if the revocation fails because", async () => {
+      let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
+
+      beforeEach(async () => {
+        cashback.token = await deployTokenMock();
+        cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks([cashback]);
+      });
+
+      async function checkRevokingOfUnsuccessfulCashback(targetRevocationStatus: RevocationStatus) {
+        await expect(
+          cashbackDistributor.connect(cashback.sender).revokeCashback(cashback.nonce, cashback.revokedAmount)
+        ).to.changeTokenBalances(
+          cashback.token,
+          [cashbackDistributor, cashback.recipient, cashback.sender],
+          [0, 0, 0]
+        ).and.to.emit(
+          cashbackDistributor,
+          "RevokeCashback"
+        ).withArgs(
+          cashback.token.address,
+          cashback.kind,
+          cashback.status,
+          targetRevocationStatus,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.revokedAmount,
+          cashback.sender.address,
+          cashback.nonce,
+        );
+        cashback.revokedAmount = 0;
+        await checkCashbackDistributorState([cashback], cashbackDistributorInitialBalanceByToken);
+      }
+
+      it("The caller has not enough tokens", async () => {
+        await proveTx(cashbackDistributor.enable());
+        await sendCashbacks([cashback], CashbackStatus.Success);
+        await proveTx(cashback.token.mint(cashback.sender.address, (cashback.revokedAmount || 0) - 1));
+        await proveTx(cashback.token.connect(cashback.sender).approve(
+          cashbackDistributor.address,
+          ethers.constants.MaxUint256
+        ));
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.OutOfFunds);
+      });
+
+      it("The cashback distributor has not enough allowance from the caller", async () => {
+        await proveTx(cashbackDistributor.enable());
+        await sendCashbacks([cashback], CashbackStatus.Success);
+        await proveTx(cashback.token.mint(cashback.sender.address, cashback.revokedAmount));
+        await proveTx(cashback.token.connect(cashback.sender).approve(
+          cashbackDistributor.address,
+          (cashback.revokedAmount || 0) - 1
+        ));
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.OutOfAllowance);
+      });
+
+      it("Cashback operations were disabled prior cashback sending", async () => {
+        await sendCashbacks([cashback], CashbackStatus.Disabled);
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.Inapplicable);
+      });
+
+      it("The cashback distributor had not enough balance prior cashback sending", async () => {
+        await proveTx(cashbackDistributor.enable());
+        cashback.amount = cashback.amount + 1;
+        await sendCashbacks([cashback], CashbackStatus.OutOfFunds);
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.Inapplicable);
+      });
+
+      it("The cashback recipient was blacklisted prior cashback sending", async () => {
+        await proveTx(cashbackDistributor.enable());
+        await proveTx(cashbackDistributor.grantRole(blacklisterRole, deployer.address));
+        await proveTx(cashbackDistributor.blacklist(cashback.recipient.address));
+        await sendCashbacks([cashback], CashbackStatus.Blacklisted);
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.Inapplicable);
+      });
+
+      it("The initial cashback amount is less than revocation amount", async () => {
+        await proveTx(cashbackDistributor.enable());
+        await sendCashbacks([cashback], CashbackStatus.Success);
+        await proveTx(cashback.token.mint(cashback.sender.address, cashback.amount + 1));
+        await proveTx(cashback.token.connect(cashback.sender).approve(
+          cashbackDistributor.address,
+          ethers.constants.MaxUint256
+        ));
+        cashback.revokedAmount = cashback.amount + 1;
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.OutOfBalance);
+      });
+    });
+  });
+
+  describe("Getter functions 'getCashbackNonces()' and 'getCashbacks()'", async () => {
+    let cashbacks: TestCashback[];
+    let cashbackNonces: BigNumber[];
+
+    beforeEach(async () => {
+      const tokenMock: Contract = await deployTokenMock();
+      cashbacks = [1, 2, 3].map(nonceValue => {
+        return {
+          token: tokenMock,
+          kind: CashbackKind.CardPayment,
+          status: CashbackStatus.Nonexistent,
+          externalId: CASHBACK_EXTERNAL_ID_STUB1,
+          recipient: user,
+          amount: 100 + nonceValue,
+          sender: distributor,
+          nonce: nonceValue,
+        };
+      });
+      cashbackNonces = cashbacks.map(cashback => BigNumber.from(cashback.nonce));
+      await proveTx(cashbackDistributor.grantRole(distributorRole, distributor.address));
+    });
+
+    it("Execute as expected", async () => {
+      await proveTx(cashbackDistributor.enable());
+      await setUpContractsForSendingCashbacks(cashbacks);
+      await sendCashbacks(cashbacks, CashbackStatus.Success);
+
+      // Check existing cashbacks
+      let actualCashbacks: any[] = await cashbackDistributor.getCashbacks(cashbackNonces);
+      expect(actualCashbacks.length).to.equal(cashbacks.length);
+      cashbacks.forEach(cashback => {
+        checkEquality(actualCashbacks[cashback.nonce - 1], cashback);
+      });
+
+      // Check nonexistent cashbacks
+      const nonceAfterExistingCashbacks: number = cashbacks.length + 1;
+      actualCashbacks = await cashbackDistributor.getCashbacks([0, nonceAfterExistingCashbacks]);
+      expect(actualCashbacks.length).to.equal(2);
+      checkNonexistentCashback(actualCashbacks[0], 0);
+      checkNonexistentCashback(actualCashbacks[1], nonceAfterExistingCashbacks);
+
+      // Check getting of cashback nonces in different cases
+      let actualNonces: BigNumber[];
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 0, 50);
+      expect(actualNonces).to.be.deep.equal(cashbackNonces);
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 0, 2);
+      expect(actualNonces).to.be.deep.equal([cashbackNonces[0], cashbackNonces[1]]);
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 1, 2);
+      expect(actualNonces).to.be.deep.equal([cashbackNonces[1], cashbackNonces[2]]);
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 1, 1);
+      expect(actualNonces).to.be.deep.equal([cashbackNonces[1]]);
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 1, 50);
+      expect(actualNonces).to.be.deep.equal([cashbackNonces[1], cashbackNonces[2]]);
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 3, 50);
+      expect(actualNonces).to.be.deep.equal([]);
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 1, 0);
+      expect(actualNonces).to.be.deep.equal([]);
+    });
+  });
+
+  describe("Complex scenario", async () => {
+    let tokenMock1: Contract;
+    let tokenMock2: Contract;
+    let cashbacks: TestCashback[];
+    let begNonce: number;
+    let endNonce: number;
+    let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
+
+    beforeEach(async () => {
+      tokenMock1 = await deployTokenMock("TEST1");
+      tokenMock2 = await deployTokenMock("TEST2");
+
+      cashbacks = [1, 2, 3, 4, 5, 6, 7, 8].map(nonce => {
+        return {
+          token: [tokenMock2, tokenMock1][(nonce >> 0) & 1],
+          kind: CashbackKind.CardPayment,
+          status: CashbackStatus.Nonexistent,
+          externalId: [CASHBACK_EXTERNAL_ID_STUB1, CASHBACK_EXTERNAL_ID_STUB2][(nonce >> 1) & 1],
+          recipient: [user, deployer][(nonce >> 2) & 1],
+          amount: 100 + nonce,
+          sender: distributor,
+          nonce: nonce,
+        };
+      });
+      begNonce = cashbacks[0].nonce;
+      endNonce = cashbacks[cashbacks.length - 1].nonce + 1;
+      await proveTx(cashbackDistributor.grantRole(distributorRole, distributor.address));
+      cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks(cashbacks);
+    });
+
+    async function revokeCashback(cashback: TestCashback) {
+      await proveTx(cashback.token.mint(cashback.sender.address, cashback.revokedAmount || 0));
+      await proveTx(
+        cashback.token.connect(cashback.sender).approve(cashbackDistributor.address, cashback.revokedAmount || 0)
+      );
+      await proveTx(
+        cashbackDistributor.connect(cashback.sender).revokeCashback(cashback.nonce, cashback.revokedAmount || 0)
+      );
+    }
+
+    it("Execute as expected", async () => {
+      await proveTx(cashbackDistributor.enable());
+      await sendCashbacks(cashbacks, CashbackStatus.Success);
+      await checkCashbackDistributorState(cashbacks, cashbackDistributorInitialBalanceByToken);
+
+      await revokeCashback(cashbacks[3]);
+      await checkCashbackDistributorState(cashbacks, cashbackDistributorInitialBalanceByToken);
+
+      await revokeCashback(cashbacks[0]);
+      await checkCashbackDistributorState(cashbacks, cashbackDistributorInitialBalanceByToken);
+
+      await revokeCashback(cashbacks[1]);
+      await checkCashbackDistributorState(cashbacks, cashbackDistributorInitialBalanceByToken);
+    });
+  });
+});


### PR DESCRIPTION
### Main changes
1. The refund logic has been added to the `CardPaymentProcessor`. The `refundPayment()` function can be used to execute a refund related to a payment, e.g. due to of a voucher, charge back, etc.  
2. The `cashOutAccount` address has been moved from the parameter of functions to the `_cashOutAccount` storage variable of the `CardPaymentProcessor` contract. It is needed to supply refunds after confirming a payment.
3. The new `CashbackDistributor` contract has been introduced. It is used for distribute cashback.
4. The cashback logic has been added to the `CardPaymentProccessor`. The rate of the cashback is defined by the `_cashbackRateInPermil` storage variable. Cashback giving is organized through the new `CashbackDistributor` contract.
5. The tests have been updated according to the changes in contracts.

### Testing and coverage
The tests have been successfully run on the Internal Hardhat net.

Coverage is not 100% because of  some service functions that will be removed later:
![image](https://user-images.githubusercontent.com/97302011/212461887-8ad00b0c-4187-4505-8fba-0aa823c56ad4.png)
