### PR TITLE
PIX Cashier V2

### DIFF
--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -969,28 +969,4 @@ contract CardPaymentProcessor is
     function calculateCashback(uint256 amount, uint256 cashbackRateInPermil) internal pure returns (uint256) {
         return amount * cashbackRateInPermil / 1000;
     }
-
-    /**
-     * @dev Service function for backward compatibility.
-     */
-    function confirmPayments(bytes16[] memory authorizationIds, address cashOutAccount_)
-        external
-        whenNotPaused
-        onlyRole(EXECUTOR_ROLE)
-    {
-        require(cashOutAccount_ == requireCashOutAccount(), "!cashOutAccount");
-        confirmPayments(authorizationIds);
-    }
-
-    /**
-     * @dev Service function for backward compatibility.
-     */
-    function confirmPayment(bytes16 authorizationId, address cashOutAccount_)
-        external
-        whenNotPaused
-        onlyRole(EXECUTOR_ROLE)
-    {
-        require(cashOutAccount_ == requireCashOutAccount(), "!cashOutAccount");
-        confirmPayment(authorizationId);
-    }
 }

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -419,7 +419,7 @@ contract CardPaymentProcessor is
         if (status == PaymentStatus.Nonexistent) {
             revert PaymentNotExist();
         }
-        if (status == PaymentStatus.Reversed || status == PaymentStatus.Revoked) {
+        if (status != PaymentStatus.Uncleared && status != PaymentStatus.Cleared && status != PaymentStatus.Confirmed) {
             revert InappropriatePaymentStatus(status);
         }
         if (newRefundAmount > paymentAmount) {
@@ -427,7 +427,7 @@ contract CardPaymentProcessor is
         }
 
         uint256 newCompensationAmount = newRefundAmount +
-            calculateCashback(paymentAmount - newRefundAmount, payment.cashbackRate);
+        calculateCashback(paymentAmount - newRefundAmount, payment.cashbackRate);
         uint256 sentAmount = newCompensationAmount - payment.compensationAmount;
         uint256 revokedCashbackAmount = amount - sentAmount;
 
@@ -442,7 +442,7 @@ contract CardPaymentProcessor is
             _totalClearedBalance -= amount;
             _clearedBalances[account] -= amount;
             IERC20Upgradeable(_token).safeTransfer(account, sentAmount);
-        } else if (status == PaymentStatus.Confirmed) {
+        } else { // status == PaymentStatus.ConfirmPayment
             address cashOutAccount_ = requireCashOutAccount();
             IERC20Upgradeable token = IERC20Upgradeable(_token);
             token.safeTransferFrom(cashOutAccount_, account, sentAmount);

--- a/contracts/CardPaymentProcessorStorage.sol
+++ b/contracts/CardPaymentProcessorStorage.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.8.16;
 
 import { ICardPaymentProcessorTypes } from "./interfaces/ICardPaymentProcessor.sol";
+import { ICardPaymentCashbackTypes } from "./interfaces/ICardPaymentCashback.sol";
 
 /**
  * @title CardPaymentProcessor storage version 1
@@ -37,6 +38,31 @@ abstract contract CardPaymentProcessorStorageV1 is ICardPaymentProcessorTypes {
 }
 
 /**
+ * @title CardPaymentProcessor storage version 2
+ */
+abstract contract CardPaymentProcessorStorageV2 {
+    /// @dev The account to transfer cleared tokens to.
+    address internal _cashOutAccount;
+}
+
+/**
+ * @title CardPaymentProcessor storage version 3
+ */
+abstract contract CardPaymentProcessorStorageV3 is ICardPaymentCashbackTypes {
+    /// @dev The enable flag of the cashback operations.
+    bool internal _cashbackEnabled;
+
+    /// @dev The address of the cashback distributor contract.
+    address internal _cashbackDistributor;
+
+    /// @dev The current cashback rate in permil (parts per thousand).
+    uint16 internal _cashbackRateInPermil;
+
+    /// @dev Mapping of a structure with cashback data for a given authorization ID.
+    mapping(bytes16 => Cashback) internal _cashbacks;
+}
+
+/**
  * @title CardPaymentProcessor storage
  * @dev Contains storage variables of the {CardPaymentProcessor} contract.
  *
@@ -46,6 +72,9 @@ abstract contract CardPaymentProcessorStorageV1 is ICardPaymentProcessorTypes {
  * e.g. CardPaymentProcessorStorage<versionNumber>, so finally it would look like
  * "contract CardPaymentProcessorStorage is CardPaymentProcessorStorageV1, CardPaymentProcessorStorageV2".
  */
-abstract contract CardPaymentProcessorStorage is CardPaymentProcessorStorageV1 {
+abstract contract CardPaymentProcessorStorage is
+    CardPaymentProcessorStorageV1,
+    CardPaymentProcessorStorageV2,
+    CardPaymentProcessorStorageV3 {
 
 }

--- a/contracts/CashbackDistributor.sol
+++ b/contracts/CashbackDistributor.sol
@@ -307,18 +307,4 @@ contract CashbackDistributor is
     function getTotalCashbackByTokenAndRecipient(address token, address recipient) external view returns (uint256){
         return _totalCashbackByTokenAndRecipient[token][recipient];
     }
-
-    /**
-     * @dev Service function.
-     */
-    function updateRevokeAmount(uint256 fromNonce, uint256 count) external onlyRole(OWNER_ROLE) {
-        uint256 len = fromNonce + count;
-        for (uint256 i = fromNonce; i < len; ++i) {
-            Cashback storage cashback = _cashbacks[i];
-            if (cashback.status == CashbackStatus.Revoked) {
-                cashback.status = CashbackStatus.Success;
-                cashback.revokedAmount = cashback.amount;
-            }
-        }
-    }
 }

--- a/contracts/CashbackDistributor.sol
+++ b/contracts/CashbackDistributor.sol
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { EnumerableSetUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/structs/EnumerableSetUpgradeable.sol";
+import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+import { BlacklistControlUpgradeable } from "./base/BlacklistControlUpgradeable.sol";
+import { PauseControlUpgradeable } from "./base/PauseControlUpgradeable.sol";
+import { RescueControlUpgradeable } from "./base/RescueControlUpgradeable.sol";
+import { CashbackDistributorStorage } from "./CashbackDistributorStorage.sol";
+import { StoragePlaceholder200 } from "./base/StoragePlaceholder.sol";
+import { ICashbackDistributor } from "./interfaces/ICashbackDistributor.sol";
+
+/**
+ * @title CashbackDistributor contract
+ * @dev Wrapper contract for the cashback operations.
+ */
+contract CashbackDistributor is
+    AccessControlUpgradeable,
+    BlacklistControlUpgradeable,
+    PauseControlUpgradeable,
+    RescueControlUpgradeable,
+    StoragePlaceholder200,
+    CashbackDistributorStorage,
+    ICashbackDistributor
+{
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using EnumerableSetUpgradeable for EnumerableSetUpgradeable.Bytes32Set;
+
+    /// @dev The role of this contract owner.
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /// @dev The role of distributor that is allowed to execute the cashback operations.
+    bytes32 public constant DISTRIBUTOR_ROLE = keccak256("DISTRIBUTOR_ROLE");
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev The cashback operations are already enabled.
+    error CashbackAlreadyEnabled();
+
+    /// @dev The cashback operations are already disabled.
+    error CashbackAlreadyDisabled();
+
+    /// @dev The zero token address has been passed as a function argument.
+    error ZeroTokenAddress();
+
+    /// @dev Zero external identifier has been passed as a function argument.
+    error ZeroExternalId();
+
+    /// @dev The zero account address has been passed as a function argument.
+    error ZeroRecipientAddress();
+
+    // ------------------- Functions ---------------------------------
+
+    /**
+     * @dev The initialize function of the upgradable contract.
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
+     */
+    function initialize() external initializer {
+        __CashbackDistributor_init();
+    }
+
+    function __CashbackDistributor_init() internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __AccessControl_init_unchained();
+        __BlacklistControl_init_unchained(OWNER_ROLE);
+        __Pausable_init_unchained();
+        __PauseControl_init_unchained(OWNER_ROLE);
+        __RescueControl_init_unchained(OWNER_ROLE);
+
+        __CashbackDistributor_init_unchained();
+    }
+
+    function __CashbackDistributor_init_unchained() internal onlyInitializing {
+        _nextNonce = 1;
+
+        _setRoleAdmin(OWNER_ROLE, OWNER_ROLE);
+        _setRoleAdmin(DISTRIBUTOR_ROLE, OWNER_ROLE);
+
+        _setupRole(OWNER_ROLE, _msgSender());
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-sendCashback}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {DISTRIBUTOR_ROLE} role.
+     * - The external cashback identifier must not be zero.
+     * - The cashback recipient address must not be zero.
+     * - The token contract address must not be zero.
+     */
+    function sendCashback(
+        address token,
+        CashbackKind kind,
+        bytes32 externalId,
+        address recipient,
+        uint256 amount
+    ) external whenNotPaused onlyRole(DISTRIBUTOR_ROLE) returns (bool success, uint256 nonce) {
+        if (token == address(0)) {
+            revert ZeroTokenAddress();
+        }
+        if (recipient == address(0)) {
+            revert ZeroRecipientAddress();
+        }
+        if (externalId == 0) {
+            revert ZeroExternalId();
+        }
+
+        CashbackStatus status = CashbackStatus.Success;
+
+        if (!_enabled) {
+            status = CashbackStatus.Disabled;
+        } else if (isBlacklisted(recipient)) {
+            status = CashbackStatus.Blacklisted;
+        } else if (IERC20Upgradeable(token).balanceOf(address(this)) < amount) {
+            status = CashbackStatus.OutOfFunds;
+        }
+
+        address sender = _msgSender();
+        nonce = _nextNonce++;
+
+        Cashback storage cashback = _cashbacks[nonce];
+        cashback.token = token;
+        cashback.kind = kind;
+        cashback.status = status;
+        cashback.externalId = externalId;
+        cashback.recipient = recipient;
+        cashback.amount = amount;
+        cashback.sender = sender;
+
+        _nonceCollectionByExternalId[externalId].push(nonce);
+
+        emit SendCashback(
+            token,
+            kind,
+            status,
+            externalId,
+            recipient,
+            amount,
+            sender,
+            nonce
+        );
+
+        if (status == CashbackStatus.Success) {
+            _totalCashbackByTokenAndRecipient[token][recipient] += amount;
+            _totalCashbackByTokenAndExternalId[token][externalId] += amount;
+            IERC20Upgradeable(token).safeTransfer(recipient, amount);
+            success = true;
+        }
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-revokeCashback}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {DISTRIBUTOR_ROLE} role.
+     */
+    function revokeCashback(
+        uint256 nonce,
+        uint256 amount
+    ) external whenNotPaused onlyRole(DISTRIBUTOR_ROLE) returns (bool success) {
+        Cashback storage cashback = _cashbacks[nonce];
+
+        address sender = _msgSender();
+        RevocationStatus revocationStatus = RevocationStatus.Success;
+
+        if (cashback.status != CashbackStatus.Success) {
+            revocationStatus = RevocationStatus.Inapplicable;
+        } else if (amount > IERC20Upgradeable(cashback.token).balanceOf(sender)) {
+            revocationStatus = RevocationStatus.OutOfFunds;
+        } else if (amount > IERC20Upgradeable(cashback.token).allowance(sender, address(this))) {
+            revocationStatus = RevocationStatus.OutOfAllowance;
+        } else if (amount > cashback.amount - cashback.revokedAmount) {
+            revocationStatus = RevocationStatus.OutOfBalance;
+        }
+
+        emit RevokeCashback(
+            cashback.token,
+            cashback.kind,
+            cashback.status,
+            revocationStatus,
+            cashback.externalId,
+            cashback.recipient,
+            amount,
+            sender,
+            nonce
+        );
+
+        if (revocationStatus == RevocationStatus.Success) {
+            cashback.revokedAmount += amount;
+            _totalCashbackByTokenAndRecipient[cashback.token][cashback.recipient] -= amount;
+            _totalCashbackByTokenAndExternalId[cashback.token][cashback.externalId] -= amount;
+            IERC20Upgradeable(cashback.token).safeTransferFrom(sender, address(this), amount);
+            success = true;
+        }
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-enable}.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {OWNER_ROLE} role.
+     */
+    function enable() external onlyRole(OWNER_ROLE) {
+        if (_enabled) {
+            revert CashbackAlreadyEnabled();
+        }
+
+        _enabled = true;
+
+        emit Enable(_msgSender());
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-disable}.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {OWNER_ROLE} role.
+     */
+    function disable() external onlyRole(OWNER_ROLE) {
+        if (!_enabled) {
+            revert CashbackAlreadyDisabled();
+        }
+
+        _enabled = false;
+
+        emit Disable(_msgSender());
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-enabled}.
+     */
+    function enabled() external view returns (bool) {
+        return _enabled;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-nextNonce}.
+     */
+    function nextNonce() external view returns (uint256) {
+        return _nextNonce;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getCashback}.
+     */
+    function getCashback(uint256 nonce) external view returns (Cashback memory cashback) {
+        cashback = _cashbacks[nonce];
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getCashbacks}.
+     */
+    function getCashbacks(uint256[] calldata nonces) external view returns (Cashback[] memory cashbacks) {
+        uint256 len = nonces.length;
+        cashbacks = new Cashback[](len);
+        for (uint256 i = 0; i < len; i++) {
+            cashbacks[i] = _cashbacks[nonces[i]];
+        }
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getCashbackNonces}.
+     */
+    function getCashbackNonces(
+        bytes32 externalId,
+        uint256 index,
+        uint256 limit
+    ) external view returns (uint256[] memory nonces) {
+        uint256[] storage nonceArray = _nonceCollectionByExternalId[externalId];
+        uint256 len = nonceArray.length;
+        if (len <= index || limit == 0) {
+            nonces = new uint256[](0);
+        } else {
+            len -= index;
+            if (len > limit) {
+                len = limit;
+            }
+            nonces = new uint256[](len);
+            for (uint256 i = 0; i < len; i++) {
+                nonces[i] = nonceArray[index];
+                index++;
+            }
+        }
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getTotalCashbackByTokenAndExternalId}.
+     */
+    function getTotalCashbackByTokenAndExternalId(address token, bytes32 externalId) external view returns (uint256) {
+        return _totalCashbackByTokenAndExternalId[token][externalId];
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getTotalCashbackByTokenAndRecipient}.
+     */
+    function getTotalCashbackByTokenAndRecipient(address token, address recipient) external view returns (uint256){
+        return _totalCashbackByTokenAndRecipient[token][recipient];
+    }
+
+    /**
+     * @dev Service function.
+     */
+    function updateRevokeAmount(uint256 fromNonce, uint256 count) external onlyRole(OWNER_ROLE) {
+        uint256 len = fromNonce + count;
+        for (uint256 i = fromNonce; i < len; ++i) {
+            Cashback storage cashback = _cashbacks[i];
+            if (cashback.status == CashbackStatus.Revoked) {
+                cashback.status = CashbackStatus.Success;
+                cashback.revokedAmount = cashback.amount;
+            }
+        }
+    }
+}

--- a/contracts/CashbackDistributorStorage.sol
+++ b/contracts/CashbackDistributorStorage.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { EnumerableSetUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/structs/EnumerableSetUpgradeable.sol";
+import { ICashbackDistributorTypes } from "./interfaces/ICashbackDistributor.sol";
+
+/**
+ * @title CashbackDistributor storage version 1
+ */
+abstract contract CashbackDistributorStorageV1 is ICashbackDistributorTypes {
+    /// @dev The enable flag of the cashback operations.
+    bool internal _enabled;
+
+    /// @dev The nonce of the next cashback operation.
+    uint256 internal _nextNonce;
+
+    /// @dev The mapping of a cashback structure for a given cashback nonce.
+    mapping(uint256 => Cashback) internal _cashbacks;
+
+    /// @dev Mapping of a nonce collection of all the cashback operations for a given external cashback identifier.
+    mapping(bytes32 => uint256[]) internal _nonceCollectionByExternalId;
+
+    // Obsolete
+    mapping(bytes32 => uint256) private _totalAmountByExternalId;
+
+    // Obsolete
+    mapping(address => uint256) private _totalAmountByRecipient;
+
+    /// @dev Mapping of a total amount of success cashback operations for a given token and an external identifier.
+    mapping(address => mapping(bytes32 => uint256)) internal _totalCashbackByTokenAndExternalId;
+
+    /// @dev Mapping of a total amount of success cashback operations for a given token and an recipient address.
+    mapping(address => mapping(address => uint256)) internal _totalCashbackByTokenAndRecipient;
+}
+
+/**
+ * @title CashbackDistributor storage
+ * @dev Contains storage variables of the {CashbackDistributor} contract.
+ *
+ * We are following Compound's approach of upgrading new contract implementations.
+ * See https://github.com/compound-finance/compound-protocol.
+ * When we need to add new storage variables, we create a new version of CashbackDistributorStorage
+ * e.g. CashbackDistributorStorage<versionNumber>, so finally it would look like
+ * "contract CashbackDistributorStorage is CashbackDistributorStorageV1, CashbackDistributorStorageV2".
+ */
+abstract contract CashbackDistributorStorage is CashbackDistributorStorageV1 {
+
+}

--- a/contracts/PixCashierStorage.sol
+++ b/contracts/PixCashierStorage.sol
@@ -2,15 +2,27 @@
 
 pragma solidity 0.8.16;
 
+import { EnumerableSetUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/structs/EnumerableSetUpgradeable.sol";
+import { IPixCashierTypes } from "./interfaces/IPixCashier.sol";
+
 /**
  * @title PixCashier storage version 1
  */
-abstract contract PixCashierStorageV1 {
+abstract contract PixCashierStorageV1 is IPixCashierTypes {
     /// @dev The address of the underlying token.
     address internal _token;
 
-    /// @dev Mapping of a pending cash-out balance for a given account.
+    /// @dev The mapping of a pending cash-out balance for a given account.
     mapping(address => uint256) internal _cashOutBalances;
+
+    /// @dev The mapping of a cash-out operation structure for a given off-chain transaction identifier.
+    mapping(bytes32 => CashOut) internal _cashOuts;
+
+    /// @dev The set of off-chain transaction identifiers that correspond the pending cash-out operations.
+    EnumerableSetUpgradeable.Bytes32Set _pendingCashOutTxIds;
+
+    /// @dev The processed cash-out operation counter that includes number of reversed and confirmed operations.
+    uint256 internal _processedCashOutCounter;
 }
 
 /**

--- a/contracts/interfaces/ICardPaymentCashback.sol
+++ b/contracts/interfaces/ICardPaymentCashback.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+/**
+ * @title CardPaymentCashback types interface
+ */
+interface ICardPaymentCashbackTypes {
+    /// @dev Structure with data of a single cashback operation.
+    struct Cashback {
+        uint256 lastCashbackNonce; // The nonce of the last cashback operation.
+    }
+}
+
+/**
+ * @title CardPaymentCashback interface
+ * @dev The interface of the wrapper contract for the card payment cashback operations.
+ */
+interface ICardPaymentCashback is ICardPaymentCashbackTypes {
+    /**
+     * @dev Emitted when the cashback distributor is changed.
+     * @param oldDistributor The address of the old cashback distributor contract.
+     * @param newDistributor The address of the new cashback distributor contract.
+     */
+    event SetCashbackDistributor(address oldDistributor, address newDistributor);
+
+    /**
+     * @dev Emitted when the cashback rate is changed.
+     * @param oldRateInPermil The value of the old cashback rate in permil.
+     * @param newRateInPermil The value of the new cashback rate in permil.
+     */
+    event SetCashbackRate(uint16 oldRateInPermil, uint16 newRateInPermil);
+
+    /**
+     * @dev Emitted when a cashback send request succeeded.
+     * @param cashbackDistributor The address of the cashback distributor.
+     * @param amount The amount of the cashback.
+     * @param nonce The nonce of the cashback.
+     */
+    event SendCashbackSuccess(address indexed cashbackDistributor, uint256 amount, uint256 nonce);
+
+    /**
+     * @dev Emitted when a cashback send request failed.
+     * @param cashbackDistributor The address of the cashback distributor.
+     * @param nonce The nonce of the cashback.
+     */
+    event SendCashbackFailure(address indexed cashbackDistributor, uint256 amount, uint256 nonce);
+
+    /**
+     * @dev Emitted when a cashback revoke request succeeded.
+     * @param cashbackDistributor The address of the cashback distributor.
+     * @param amount The amount of the revoked cashback.
+     * @param nonce The nonce of the cashback.
+     */
+    event RevokeCashbackSuccess(address indexed cashbackDistributor, uint256 amount, uint256 nonce);
+
+    /**
+     * @dev Emitted when a cashback revoke request failed.
+     * @param cashbackDistributor The address of the cashback distributor.
+     * @param amount The amount of the revoked cashback.
+     * @param nonce The nonce of the cashback.
+     */
+    event RevokeCashbackFailure(address indexed cashbackDistributor, uint256 amount, uint256 nonce);
+
+    /// @dev Emitted when cashback operations are enabled.
+    event EnableCashback();
+
+    /// @dev Emitted when cashback operations are disabled.
+    event DisableCashback();
+
+    /**
+     * @dev Returns the address of the cashback distributor contract.
+     */
+    function cashbackDistributor() external view returns (address);
+
+    /**
+     * @dev Checks if the cashback operations are enabled.
+     */
+    function cashbackEnabled() external view returns (bool);
+
+    /**
+     * @dev Returns the current cashback rate in permil.
+     */
+    function cashbackRate() external view returns (uint256);
+
+    /**
+     * @dev Returns the cashback details for the transaction authorization ID.
+     * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
+     */
+    function getCashback(bytes16 authorizationId) external view returns (Cashback memory);
+
+    /**
+     * @dev Sets a new address of the cashback distributor contract.
+     *
+     * Emits a {SetCashbackDistributor} event.
+     *
+     * @param newCashbackDistributor The address of the new cashback distributor contract.
+     */
+    function setCashbackDistributor(address newCashbackDistributor) external;
+
+    /**
+     * @dev Sets a new cashback rate.
+     *
+     * Emits a {SetCashbackRate} event.
+     *
+     * @param newCashbackRateInPermil The value of the new cashback rate in permil.
+     */
+    function setCashbackRate(uint16 newCashbackRateInPermil) external;
+
+    /**
+     * @dev Enables the cashback operations.
+     *
+     * Emits a {EnableCashback} event.
+     */
+    function enableCashback() external;
+
+    /**
+     * @dev Disables the cashback operations.
+     *
+     * Emits a {DisableCashback} event.
+     */
+    function disableCashback() external;
+}

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -39,9 +39,9 @@ interface ICardPaymentProcessorTypes {
         uint256 amount;             // Amount of tokens in the payment.
         PaymentStatus status;       // Current status of the payment.
         uint8 revocationCounter;    // Number of payment revocations.
-        uint256 compensationAmount; // TODO
-        uint256 refundAmount;       // TODO
-        uint16 cashbackRate;        // TODO
+        uint256 compensationAmount; // The total amount of compensation to the account related to the payment
+        uint256 refundAmount;       // The total amount of all refunds related to the payment
+        uint16 cashbackRate;        // The rate of cashback of the payment
     }
 }
 

--- a/contracts/interfaces/ICashbackDistributor.sol
+++ b/contracts/interfaces/ICashbackDistributor.sol
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+/**
+ * @title CashbackDistributor types interface
+ */
+interface ICashbackDistributorTypes {
+    /**
+     * @dev Kinds of a cashback operation as an enum.
+     *
+     * The possible values:
+     * - Manual ------ The cashback is sent manually (the default value).
+     * - CardPayment - The cashback is sent through the CardPaymentProcessor contract.
+     */
+    enum CashbackKind {
+        Manual,     // 0
+        CardPayment // 1
+    }
+
+    /**
+     * @dev Statuses of a cashback operation as an enum.
+     *
+     * The possible values:
+     * - Nonexistent - The cashback operation does not exist (the default value).
+     * - Success ----- The cashback operation has been successfully sent.
+     * - Blacklisted - The cashback operation has been refused because the target account is blacklisted.
+     * - OutOfFunds -- The cashback operation has been refused because the contract has not enough tokens.
+     * - Disabled ---- The cashback operation has been refused because the cashback operations are disabled.
+     * - Revoked ----- Obsolete and not in use anymore.
+     */
+    enum CashbackStatus {
+        Nonexistent, // 0
+        Success,     // 1
+        Blacklisted, // 2
+        OutOfFunds,  // 3
+        Disabled,    // 4
+        Revoked      // 5
+    }
+
+    /**
+     * @dev Statuses of a cashback revocation operation as an enum.
+     *
+     * The possible values:
+     * - Unknown -------- The operation has not been initiated (the default value).
+     * - Success -------- The operation has been successfully executed.
+     * - Inapplicable --- The operation has been failed because the cashback has not relevant status.
+     * - OutOfFunds ----- The operation has been failed because the caller has not enough tokens.
+     * - OutOfAllowance - The operation has been failed because the caller has not enough allowance for the contract.
+     * - OutOfBalance --- The operation has been failed because the revocation amount is greater than the cashback amount.
+     */
+    enum RevocationStatus {
+        Unknown,        // 0
+        Success,        // 1
+        Inapplicable,   // 2
+        OutOfFunds,     // 3
+        OutOfAllowance, // 4
+        OutOfBalance    // 5
+    }
+
+    /// @dev Structure with data of a single cashback operation.
+    struct Cashback {
+        address token;
+        CashbackKind kind;
+        CashbackStatus status;
+        bytes32 externalId;
+        address recipient;
+        uint256 amount;
+        address sender;
+        uint256 revokedAmount;
+    }
+}
+
+/**
+ * @title CashbackDistributor interface
+ * @dev The interface of the wrapper contract for the cashback operations.
+ */
+interface ICashbackDistributor is ICashbackDistributorTypes {
+    /**
+     * @dev Emitted when a cashback operation is executed.
+     * @param token The token contract of the cashback operation.
+     * @param kind The kind of the cashback operation.
+     * @param status The result of the cashback operation.
+     * @param externalId The external identifier of the cashback operation.
+     * @param recipient The account to which the cashback is intended.
+     * @param amount The amount of the cashback.
+     * @param sender The account that initiated the cashback operation.
+     * @param nonce The nonce of the cashback operation internally assigned by the contract.
+     */
+    event SendCashback(
+        address token,
+        CashbackKind kind,
+        CashbackStatus indexed status,
+        bytes32 indexed externalId,
+        address indexed recipient,
+        uint256 amount,
+        address sender,
+        uint256 nonce
+    );
+
+    /**
+     * @dev Emitted when a cashback operation is revoked.
+     * @param token The token contract of the cashback operation.
+     * @param cashbackKind The kind of the cashback operation.
+     * @param cashbackStatus The status of the cashback operation before the revocation.
+     * @param status The status of the revocation.
+     * @param externalId The external identifier of the cashback operation.
+     * @param recipient The account that received the cashback.
+     * @param amount The amount of the revoked cashback.
+     * @param sender The account that initiated the cashback revocation operation.
+     * @param nonce The nonce of the cashback operation.
+     */
+    event RevokeCashback(
+        address token,
+        CashbackKind cashbackKind,
+        CashbackStatus cashbackStatus,
+        RevocationStatus indexed status,
+        bytes32 indexed externalId,
+        address indexed recipient,
+        uint256 amount,
+        address sender,
+        uint256 nonce
+    );
+
+    /**
+     * @dev Emitted when cashback operations are enabled.
+     * @param sender The account that enabled the operations.
+     */
+    event Enable(address sender);
+
+    /**
+     * @dev Emitted when cashback operations are disabled.
+     * @param sender The account that disabled the operations.
+     */
+    event Disable(address sender);
+
+    /**
+     * @dev Sends a cashback to a recipient.
+     *
+     * Transfers the underlying tokens from the contract to the recipient if there are appropriate conditions.
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to execute cashback operations.
+     *
+     * Emits a {SendCashback} event.
+     *
+     * @param token The address of the cashback token.
+     * @param kind The kind of the cashback operation.
+     * @param externalId The external identifier of the cashback operation.
+     * @param recipient The account to which the cashback is intended.
+     * @param amount The amount of tokens to send.
+     * @return success True if the cashback has been successfully sent.
+     * @return nonce The nonce of the newly created cashback operation.
+     */
+    function sendCashback(
+        address token,
+        CashbackKind kind,
+        bytes32 externalId,
+        address recipient,
+        uint256 amount
+    ) external returns (bool success, uint256 nonce);
+
+    /**
+     * @dev Revokes a previously sent cashback.
+     *
+     * Transfers the underlying tokens from the caller to the contract.
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to execute cashback operations.
+     *
+     * Emits a {RevokeCashback} event if the cashback is successfully revoked.
+     *
+     * @param nonce The nonce of the cashback operation to revoke.
+     * @param amount The amount of tokens to revoke during the operation.
+     * @return success True if the cashback revocation was successful.
+     */
+    function revokeCashback(uint256 nonce, uint256 amount) external returns (bool success);
+
+    /**
+     * @dev Enables the cashback operations.
+     *
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to control cashback operations.
+     *
+     * Emits a {EnableCashback} event.
+     */
+    function enable() external;
+
+    /**
+     * @dev Disables the cashback operations.
+     *
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to control cashback operations.
+     *
+     * Emits a {DisableCashback} event.
+     */
+    function disable() external;
+
+    /**
+     * @dev Checks if the cashback operations are enabled.
+     */
+    function enabled() external view returns (bool);
+
+    /**
+     * @dev Returns the nonce of the next cashback operation.
+     */
+    function nextNonce() external view returns (uint256);
+
+    /**
+     * @dev Returns the data of a cashback operation by its nonce.
+     * @param nonce The nonce of the cashback operation to return.
+     */
+    function getCashback(uint256 nonce) external view returns (Cashback memory cashback);
+
+    /**
+     * @dev Returns the data of cashback operations by their nonces.
+     * @param nonces The array of nonces of cashback operations to return.
+     */
+    function getCashbacks(uint256[] calldata nonces) external view returns (Cashback[] memory cashbacks);
+
+    /**
+     * @dev Returns an array of cashback nonces associated with an external identifier.
+     * @param externalId The external cashback identifier to return nonces.
+     * @param index The index of the first nonce in the range to return.
+     * @param limit The max number of nonces in the range to return.
+     */
+    function getCashbackNonces(
+        bytes32 externalId,
+        uint256 index,
+        uint256 limit
+    ) external view returns (uint256[] memory);
+
+    /**
+     * @dev Returns the total amount of all the success cashback operations associated with a token and an external ID.
+     * @param token The token contract address of the cashback operations to define the returned total amount.
+     * @param externalId The external identifier of the cashback operations to define the returned total amount.
+     */
+    function getTotalCashbackByTokenAndExternalId(address token, bytes32 externalId) external view returns (uint256);
+
+    /**
+     * @dev Returns the total amount of all the success cashback operations associated with a token and a recipient.
+     * @param token The token contract address of the cashback operations to define the returned total amount.
+     * @param recipient The recipient address of the cashback operations to define the returned total amount.
+     */
+    function getTotalCashbackByTokenAndRecipient(address token, address recipient) external view returns (uint256);
+}

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -3,10 +3,38 @@
 pragma solidity 0.8.16;
 
 /**
+ * @title PixCashier types interface
+ */
+interface IPixCashierTypes {
+    /**
+     * @dev Possible statuses of a cash-out operation as an enum.
+     *
+     * The possible values:
+     * - Nonexistent - The operation does not exist (the default value).
+     * - Pending ----- The status immediately after the operation requesting.
+     * - Reversed ---- The operation was reversed.
+     * - Confirmed --- The operations was confirmed.
+     */
+    enum CashOutStatus {
+        Nonexistent, // 0
+        Pending,     // 1
+        Reversed,    // 2
+        Confirmed    // 3
+    }
+
+    /// @dev Structure with data of a single cash-out operation.
+    struct CashOut {
+        address account;      // The owner of tokens to cash-out.
+        uint256 amount;       // The amount of tokens to cash-out.
+        CashOutStatus status; // The status of the cash-out operation according to the {CashOutStatus} enum.
+    }
+}
+
+/**
  * @title PixCashier interface
  * @dev The interface of the wrapper contract for PIX cash-in and cash-out operations.
  */
-interface IPixCashier {
+interface IPixCashier is IPixCashierTypes {
     /// @dev Emitted when a new cash-in operation is executed.
     event CashIn(
         address indexed account, // The account that receives tokens.
@@ -15,24 +43,25 @@ interface IPixCashier {
     );
 
     /// @dev Emitted when a new cash-out operation is initiated.
-    event CashOut(
-        address indexed account, // The account that executes tokens cash-out.
+    event RequestCashOut(
+        address indexed account, // The account that owns the tokens to cash-out.
         uint256 amount,          // The amount of tokens to cash-out.
         uint256 balance,         // The new pending cash-out balance of the account.
-        bytes32 indexed txId     // The off-chain transaction identifier.
+        bytes32 indexed txId,    // The off-chain transaction identifier.
+        address indexed sender   // The account that initiated the cash-out.
     );
 
     /// @dev Emitted when a cash-out operation is confirmed.
-    event CashOutConfirm(
-        address indexed account, // The account that executes tokens cash-out.
+    event ConfirmCashOut(
+        address indexed account, // The account that owns the tokens to cash-out.
         uint256 amount,          // The amount of tokens to cash-out.
         uint256 balance,         // The new pending cash-out balance of the account.
         bytes32 indexed txId     // The off-chain transaction identifier.
     );
 
     /// @dev Emitted when a cash-out operation is reversed.
-    event CashOutReverse(
-        address indexed account, // The account that executes tokens cash-out.
+    event ReverseCashOut(
+        address indexed account, // The account that owns the tokens to cash-out.
         uint256 amount,          // The amount of tokens to cash-out.
         uint256 balance,         // The new pending cash-out balance of the account.
         bytes32 indexed txId     // The off-chain transaction identifier.
@@ -50,15 +79,56 @@ interface IPixCashier {
     function cashOutBalanceOf(address account) external view returns (uint256);
 
     /**
+     * @dev Returns the pending cash-out operation counter.
+     */
+    function pendingCashOutCounter() external view returns (uint256);
+
+    /**
+     * @dev Returns the processed cash-out operation counter (reversed and confirmed operations included).
+     */
+    function processedCashOutCounter() external view returns (uint256);
+
+    /**
+     * @dev Returns the off-chain transaction identifiers of pending cash-out operations.
+     *
+     * No guarantees are made on the ordering of the identifiers in the returned array.
+     * When you can't prevent confirming and reversing of cash-out operations during calling this function several
+     * times to sequentially read of all available identifiers the following procedure is recommended:
+     *
+     * - 1. Call the `processedCashOutCounter()` function and remember the returned value as C1.
+     * - 2. Call this function several times with needed values of `index` and `limit` like (0,5), (5,5), (10,5), ...
+     * - 3. Execute step 2 until the length of the returned array becomes less than the `limit` value.
+     * - 4. Call the `processedCashOutCounter()` function and remember the returned value as C2.
+     * - 5. If C1 == C2 the result of function calls is consistent. Else repeat the procedure from step 1.
+     * @param index The first index in the internal array of pending identifiers to fetch.
+     * @param limit The maximum number of returned identifiers.
+     * @return txIds The array of requested identifiers.
+     */
+    function getPendingCashOutTxIds(uint256 index, uint256 limit) external view returns (bytes32[] memory txIds);
+
+    /**
+     * @dev Returns the data of a single cash-out operation.
+     * @param txId The off-chain transaction identifier of the operation.
+     */
+    function getCashOut(bytes32 txId) external view returns (CashOut memory);
+
+    /**
+     * @dev Returns the data of multiple cash-out operations.
+     * @param txIds The off-chain transaction identifiers of the operations.
+     */
+    function getCashOuts(bytes32[] memory txIds) external view returns (CashOut[] memory cashOuts);
+
+    /**
      * @dev Executes a cash-in operation.
      *
-     * This function can be called by a limited number of accounts that are allowed to execute cash-in operations.
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to execute cash-in operations.
      *
      * Emits a {CashIn} event.
      *
      * @param account The address of the tokens recipient.
      * @param amount The amount of tokens to be received.
-     * @param txId The off-chain transaction identifier.
+     * @param txId The off-chain transaction identifier of the operation.
      */
     function cashIn(
         address account,
@@ -75,33 +145,78 @@ interface IPixCashier {
      * Emits a {CashOut} event.
      *
      * @param amount The amount of tokens to be cash-outed.
-     * @param txId The off-chain transaction identifier.
+     * @param txId The off-chain transaction identifier of the operation.
      */
-    function cashOut(uint256 amount, bytes32 txId) external;
+    function requestCashOut(uint256 amount, bytes32 txId) external;
 
     /**
-     * @dev Confirms a cash-out operation.
+     * @dev Initiates a cash-out operation from some other account.
+     *
+     * Transfers tokens from the account to the contract.
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to process cash-out operations.
+     *
+     * Emits a {CashOut} event.
+     *
+     * @param account The account on that behalf the operation is made.
+     * @param amount The amount of tokens to be cash-outed.
+     * @param txId The off-chain transaction identifier of the operation.
+     */
+    function requestCashOutFrom(
+        address account,
+        uint256 amount,
+        bytes32 txId
+    ) external;
+
+    /**
+     * @dev Confirms a single cash-out operation.
      *
      * Burns tokens previously transferred to the contract.
-     * This function is expected to be called by any account.
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to process cash-out operations.
      *
-     * Emits a {CashOutConfirm} event.
+     * Emits a {CashOutConfirm} event for the operation.
      *
-     * @param amount The amount of tokens to be burned.
-     * @param txId The off-chain transaction identifier.
+     * @param txId The off-chain transaction identifier of the operation.
      */
-    function cashOutConfirm(uint256 amount, bytes32 txId) external;
+    function confirmCashOut(bytes32 txId) external;
 
     /**
-     * @dev Reverts a cash-out operation.
+     * @dev Confirms multiple cash-out operations.
      *
-     * Transfers tokens back from the contract to the caller.
-     * This function is expected to be called by any account.
+     * Burns tokens previously transferred to the contract.
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to process cash-out operations.
      *
-     * Emits a {CashOutReverse} event.
+     * Emits a {CashOutConfirm} event for each operation.
      *
-     * @param amount The amount of tokens to be transferred back.
-     * @param txId The off-chain transaction identifier.
+     * @param txIds The off-chain transaction identifiers of the operations.
      */
-    function cashOutReverse(uint256 amount, bytes32 txId) external;
+    function confirmCashOuts(bytes32[] memory txIds) external;
+
+    /**
+     * @dev Reverts a single cash-out operation.
+     *
+     * Transfers tokens back from the contract to the account that requested the operation.
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to process cash-out operations.
+     *
+     * Emits a {CashOutReverse} event for the operation.
+     *
+     * @param txId The off-chain transaction identifier of the operation.
+     */
+    function reverseCashOut(bytes32 txId) external;
+
+    /**
+     * @dev Reverts multiple cash-out operation.
+     *
+     * Transfers tokens back from the contract to the accounts that requested the operations.
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to process cash-out operations.
+     *
+     * Emits a {CashOutReverse} event for each operation.
+     *
+     * @param txIds The off-chain transaction identifiers of the operations.
+     */
+    function reverseCashOuts(bytes32[] memory txIds) external;
 }

--- a/contracts/mocks/CashbackDistributorMock.sol
+++ b/contracts/mocks/CashbackDistributorMock.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { ICashbackDistributor } from "../interfaces/ICashbackDistributor.sol";
+
+/**
+ * @title CashbackDistributor contract
+ * @dev An implementation of the {ICashbackDistributor} interface for test purposes.
+ */
+contract CashbackDistributorMock is ICashbackDistributor {
+    /// @dev The success part of the `sendCashback()` function result to return next time.
+    bool public sendCashbackSuccessResult;
+
+    /// @dev The nonce part of the `sendCashback()` function result to return next time.
+    uint256 public sendCashbackNonceResult;
+
+    /// @dev The success part of the `revokeCashback()` function result to return next time.
+    bool public revokeCashbackSuccessResult;
+
+    /**
+     * @dev Emitted when the 'sendCashback()' function is called
+     */
+    event SendCashbackMock(
+        address sender,
+        address token,
+        CashbackKind kind,
+        bytes32 indexed externalId,
+        address indexed recipient,
+        uint256 amount
+    );
+
+    /**
+     * @dev Emitted when the 'revokeCashback()' function is called
+     */
+    event RevokeCashbackMock(address sender, uint256 nonce, uint256 amount);
+
+    /**
+     * @dev Constructor that simply set values of all storage variables.
+     */
+    constructor(
+        bool sendCashbackSuccessResult_,
+        uint256 sendCashbackNonceResult_,
+        bool revokeCashbackSuccessResult_
+    ) {
+        sendCashbackSuccessResult = sendCashbackSuccessResult_;
+        sendCashbackNonceResult = sendCashbackNonceResult_;
+        revokeCashbackSuccessResult = revokeCashbackSuccessResult_;
+
+        // Calling stub functions just to provide 100% coverage
+        enabled();
+        nextNonce();
+        getCashback(0);
+        getCashbacks(new uint256[](0));
+        getCashbackNonces(bytes32(0), 0, 0);
+        getTotalCashbackByTokenAndExternalId(address(0), bytes32(0));
+        getTotalCashbackByTokenAndRecipient(address(0), address(0));
+        enable();
+        disable();
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-revokeCashback}.
+     *
+     * Just a stub for testing. Always returns `true`.
+     */
+    function enabled() public pure returns (bool) {
+        return true;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-nextNonce}.
+     *
+     * Just a stub for testing. Always returns `true`.
+     */
+    function nextNonce() public pure returns (uint256) {
+        return 0;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getCashback}.
+     *
+     * Just a stub for testing. Always returns an empty structure.
+     */
+    function getCashback(uint256 nonce) public pure returns (Cashback memory cashback) {
+        cashback = (new Cashback[](1))[0];
+        nonce;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getCashbacks}.
+     *
+     * Just a stub for testing. Always returns an empty array.
+     */
+    function getCashbacks(uint256[] memory nonces) public pure returns (Cashback[] memory cashbacks) {
+        cashbacks = new Cashback[](0);
+        nonces;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getCashbackNonces}.
+     *
+     * Just a stub for testing. Always returns an empty array.
+     */
+    function getCashbackNonces(
+        bytes32 externalId,
+        uint256 index,
+        uint256 limit
+    ) public pure returns (uint256[] memory nonces) {
+        nonces = new uint256[](0);
+        externalId;
+        index;
+        limit;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getTotalCashbackByTokenAndExternalId}.
+     *
+     * Just a stub for testing. Always returns zero.
+     */
+    function getTotalCashbackByTokenAndExternalId(address token, bytes32 externalId) public pure returns (uint256) {
+        token;
+        externalId;
+        return 0;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getTotalCashbackByTokenAndRecipient}.
+     *
+     * Just a stub for testing. Always returns zero.
+     */
+    function getTotalCashbackByTokenAndRecipient(address token, address recipient) public pure returns (uint256) {
+        token;
+        recipient;
+        return 0;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-enable}.
+     *
+     * Just a stub for testing. Does nothing.
+     */
+    function enable() public {}
+
+    /**
+     * @dev See {ICashbackDistributor-disable}.
+     *
+     * Just a stub for testing. Does nothing.
+     */
+    function disable() public {}
+
+    /**
+     * @dev See {ICashbackDistributor-sendCashback}.
+     *
+     * Just a stub for testing. Returns the previously set values and emits an event with provided arguments.
+     */
+    function sendCashback(
+        address token,
+        CashbackKind kind,
+        bytes32 externalId,
+        address recipient,
+        uint256 amount
+    ) external returns (bool success, uint256 nonce) {
+        success = sendCashbackSuccessResult;
+        nonce = sendCashbackNonceResult;
+        emit SendCashbackMock(msg.sender, token, kind, externalId, recipient, amount);
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-revokeCashback}.
+     *
+     * Just a stub for testing. Returns the previously set value and emits an event with provided arguments.
+     */
+    function revokeCashback(uint256 nonce, uint256 amount) external returns (bool success) {
+        success = revokeCashbackSuccessResult;
+        emit RevokeCashbackMock(msg.sender, nonce, amount);
+    }
+
+    /**
+     * @dev Sets a new value for the success part of the `sendCashback()` function result.
+     */
+    function setSendCashbackSuccessResult(bool newSendCashbackSuccessResult) external {
+        sendCashbackSuccessResult = newSendCashbackSuccessResult;
+    }
+
+    /**
+     * @dev Sets a new value for the success part of the `revokeCashback()` function result.
+     */
+    function setRevokeCashbackSuccessResult(bool newRevokeCashbackSuccessResult) external {
+        revokeCashbackSuccessResult = newRevokeCashbackSuccessResult;
+    }
+}

--- a/contracts/mocks/tokens/ERC20UpgradeableMock.sol
+++ b/contracts/mocks/tokens/ERC20UpgradeableMock.sol
@@ -9,6 +9,8 @@ import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC2
  * @dev An implementation of the {ERC20Upgradeable} contract for test purposes.
  */
 contract ERC20UpgradeableMock is ERC20Upgradeable {
+    bool public mintResult;
+
     /**
      * @dev The initialize function of the upgradable contract.
      * @param name_ The name of the token to set for this ERC20-comparable contract.
@@ -16,6 +18,7 @@ contract ERC20UpgradeableMock is ERC20Upgradeable {
      */
     function initialize(string memory name_, string memory symbol_) public initializer {
         __ERC20_init(name_, symbol_);
+        mintResult = true;
     }
 
     /**
@@ -25,7 +28,7 @@ contract ERC20UpgradeableMock is ERC20Upgradeable {
      */
     function mint(address account, uint256 amount) external returns (bool) {
         _mint(account, amount);
-        return true;
+        return mintResult;
     }
 
     /**
@@ -34,5 +37,9 @@ contract ERC20UpgradeableMock is ERC20Upgradeable {
      */
     function burn(uint256 amount) external {
         _burn(msg.sender, amount);
+    }
+
+    function setMintResult(bool _newMintResult) external {
+        mintResult = _newMintResult;
     }
 }

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -167,9 +167,6 @@ async function deployCashbackDistributorMock():
 }
 
 describe("Contract 'CardPaymentProcessor'", async () => {
-  const CONFIRM_PAYMENT_FUNCTION_SIGNATURE = "confirmPayment(bytes16)";
-  const CONFIRM_PAYMENTS_FUNCTION_SIGNATURE = "confirmPayments(bytes16[])";
-
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
   const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
   const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
@@ -2243,25 +2240,25 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await proveTx(cardPaymentProcessor.pause());
 
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](authorizationId)
+        cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the executor role", async () => {
       await expect(
-        cardPaymentProcessor.connect(deployer).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](authorizationId)
+        cardPaymentProcessor.connect(deployer).confirmPayment(authorizationId)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
     it("Is reverted if the payment authorization ID is zero", async () => {
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](ZERO_AUTHORIZATION_ID)
+        cardPaymentProcessor.connect(executor).confirmPayment(ZERO_AUTHORIZATION_ID)
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
     });
 
     it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](
+        cardPaymentProcessor.connect(executor).confirmPayment(
           createBytesString(payment.authorizationId + 1, BYTES16_LENGTH)
         )
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
@@ -2271,13 +2268,13 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await proveTx(cardPaymentProcessor.connect(executor).unclearPayment(authorizationId));
 
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](authorizationId)
+        cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
     });
 
     it("Is reverted if the cash-out account is not set", async () => {
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](authorizationId)
+        cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO);
     });
 
@@ -2287,7 +2284,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const expectedClearedBalance: number = 0;
 
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](authorizationId)
+        cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
       ).to.changeTokenBalances(
         tokenMock,
         [cardPaymentProcessor, cashOutAccount, payment.account],
@@ -2352,25 +2349,25 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
       await proveTx(cardPaymentProcessor.pause());
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENTS_FUNCTION_SIGNATURE](authorizationIds)
+        cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the executor role", async () => {
       await expect(
-        cardPaymentProcessor.connect(deployer).functions[CONFIRM_PAYMENTS_FUNCTION_SIGNATURE](authorizationIds)
+        cardPaymentProcessor.connect(deployer).confirmPayments(authorizationIds)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
     it("Is reverted if the payment authorization IDs array is empty", async () => {
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENTS_FUNCTION_SIGNATURE]([])
+        cardPaymentProcessor.connect(executor).confirmPayments([])
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
     });
 
     it("Is reverted if one of the payment authorization IDs is zero", async () => {
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENTS_FUNCTION_SIGNATURE](
+        cardPaymentProcessor.connect(executor).confirmPayments(
           [authorizationIds[0], ZERO_AUTHORIZATION_ID]
         )
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
@@ -2378,7 +2375,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
 
     it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENTS_FUNCTION_SIGNATURE](
+        cardPaymentProcessor.connect(executor).confirmPayments(
           [
             authorizationIds[0],
             createBytesString(payments[payments.length - 1].authorizationId + 1, BYTES16_LENGTH)
@@ -2391,13 +2388,13 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await proveTx(cardPaymentProcessor.connect(executor).unclearPayment(authorizationIds[1]));
 
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENTS_FUNCTION_SIGNATURE](authorizationIds)
+        cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds)
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
     });
 
     it("Is reverted if the cash-out account is not set", async () => {
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENTS_FUNCTION_SIGNATURE](authorizationIds)
+        cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds)
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO);
     });
 
@@ -2407,7 +2404,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
 
       const txResponse: TransactionResponse =
-        await cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENTS_FUNCTION_SIGNATURE](authorizationIds);
+        await cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds);
       await expect(
         txResponse
       ).to.changeTokenBalances(
@@ -2523,7 +2520,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await clearPayments([payment]);
       await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
       await proveTx(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](authorizationId)
+        cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
       );
       payment.status = PaymentStatus.Confirmed;
       await proveTx(cardPaymentProcessor.setCashOutAccount(ethers.constants.AddressZero));
@@ -2644,7 +2641,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
           );
           await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
           await proveTx(
-            cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](authorizationId)
+            cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
           );
           payment.status = PaymentStatus.Confirmed;
           await checkRefunding(cashOutAccount);
@@ -2672,7 +2669,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
           );
           await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
           await proveTx(
-            cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](authorizationId)
+            cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
           );
           payment.status = PaymentStatus.Confirmed;
 
@@ -2701,7 +2698,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
           );
           await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
           await proveTx(
-            cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](authorizationId)
+            cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
           );
           payment.status = PaymentStatus.Confirmed;
 
@@ -2749,11 +2746,11 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
 
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](authorizationIds[0])
+        cardPaymentProcessor.connect(executor).confirmPayment(authorizationIds[0])
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
 
       await expect(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENTS_FUNCTION_SIGNATURE](authorizationIds)
+        cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds)
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
     }
 
@@ -2850,7 +2847,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await clearPayments(payments);
       await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
       await proveTx(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](authorizationIds[0])
+        cardPaymentProcessor.connect(executor).confirmPayment(authorizationIds[0])
       );
       payments[0].status = PaymentStatus.Confirmed;
 
@@ -2952,7 +2949,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const cashOutAccountBalanceBefore: BigNumber = await tokenMock.balanceOf(cashOutAccount.address);
       await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
       await proveTx(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENTS_FUNCTION_SIGNATURE]([authorizationIds[0]])
+        cardPaymentProcessor.connect(executor).confirmPayments([authorizationIds[0]])
       );
       payments[0].status = PaymentStatus.Confirmed;
       const cashOutAccountBalanceAfter: BigNumber = await tokenMock.balanceOf(cashOutAccount.address);
@@ -3049,7 +3046,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
 
       await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
       await proveTx(
-        cardPaymentProcessor.connect(executor).functions[CONFIRM_PAYMENT_FUNCTION_SIGNATURE](authorizationId)
+        cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
       );
       payment.status = PaymentStatus.Confirmed;
       await checkCardPaymentProcessorState([payment]);

--- a/test/CashbackDistributor.test.ts
+++ b/test/CashbackDistributor.test.ts
@@ -1,0 +1,907 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../test-utils/eth";
+import { createBytesString, createRevertMessageDueToMissingRole } from "../test-utils/misc";
+
+const BYTES32_LENGTH: number = 32;
+const CASHBACK_EXTERNAL_ID_STUB1 = createBytesString("01", BYTES32_LENGTH);
+const CASHBACK_EXTERNAL_ID_STUB2 = createBytesString("02", BYTES32_LENGTH);
+const TOKEN_ADDRESS_STUB = "0x0000000000000000000000000000000000000001";
+
+enum CashbackStatus {
+  Nonexistent = 0,
+  Success = 1,
+  Blacklisted = 2,
+  OutOfFunds = 3,
+  Disabled = 4,
+  Revoked = 5,
+}
+
+enum RevocationStatus {
+  Success = 1,
+  Inapplicable = 2,
+  OutOfFunds = 3,
+  OutOfAllowance = 4,
+  OutOfBalance = 5
+}
+
+enum CashbackKind {
+  Manual = 0,
+  CardPayment = 1,
+}
+
+interface TestCashback {
+  token: Contract;
+  kind: CashbackKind;
+  status: CashbackStatus;
+  externalId: string;
+  recipient: SignerWithAddress;
+  amount: number;
+  sender: SignerWithAddress;
+  nonce: number;
+  revokedAmount?: number;
+}
+
+function checkNonexistentCashback(
+  actualOnChainCashback: any,
+  cashbackNonce: number
+) {
+  expect(actualOnChainCashback.token).to.equal(
+    ethers.constants.AddressZero,
+    `cashback[${cashbackNonce}].token is incorrect`
+  );
+  expect(actualOnChainCashback.kind).to.equal(
+    CashbackKind.Manual,
+    `cashback[${cashbackNonce}].account is incorrect`
+  );
+  expect(actualOnChainCashback.status).to.equal(
+    CashbackStatus.Nonexistent,
+    `cashback[${cashbackNonce}].status is incorrect`
+  );
+  expect(actualOnChainCashback.externalId).to.equal(
+    ethers.constants.HashZero,
+    `cashback[${cashbackNonce}].externalId is incorrect`
+  );
+  expect(actualOnChainCashback.recipient).to.equal(
+    ethers.constants.AddressZero,
+    `cashback[${cashbackNonce}].recipient is incorrect`
+  );
+  expect(actualOnChainCashback.amount).to.equal(
+    0,
+    `cashback[${cashbackNonce}].amount is incorrect`
+  );
+  expect(actualOnChainCashback.sender).to.equal(
+    ethers.constants.AddressZero,
+    `cashback[${cashbackNonce}].sender is incorrect`
+  );
+  expect(actualOnChainCashback.revokedAmount).to.equal(
+    0,
+    `cashback[${cashbackNonce}].revokedAmount is incorrect`
+  );
+}
+
+function checkEquality(
+  actualOnChainCashback: any,
+  expectedCashback: TestCashback,
+) {
+  if (expectedCashback.status == CashbackStatus.Nonexistent) {
+    checkNonexistentCashback(actualOnChainCashback, expectedCashback.nonce);
+  } else {
+    expect(actualOnChainCashback.token).to.equal(
+      expectedCashback.token.address,
+      `cashback[${expectedCashback.nonce}].token is incorrect`
+    );
+    expect(actualOnChainCashback.kind).to.equal(
+      expectedCashback.kind,
+      `cashback[${expectedCashback.nonce}].account is incorrect`
+    );
+    expect(actualOnChainCashback.status).to.equal(
+      expectedCashback.status,
+      `cashback[${expectedCashback.nonce}].status is incorrect`
+    );
+    expect(actualOnChainCashback.externalId).to.equal(
+      expectedCashback.externalId,
+      `cashback[${expectedCashback.nonce}].externalId is incorrect`
+    );
+    expect(actualOnChainCashback.recipient).to.equal(
+      expectedCashback.recipient.address,
+      `cashback[${expectedCashback.nonce}].recipient is incorrect`
+    );
+    expect(actualOnChainCashback.amount).to.equal(
+      expectedCashback.amount,
+      `cashback[${expectedCashback.nonce}].amount is incorrect`
+    );
+    expect(actualOnChainCashback.sender).to.equal(
+      expectedCashback.sender.address,
+      `cashback[${expectedCashback.nonce}].sender is incorrect`
+    );
+    expect(actualOnChainCashback.revokedAmount).to.equal(
+      expectedCashback.revokedAmount || 0,
+      `cashback[${expectedCashback.nonce}].revokedAmount is incorrect`
+    );
+  }
+}
+
+async function deployTokenMock(symbol: string = "TEST"): Promise<Contract> {
+  const tokenMockFactory: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+  const tokenMock = await tokenMockFactory.deploy();
+  await tokenMock.deployed();
+  await proveTx(tokenMock.initialize("ERC20 Test", symbol));
+
+  return tokenMock;
+}
+
+describe("Contract 'CashbackDistributor'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+
+  const REVERT_ERROR_IF_CASHBACK_ALREADY_ENABLED = "CashbackAlreadyEnabled";
+  const REVERT_ERROR_IF_CASHBACK_ALREADY_DISABLED = "CashbackAlreadyDisabled";
+  const REVERT_ERROR_IF_TOKEN_ADDRESS_IS_ZERO = "ZeroTokenAddress";
+  const REVERT_ERROR_IF_RECIPIENT_ADDRESS_IS_ZERO = "ZeroRecipientAddress";
+  const REVERT_ERROR_IF_EXTERNAL_ID_IS_ZERO = "ZeroExternalId";
+
+  let cashbackDistributorFactory: ContractFactory;
+  let cashbackDistributor: Contract;
+  let tokenMockFactory: ContractFactory;
+
+  let deployer: SignerWithAddress;
+  let distributor: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  let ownerRole: string;
+  let blacklisterRole: string;
+  let pauserRole: string;
+  let rescuerRole: string;
+  let distributorRole: string;
+
+  beforeEach(async () => {
+    // Token mock factory
+    tokenMockFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+
+    // Deploy the contract under test
+    cashbackDistributorFactory = await ethers.getContractFactory("CashbackDistributor");
+    cashbackDistributor = await cashbackDistributorFactory.deploy();
+    await cashbackDistributor.deployed();
+    await proveTx(cashbackDistributor.initialize());
+
+    // Accounts
+    [deployer, distributor, user] = await ethers.getSigners();
+
+    // Roles
+    ownerRole = (await cashbackDistributor.OWNER_ROLE()).toLowerCase();
+    blacklisterRole = (await cashbackDistributor.BLACKLISTER_ROLE()).toLowerCase();
+    pauserRole = (await cashbackDistributor.PAUSER_ROLE()).toLowerCase();
+    rescuerRole = (await cashbackDistributor.RESCUER_ROLE()).toLowerCase();
+    distributorRole = (await cashbackDistributor.DISTRIBUTOR_ROLE()).toLowerCase();
+  });
+
+  async function setUpContractsForSendingCashbacks(cashbacks: TestCashback[]): Promise<Map<Contract, number>> {
+    const cashbackDistributorBalanceByToken: Map<Contract, number> = new Map<Contract, number>();
+    cashbacks.forEach(cashback => {
+      let totalCashbackAmount: number = cashbackDistributorBalanceByToken.get(cashback.token) || 0;
+      totalCashbackAmount += cashback.amount;
+      cashbackDistributorBalanceByToken.set(cashback.token, totalCashbackAmount);
+    });
+    for (let [token, totalCashbackAmount] of cashbackDistributorBalanceByToken.entries()) {
+      await proveTx(token.mint(cashbackDistributor.address, totalCashbackAmount));
+    }
+    return cashbackDistributorBalanceByToken;
+  }
+
+  async function sendCashbacks(cashbacks: TestCashback[], targetStatus: CashbackStatus) {
+    for (let cashback of cashbacks) {
+      await proveTx(
+        cashbackDistributor.connect(cashback.sender).sendCashback(
+          cashback.token.address,
+          cashback.kind,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount
+        )
+      );
+      expect(
+        (await cashbackDistributor.getCashback(cashback.nonce)).status
+      ).to.equal(
+        targetStatus,
+        "The sent cashback has unexpected status"
+      );
+      cashback.status = targetStatus;
+    }
+  }
+
+  async function checkCashbackStructures(cashbacks: TestCashback[]) {
+    // The cashback structure with the zero nonce must be always nonexistent one.
+    checkNonexistentCashback(await cashbackDistributor.getCashback(0), 0);
+
+    // Check other structures
+    for (let cashback of cashbacks) {
+      const actualCashback = await cashbackDistributor.getCashback(cashback.nonce);
+      checkEquality(actualCashback, cashback);
+    }
+
+    // Check the cashback structure after the last expected one. It must be nonexistent one.
+    if (cashbacks.length > 0) {
+      checkNonexistentCashback(await cashbackDistributor.getCashback(0), cashbacks[cashbacks.length - 1].nonce);
+    }
+  }
+
+  async function checkCashbackNonceByExternalId(cashbacks: TestCashback[]) {
+    const expectedMap = new Map<string, BigNumber[]>();
+    cashbacks.forEach(cashback => {
+      const nonces: BigNumber[] = expectedMap.get(cashback.externalId) || [];
+      nonces.push(BigNumber.from(cashback.nonce));
+      expectedMap.set(cashback.externalId, nonces);
+    });
+
+    for (let [externalId, expectedNonces] of expectedMap) {
+      expect(
+        await cashbackDistributor.getCashbackNonces(externalId, 0, 50)
+      ).to.deep.equal(
+        expectedNonces,
+        `Wrong array of nonces for the external ID ${externalId}`
+      );
+    }
+  }
+
+  async function checkTotalCashbackByTokenAndExternalId(cashbacks: TestCashback[]) {
+    const expectedMap = new Map<Contract, Map<string, number>>();
+    cashbacks.forEach(cashback => {
+      const totalCashbackMap: Map<string, number> = expectedMap.get(cashback.token) || new Map<string, number>();
+      let totalCashback: number = totalCashbackMap.get(cashback.externalId) || 0;
+      if (cashback.status == CashbackStatus.Success) {
+        totalCashback += cashback.amount - (cashback.revokedAmount || 0);
+      }
+      totalCashbackMap.set(cashback.externalId, totalCashback);
+      expectedMap.set(cashback.token, totalCashbackMap);
+    });
+
+    for (let [token, expectedTotalCashbackByExternalId] of expectedMap) {
+      for (let [externalId, expectedTotalCashback] of expectedTotalCashbackByExternalId) {
+        expect(
+          await cashbackDistributor.getTotalCashbackByTokenAndExternalId(token.address, externalId)
+        ).to.equal(
+          expectedTotalCashback,
+          `Wrong total cashback for the token with symbol ${await token.symbol()} and external ID ${externalId}`
+        );
+      }
+    }
+  }
+
+  async function checkTotalCashbackByTokenAndRecipient(cashbacks: TestCashback[]) {
+    const expectedMap = new Map<Contract, Map<string, number>>();
+    cashbacks.forEach(cashback => {
+      const recipientAddress: string = cashback.recipient.address;
+      const totalCashbackMap: Map<string, number> = expectedMap.get(cashback.token) || new Map<string, number>();
+      let totalCashback: number = totalCashbackMap.get(recipientAddress) || 0;
+      if (cashback.status == CashbackStatus.Success) {
+        totalCashback += cashback.amount - (cashback.revokedAmount || 0);
+      }
+      totalCashbackMap.set(recipientAddress, totalCashback);
+      expectedMap.set(cashback.token, totalCashbackMap);
+    });
+
+    for (let [token, expectedTotalCashbackByRecipient] of expectedMap) {
+      const tokenSymbol: string = await token.symbol();
+      for (let [recipientAddress, expectedTotalCashback] of expectedTotalCashbackByRecipient) {
+        expect(
+          await cashbackDistributor.getTotalCashbackByTokenAndRecipient(token.address, recipientAddress)
+        ).to.equal(
+          expectedTotalCashback,
+          `Wrong total cashback for the token with symbol "${tokenSymbol}" and recipient address ${recipientAddress}`
+        );
+      }
+    }
+  }
+
+  async function checkCashbackDistributorBalanceByTokens(
+    cashbacks: TestCashback[],
+    cashbackDistributorInitialBalanceByToken: Map<Contract, number>
+  ) {
+    const expectedMap = new Map<Contract, number>();
+    cashbacks.forEach(cashback => {
+      let balance: number = expectedMap.get(cashback.token)
+        || (cashbackDistributorInitialBalanceByToken.get(cashback.token) || 0);
+      if (cashback.status == CashbackStatus.Success) {
+        balance -= cashback.amount - (cashback.revokedAmount || 0);
+      }
+      expectedMap.set(cashback.token, balance);
+    });
+
+    for (let [token, expectedBalance] of expectedMap) {
+      const tokenSymbol: string = await token.symbol();
+      expect(
+        await token.balanceOf(cashbackDistributor.address)
+      ).to.equal(
+        expectedBalance,
+        `Wrong balance of the cashback distributor for token address with symbol "${tokenSymbol}"`
+      );
+    }
+  }
+
+  async function checkCashbackDistributorState(
+    cashbacks: TestCashback[],
+    cashbackDistributorInitialBalanceByToken: Map<Contract, number>
+  ) {
+    await checkCashbackStructures(cashbacks);
+    await checkCashbackNonceByExternalId(cashbacks);
+    await checkTotalCashbackByTokenAndExternalId(cashbacks);
+    await checkTotalCashbackByTokenAndRecipient(cashbacks);
+    await checkCashbackDistributorBalanceByTokens(cashbacks, cashbackDistributorInitialBalanceByToken);
+  }
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(
+      cashbackDistributor.initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initial contract configuration should be as expected", async () => {
+    // The admins of roles
+    expect(await cashbackDistributor.getRoleAdmin(ownerRole)).to.equal(ownerRole);
+    expect(await cashbackDistributor.getRoleAdmin(blacklisterRole)).to.equal(ownerRole);
+    expect(await cashbackDistributor.getRoleAdmin(pauserRole)).to.equal(ownerRole);
+    expect(await cashbackDistributor.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
+    expect(await cashbackDistributor.getRoleAdmin(distributorRole)).to.equal(ownerRole);
+
+    // The deployer should have the owner role, but not the other roles
+    expect(await cashbackDistributor.hasRole(ownerRole, deployer.address)).to.equal(true);
+    expect(await cashbackDistributor.hasRole(blacklisterRole, deployer.address)).to.equal(false);
+    expect(await cashbackDistributor.hasRole(pauserRole, deployer.address)).to.equal(false);
+    expect(await cashbackDistributor.hasRole(rescuerRole, deployer.address)).to.equal(false);
+    expect(await cashbackDistributor.hasRole(distributorRole, deployer.address)).to.equal(false);
+
+    // The initial contract state is unpaused
+    expect(await cashbackDistributor.paused()).to.equal(false);
+
+    // Cashback related values
+    expect(await cashbackDistributor.enabled()).to.equal(false);
+    expect(await cashbackDistributor.nextNonce()).to.equal(1);
+    const cashbackDistributorInitialBalanceByToken = new Map<Contract, number>();
+    await checkCashbackDistributorState([], cashbackDistributorInitialBalanceByToken);
+  });
+
+  describe("Function 'enable()'", async () => {
+    it("Is reverted if the caller does not have the owner role", async () => {
+      await expect(
+        cashbackDistributor.connect(user).enable()
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user.address, ownerRole));
+    });
+
+    it("Executes as expected and emits the correct event", async () => {
+      await expect(
+        cashbackDistributor.enable()
+      ).to.emit(
+        cashbackDistributor,
+        "Enable"
+      ).withArgs(
+        deployer.address
+      );
+      expect(await cashbackDistributor.enabled()).to.equal(true);
+    });
+
+    it("Is reverted if cashback operations are already enabled", async () => {
+      await proveTx(cashbackDistributor.enable());
+      await expect(
+        cashbackDistributor.enable()
+      ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_CASHBACK_ALREADY_ENABLED);
+    });
+  });
+
+  describe("Function 'disable()'", async () => {
+    it("Is reverted if the caller does not have the owner role", async () => {
+      await expect(
+        cashbackDistributor.connect(user).disable()
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user.address, ownerRole));
+    });
+
+    it("Is reverted if cashback operations are already disabled", async () => {
+      await expect(
+        cashbackDistributor.disable()
+      ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_CASHBACK_ALREADY_DISABLED);
+    });
+
+    it("Executes as expected and emits the correct event", async () => {
+      await proveTx(cashbackDistributor.enable());
+      expect(await cashbackDistributor.enabled()).to.equal(true);
+      await expect(
+        cashbackDistributor.disable()
+      ).to.emit(
+        cashbackDistributor,
+        "Disable"
+      ).withArgs(
+        deployer.address
+      );
+      expect(await cashbackDistributor.enabled()).to.equal(false);
+    });
+  });
+
+  describe("Function 'sendCashback()'", async () => {
+    let cashback: TestCashback;
+
+    beforeEach(async () => {
+      cashback = {
+        token: tokenMockFactory.attach(TOKEN_ADDRESS_STUB),
+        kind: CashbackKind.CardPayment,
+        status: CashbackStatus.Nonexistent,
+        externalId: CASHBACK_EXTERNAL_ID_STUB1,
+        recipient: user,
+        amount: 123,
+        sender: distributor,
+        nonce: 1,
+      };
+      await proveTx(cashbackDistributor.grantRole(distributorRole, distributor.address));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(cashbackDistributor.grantRole(pauserRole, deployer.address));
+      await proveTx(cashbackDistributor.pause());
+      await expect(
+        cashbackDistributor.connect(cashback.sender).sendCashback(
+          cashback.token.address,
+          cashback.kind,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount
+        )
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the distributor role", async () => {
+      await expect(
+        cashbackDistributor.sendCashback(
+          cashback.token.address,
+          cashback.kind,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount
+        )
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, distributorRole));
+    });
+
+    it("Is reverted if the token address is zero", async () => {
+      await expect(
+        cashbackDistributor.connect(cashback.sender).sendCashback(
+          ethers.constants.AddressZero,
+          cashback.kind,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount
+        )
+      ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_TOKEN_ADDRESS_IS_ZERO);
+    });
+
+    it("Is reverted if the recipient address is zero", async () => {
+      await expect(
+        cashbackDistributor.connect(cashback.sender).sendCashback(
+          cashback.token.address,
+          cashback.kind,
+          cashback.externalId,
+          ethers.constants.AddressZero,
+          cashback.amount
+        )
+      ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_RECIPIENT_ADDRESS_IS_ZERO);
+    });
+
+    it("Is reverted if the cashback external ID is zero", async () => {
+      cashback.externalId = ethers.constants.HashZero;
+      await expect(
+        cashbackDistributor.connect(cashback.sender).sendCashback(
+          cashback.token.address,
+          cashback.kind,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount
+        )
+      ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_EXTERNAL_ID_IS_ZERO);
+    });
+
+    describe("Executes as expected and emits the correct event if the sending succeeds and", async () => {
+      let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
+
+      beforeEach(async () => {
+        cashback.token = await deployTokenMock();
+        cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks([cashback]);
+      });
+
+      async function checkSuccessfulCashbackSending() {
+        await proveTx(cashbackDistributor.enable());
+        cashback.status = CashbackStatus.Success;
+        await expect(
+          cashbackDistributor.connect(cashback.sender).sendCashback(
+            cashback.token.address,
+            cashback.kind,
+            cashback.externalId,
+            cashback.recipient.address,
+            cashback.amount
+          )
+        ).to.changeTokenBalances(
+          cashback.token,
+          [cashbackDistributor, cashback.recipient, cashback.sender],
+          [-cashback.amount, +cashback.amount, 0]
+        ).and.to.emit(
+          cashbackDistributor,
+          "SendCashback"
+        ).withArgs(
+          cashback.token.address,
+          cashback.kind,
+          cashback.status,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount,
+          cashback.sender.address,
+          cashback.nonce,
+        );
+        await checkCashbackDistributorState([cashback], cashbackDistributorInitialBalanceByToken);
+      }
+
+      it("The cashback amount is nonzero", async () => {
+        await checkSuccessfulCashbackSending();
+      });
+
+      it("The cashback amount is zero", async () => {
+        cashback.amount = 0;
+        await checkSuccessfulCashbackSending();
+      });
+    });
+
+    describe("Executes as expected and emits the correct event if the sending fails because", async () => {
+      let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
+
+      beforeEach(async () => {
+        cashback.token = await deployTokenMock();
+        cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks([cashback]);
+      });
+
+      async function checkUnsuccessfulCashbackSending() {
+        await expect(
+          cashbackDistributor.connect(cashback.sender).sendCashback(
+            cashback.token.address,
+            cashback.kind,
+            cashback.externalId,
+            cashback.recipient.address,
+            cashback.amount
+          )
+        ).to.changeTokenBalances(
+          cashback.token,
+          [cashbackDistributor, cashback.recipient, cashback.sender],
+          [0, 0, 0]
+        ).and.to.emit(
+          cashbackDistributor,
+          "SendCashback"
+        ).withArgs(
+          cashback.token.address,
+          cashback.kind,
+          cashback.status,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.amount,
+          cashback.sender.address,
+          cashback.nonce,
+        );
+        await checkCashbackDistributorState([cashback], cashbackDistributorInitialBalanceByToken);
+      }
+
+      it("Cashback operations are disabled", async () => {
+        cashback.status = CashbackStatus.Disabled;
+        await checkUnsuccessfulCashbackSending();
+      });
+
+      it("The cashback distributor contract has not enough balance", async () => {
+        await proveTx(cashbackDistributor.enable());
+        cashback.amount = cashback.amount + 1;
+        cashback.status = CashbackStatus.OutOfFunds;
+        await checkUnsuccessfulCashbackSending();
+      });
+
+      it("The cashback recipient is blacklisted", async () => {
+        await proveTx(cashbackDistributor.enable());
+        await proveTx(cashbackDistributor.grantRole(blacklisterRole, deployer.address));
+        await proveTx(cashbackDistributor.blacklist(cashback.recipient.address));
+        cashback.status = CashbackStatus.Blacklisted;
+        await checkUnsuccessfulCashbackSending();
+      });
+    });
+  });
+
+  describe("Function 'revokeCashback()'", async () => {
+    let cashback: TestCashback;
+
+    beforeEach(async () => {
+      cashback = {
+        token: tokenMockFactory.attach(TOKEN_ADDRESS_STUB),
+        kind: CashbackKind.CardPayment,
+        status: CashbackStatus.Nonexistent,
+        externalId: CASHBACK_EXTERNAL_ID_STUB1,
+        recipient: user,
+        amount: 123,
+        sender: distributor,
+        nonce: 1,
+        revokedAmount: 12,
+      };
+      await proveTx(cashbackDistributor.grantRole(distributorRole, distributor.address));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(cashbackDistributor.grantRole(pauserRole, deployer.address));
+      await proveTx(cashbackDistributor.pause());
+      await expect(
+        cashbackDistributor.connect(cashback.sender).revokeCashback(cashback.nonce, cashback.revokedAmount)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the distributor role", async () => {
+      await expect(
+        cashbackDistributor.revokeCashback(cashback.nonce, cashback.revokedAmount)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, distributorRole));
+    });
+
+    describe("Executes as expected and emits the correct event if the revocation succeeds and", async () => {
+      let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
+
+      beforeEach(async () => {
+        cashback.token = await deployTokenMock();
+        cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks([cashback]);
+      });
+
+      async function checkRevokingOfSuccessfulCashback() {
+        await proveTx(cashbackDistributor.enable());
+        await sendCashbacks([cashback], CashbackStatus.Success);
+        await proveTx(cashback.token.mint(cashback.sender.address, cashback.revokedAmount));
+        await proveTx(cashback.token.connect(cashback.sender).approve(
+          cashbackDistributor.address,
+          ethers.constants.MaxUint256
+        ));
+
+        await expect(
+          cashbackDistributor.connect(cashback.sender).revokeCashback(cashback.nonce, cashback.revokedAmount)
+        ).to.changeTokenBalances(
+          cashback.token,
+          [cashbackDistributor, cashback.recipient, cashback.sender],
+          [+(cashback.revokedAmount || 0), 0, -(cashback.revokedAmount || 0)]
+        ).and.to.emit(
+          cashbackDistributor,
+          "RevokeCashback"
+        ).withArgs(
+          cashback.token.address,
+          cashback.kind,
+          cashback.status,
+          RevocationStatus.Success,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.revokedAmount,
+          cashback.sender.address,
+          cashback.nonce,
+        );
+        await checkCashbackDistributorState([cashback], cashbackDistributorInitialBalanceByToken);
+      }
+
+      it("The revocation amount is less than the initial cashback amount", async () => {
+        await checkRevokingOfSuccessfulCashback();
+      });
+
+      it("The revocation amount equals the initial cashback amount", async () => {
+        cashback.revokedAmount = cashback.amount;
+        await checkRevokingOfSuccessfulCashback();
+      });
+
+      it("The revocation amount is zero", async () => {
+        cashback.revokedAmount = 0;
+        await checkRevokingOfSuccessfulCashback();
+      });
+    });
+
+    describe("Executes as expected and emits the correct event if the revocation fails because", async () => {
+      let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
+
+      beforeEach(async () => {
+        cashback.token = await deployTokenMock();
+        cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks([cashback]);
+      });
+
+      async function checkRevokingOfUnsuccessfulCashback(targetRevocationStatus: RevocationStatus) {
+        await expect(
+          cashbackDistributor.connect(cashback.sender).revokeCashback(cashback.nonce, cashback.revokedAmount)
+        ).to.changeTokenBalances(
+          cashback.token,
+          [cashbackDistributor, cashback.recipient, cashback.sender],
+          [0, 0, 0]
+        ).and.to.emit(
+          cashbackDistributor,
+          "RevokeCashback"
+        ).withArgs(
+          cashback.token.address,
+          cashback.kind,
+          cashback.status,
+          targetRevocationStatus,
+          cashback.externalId,
+          cashback.recipient.address,
+          cashback.revokedAmount,
+          cashback.sender.address,
+          cashback.nonce,
+        );
+        cashback.revokedAmount = 0;
+        await checkCashbackDistributorState([cashback], cashbackDistributorInitialBalanceByToken);
+      }
+
+      it("The caller has not enough tokens", async () => {
+        await proveTx(cashbackDistributor.enable());
+        await sendCashbacks([cashback], CashbackStatus.Success);
+        await proveTx(cashback.token.mint(cashback.sender.address, (cashback.revokedAmount || 0) - 1));
+        await proveTx(cashback.token.connect(cashback.sender).approve(
+          cashbackDistributor.address,
+          ethers.constants.MaxUint256
+        ));
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.OutOfFunds);
+      });
+
+      it("The cashback distributor has not enough allowance from the caller", async () => {
+        await proveTx(cashbackDistributor.enable());
+        await sendCashbacks([cashback], CashbackStatus.Success);
+        await proveTx(cashback.token.mint(cashback.sender.address, cashback.revokedAmount));
+        await proveTx(cashback.token.connect(cashback.sender).approve(
+          cashbackDistributor.address,
+          (cashback.revokedAmount || 0) - 1
+        ));
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.OutOfAllowance);
+      });
+
+      it("Cashback operations were disabled prior cashback sending", async () => {
+        await sendCashbacks([cashback], CashbackStatus.Disabled);
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.Inapplicable);
+      });
+
+      it("The cashback distributor had not enough balance prior cashback sending", async () => {
+        await proveTx(cashbackDistributor.enable());
+        cashback.amount = cashback.amount + 1;
+        await sendCashbacks([cashback], CashbackStatus.OutOfFunds);
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.Inapplicable);
+      });
+
+      it("The cashback recipient was blacklisted prior cashback sending", async () => {
+        await proveTx(cashbackDistributor.enable());
+        await proveTx(cashbackDistributor.grantRole(blacklisterRole, deployer.address));
+        await proveTx(cashbackDistributor.blacklist(cashback.recipient.address));
+        await sendCashbacks([cashback], CashbackStatus.Blacklisted);
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.Inapplicable);
+      });
+
+      it("The initial cashback amount is less than revocation amount", async () => {
+        await proveTx(cashbackDistributor.enable());
+        await sendCashbacks([cashback], CashbackStatus.Success);
+        await proveTx(cashback.token.mint(cashback.sender.address, cashback.amount + 1));
+        await proveTx(cashback.token.connect(cashback.sender).approve(
+          cashbackDistributor.address,
+          ethers.constants.MaxUint256
+        ));
+        cashback.revokedAmount = cashback.amount + 1;
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.OutOfBalance);
+      });
+    });
+  });
+
+  describe("Getter functions 'getCashbackNonces()' and 'getCashbacks()'", async () => {
+    let cashbacks: TestCashback[];
+    let cashbackNonces: BigNumber[];
+
+    beforeEach(async () => {
+      const tokenMock: Contract = await deployTokenMock();
+      cashbacks = [1, 2, 3].map(nonceValue => {
+        return {
+          token: tokenMock,
+          kind: CashbackKind.CardPayment,
+          status: CashbackStatus.Nonexistent,
+          externalId: CASHBACK_EXTERNAL_ID_STUB1,
+          recipient: user,
+          amount: 100 + nonceValue,
+          sender: distributor,
+          nonce: nonceValue,
+        };
+      });
+      cashbackNonces = cashbacks.map(cashback => BigNumber.from(cashback.nonce));
+      await proveTx(cashbackDistributor.grantRole(distributorRole, distributor.address));
+    });
+
+    it("Execute as expected", async () => {
+      await proveTx(cashbackDistributor.enable());
+      await setUpContractsForSendingCashbacks(cashbacks);
+      await sendCashbacks(cashbacks, CashbackStatus.Success);
+
+      // Check existing cashbacks
+      let actualCashbacks: any[] = await cashbackDistributor.getCashbacks(cashbackNonces);
+      expect(actualCashbacks.length).to.equal(cashbacks.length);
+      cashbacks.forEach(cashback => {
+        checkEquality(actualCashbacks[cashback.nonce - 1], cashback);
+      });
+
+      // Check nonexistent cashbacks
+      const nonceAfterExistingCashbacks: number = cashbacks.length + 1;
+      actualCashbacks = await cashbackDistributor.getCashbacks([0, nonceAfterExistingCashbacks]);
+      expect(actualCashbacks.length).to.equal(2);
+      checkNonexistentCashback(actualCashbacks[0], 0);
+      checkNonexistentCashback(actualCashbacks[1], nonceAfterExistingCashbacks);
+
+      // Check getting of cashback nonces in different cases
+      let actualNonces: BigNumber[];
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 0, 50);
+      expect(actualNonces).to.be.deep.equal(cashbackNonces);
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 0, 2);
+      expect(actualNonces).to.be.deep.equal([cashbackNonces[0], cashbackNonces[1]]);
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 1, 2);
+      expect(actualNonces).to.be.deep.equal([cashbackNonces[1], cashbackNonces[2]]);
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 1, 1);
+      expect(actualNonces).to.be.deep.equal([cashbackNonces[1]]);
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 1, 50);
+      expect(actualNonces).to.be.deep.equal([cashbackNonces[1], cashbackNonces[2]]);
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 3, 50);
+      expect(actualNonces).to.be.deep.equal([]);
+
+      actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 1, 0);
+      expect(actualNonces).to.be.deep.equal([]);
+    });
+  });
+
+  describe("Complex scenario", async () => {
+    let tokenMock1: Contract;
+    let tokenMock2: Contract;
+    let cashbacks: TestCashback[];
+    let begNonce: number;
+    let endNonce: number;
+    let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
+
+    beforeEach(async () => {
+      tokenMock1 = await deployTokenMock("TEST1");
+      tokenMock2 = await deployTokenMock("TEST2");
+
+      cashbacks = [1, 2, 3, 4, 5, 6, 7, 8].map(nonce => {
+        return {
+          token: [tokenMock2, tokenMock1][(nonce >> 0) & 1],
+          kind: CashbackKind.CardPayment,
+          status: CashbackStatus.Nonexistent,
+          externalId: [CASHBACK_EXTERNAL_ID_STUB1, CASHBACK_EXTERNAL_ID_STUB2][(nonce >> 1) & 1],
+          recipient: [user, deployer][(nonce >> 2) & 1],
+          amount: 100 + nonce,
+          sender: distributor,
+          nonce: nonce,
+        };
+      });
+      begNonce = cashbacks[0].nonce;
+      endNonce = cashbacks[cashbacks.length - 1].nonce + 1;
+      await proveTx(cashbackDistributor.grantRole(distributorRole, distributor.address));
+      cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks(cashbacks);
+    });
+
+    async function revokeCashback(cashback: TestCashback) {
+      await proveTx(cashback.token.mint(cashback.sender.address, cashback.revokedAmount || 0));
+      await proveTx(
+        cashback.token.connect(cashback.sender).approve(cashbackDistributor.address, cashback.revokedAmount || 0)
+      );
+      await proveTx(
+        cashbackDistributor.connect(cashback.sender).revokeCashback(cashback.nonce, cashback.revokedAmount || 0)
+      );
+    }
+
+    it("Execute as expected", async () => {
+      await proveTx(cashbackDistributor.enable());
+      await sendCashbacks(cashbacks, CashbackStatus.Success);
+      await checkCashbackDistributorState(cashbacks, cashbackDistributorInitialBalanceByToken);
+
+      await revokeCashback(cashbacks[3]);
+      await checkCashbackDistributorState(cashbacks, cashbackDistributorInitialBalanceByToken);
+
+      await revokeCashback(cashbacks[0]);
+      await checkCashbackDistributorState(cashbacks, cashbackDistributorInitialBalanceByToken);
+
+      await revokeCashback(cashbacks[1]);
+      await checkCashbackDistributorState(cashbacks, cashbackDistributorInitialBalanceByToken);
+    });
+  });
+});

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -1,12 +1,66 @@
 import { ethers } from "hardhat";
 import { expect } from "chai";
-import { Contract, ContractFactory } from "ethers";
+import { BigNumber, Contract, ContractFactory } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
 import { proveTx } from "../test-utils/eth";
-import { createRevertMessageDueToMissingRole } from "../test-utils/misc";
+import { countNumberArrayTotal, createRevertMessageDueToMissingRole } from "../test-utils/misc";
+
+enum CashOutStatus {
+  Nonexistent = 0,
+  Pending = 1,
+  Reversed = 2,
+  Confirmed = 3,
+}
+
+interface TestCashOut {
+  account: SignerWithAddress;
+  amount: number;
+  txId: string;
+  status: CashOutStatus;
+}
+
+interface PixCashierState {
+  tokenBalance: number;
+  pendingCashOutCounter: number;
+  processedCashOutCounter: number;
+  pendingCashOutTxIds: string[];
+  cashOutBalancePerAccount: Map<string, number>;
+}
+
+function checkEquality(
+  actualOnChainCashOut: any,
+  expectedCashOut: TestCashOut,
+  cashOutIndex: number
+) {
+  if (expectedCashOut.status == CashOutStatus.Nonexistent) {
+    expect(actualOnChainCashOut.account).to.equal(
+      ethers.constants.AddressZero,
+      `cashOuts[${cashOutIndex}].account is incorrect`
+    );
+    expect(actualOnChainCashOut.amount).to.equal(
+      0,
+      `cashOuts[${cashOutIndex}].amount is incorrect`
+    );
+  } else {
+    expect(actualOnChainCashOut.account).to.equal(
+      expectedCashOut.account.address,
+      `cashOuts[${cashOutIndex}].account is incorrect`
+    );
+    expect(actualOnChainCashOut.amount).to.equal(
+      expectedCashOut.amount,
+      `cashOuts[${cashOutIndex}].amount is incorrect`
+    );
+    expect(actualOnChainCashOut.status).to.equal(
+      expectedCashOut.status,
+      `cashOut[${cashOutIndex}].status is incorrect`
+    );
+  }
+}
 
 describe("Contract 'PixCashier'", async () => {
-  const TRANSACTION_ID = ethers.utils.formatBytes32String("MOCK_TRANSACTION_ID");
+  const TRANSACTION_ID1 = ethers.utils.formatBytes32String("MOCK_TRANSACTION_ID1");
+  const TRANSACTION_ID2 = ethers.utils.formatBytes32String("MOCK_TRANSACTION_ID2");
+  const TRANSACTION_ID3 = ethers.utils.formatBytes32String("MOCK_TRANSACTION_ID3");
 
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
   const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
@@ -17,7 +71,9 @@ describe("Contract 'PixCashier'", async () => {
   const REVERT_ERROR_IF_ACCOUNT_IS_ZERO = "ZeroAccount";
   const REVERT_ERROR_IF_AMOUNT_IS_ZERO = "ZeroAmount";
   const REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO = "ZeroTxId";
-  const REVERT_ERROR_IF_BALANCE_IS_INSUFFICIENT = "InsufficientCashOutBalance";
+  const REVERT_ERROR_IF_TOKEN_MINTING_FAILURE = "TokenMintingFailure";
+  const REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS = "InappropriateCashOutStatus";
+  const REVERT_ERROR_IF_EMPTY_TRANSACTION_IDS_ARRAY = "EmptyTransactionIdsArray";
 
   let PixCashier: ContractFactory;
   let pixCashier: Contract;
@@ -55,6 +111,119 @@ describe("Contract 'PixCashier'", async () => {
     cashierRole = (await pixCashier.CASHIER_ROLE()).toLowerCase();
   });
 
+  async function setUpContractsForCashOuts(cashOuts: TestCashOut[]) {
+    for (let cashOut of cashOuts) {
+      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
+      const allowance: BigNumber = await tokenMock.allowance(cashOut.account.address, pixCashier.address);
+      if (allowance.lt(BigNumber.from(ethers.constants.MaxUint256))) {
+        await proveTx(
+          tokenMock.connect(cashOut.account).approve(
+            pixCashier.address,
+            ethers.constants.MaxUint256
+          )
+        );
+      }
+    }
+  }
+
+  async function requestCashOuts(cashOuts: TestCashOut[]) {
+    for (let cashOut of cashOuts) {
+      await proveTx(
+        pixCashier.connect(cashOut.account).requestCashOut(
+          cashOut.amount,
+          cashOut.txId
+        )
+      );
+      cashOut.status = CashOutStatus.Pending;
+    }
+  }
+
+  function defineExpectedPixCashierState(cashOuts: TestCashOut[]): PixCashierState {
+    let tokenBalance: number = 0;
+    let pendingCashOutCounter: number = 0;
+    let processedCashOutCounter: number = 0;
+    const pendingCashOutTxIds: string[] = [];
+    const cashOutBalancePerAccount: Map<string, number> = new Map<string, number>();
+
+    for (let cashOut of cashOuts) {
+      let newCashOutBalance: number = cashOutBalancePerAccount.get(cashOut.account.address) || 0;
+      if (cashOut.status == CashOutStatus.Pending) {
+        pendingCashOutTxIds.push(cashOut.txId);
+        ++pendingCashOutCounter;
+        tokenBalance += cashOut.amount;
+        newCashOutBalance += cashOut.amount;
+      }
+      cashOutBalancePerAccount.set(cashOut.account.address, newCashOutBalance);
+      if (cashOut.status == CashOutStatus.Reversed || cashOut.status == CashOutStatus.Confirmed) {
+        ++processedCashOutCounter;
+      }
+    }
+
+    return {
+      tokenBalance,
+      pendingCashOutCounter,
+      processedCashOutCounter,
+      pendingCashOutTxIds,
+      cashOutBalancePerAccount,
+    };
+  }
+
+  async function checkCashOutStructuresOnBlockchain(cashOuts: TestCashOut[]) {
+    const txIds: string[] = cashOuts.map(cashOut => cashOut.txId);
+    const actualCashOuts: any[] = await pixCashier.getCashOuts(txIds);
+    for (let i = 0; i < cashOuts.length; ++i) {
+      const cashOut: TestCashOut = cashOuts[i];
+      const actualCashOut: any = await pixCashier.getCashOut(cashOut.txId);
+      checkEquality(actualCashOut, cashOut, i);
+      checkEquality(actualCashOuts[i], cashOut, i);
+    }
+  }
+
+  async function checkPixCashierState(cashOuts: TestCashOut[], expectedProcessedCashOutCounter?: number) {
+    const expectedState: PixCashierState = defineExpectedPixCashierState(cashOuts);
+    await checkCashOutStructuresOnBlockchain(cashOuts);
+
+    expect(
+      await tokenMock.balanceOf(pixCashier.address)
+    ).to.equal(
+      expectedState.tokenBalance,
+      `The PIX cashier total balance is wrong`
+    );
+
+    const actualPendingCashOutCounter = await pixCashier.pendingCashOutCounter();
+    expect(actualPendingCashOutCounter).to.equal(
+      expectedState.pendingCashOutCounter,
+      `The pending cash-out counter is wrong`
+    );
+
+    if (!expectedProcessedCashOutCounter) {
+      expectedProcessedCashOutCounter = expectedState.processedCashOutCounter;
+    }
+    expect(await pixCashier.processedCashOutCounter()).to.equal(
+      expectedProcessedCashOutCounter,
+      `The processed cash-out counter is wrong`
+    );
+
+    let actualPendingCashOutTxIds: string[] = await pixCashier.getPendingCashOutTxIds(0, actualPendingCashOutCounter);
+    expect(actualPendingCashOutTxIds).to.deep.equal(
+      expectedState.pendingCashOutTxIds,
+      `The pending cash-out tx ids are wrong`
+    );
+
+    for (const account of expectedState.cashOutBalancePerAccount.keys()) {
+      const expectedCashOutBalance = expectedState.cashOutBalancePerAccount.get(account);
+      if (!expectedCashOutBalance) {
+        continue;
+      }
+      expect(
+        await pixCashier.cashOutBalanceOf(account)
+      ).to.equal(
+        expectedCashOutBalance,
+        `The cash-out balance for account ${account} is wrong`
+      );
+    }
+  }
+
   it("The initialize function can't be called more than once", async () => {
     await expect(
       pixCashier.initialize(tokenMock.address)
@@ -89,6 +258,11 @@ describe("Contract 'PixCashier'", async () => {
 
     // The initial contract state is unpaused
     expect(await pixCashier.paused()).to.equal(false);
+
+    // The initial values of counters and pending cash-outs
+    expect(await pixCashier.pendingCashOutCounter()).to.equal(0);
+    expect(await pixCashier.processedCashOutCounter()).to.equal(0);
+    expect(await pixCashier.getPendingCashOutTxIds(0, 1)).to.be.empty;
   });
 
   describe("Function 'cashIn()'", async () => {
@@ -102,25 +276,25 @@ describe("Contract 'PixCashier'", async () => {
       await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
       await proveTx(pixCashier.pause());
       await expect(
-        pixCashier.connect(cashier).cashIn(user.address, tokenAmount, TRANSACTION_ID)
+        pixCashier.connect(cashier).cashIn(user.address, tokenAmount, TRANSACTION_ID1)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the cashier role", async () => {
       await expect(
-        pixCashier.connect(deployer).cashIn(user.address, tokenAmount, TRANSACTION_ID)
+        pixCashier.connect(deployer).cashIn(user.address, tokenAmount, TRANSACTION_ID1)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
     });
 
     it("Is reverted if the account address is zero", async () => {
       await expect(
-        pixCashier.connect(cashier).cashIn(ethers.constants.AddressZero, tokenAmount, TRANSACTION_ID)
+        pixCashier.connect(cashier).cashIn(ethers.constants.AddressZero, tokenAmount, TRANSACTION_ID1)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_ZERO);
     });
 
     it("Is reverted if the token amount is zero", async () => {
       await expect(
-        pixCashier.connect(cashier).cashIn(user.address, 0, TRANSACTION_ID)
+        pixCashier.connect(cashier).cashIn(user.address, 0, TRANSACTION_ID1)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_AMOUNT_IS_ZERO);
     });
 
@@ -130,9 +304,16 @@ describe("Contract 'PixCashier'", async () => {
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
     });
 
+    it("Is reverted if minting function returns 'false'", async () => {
+      await proveTx(tokenMock.setMintResult(false));
+      await expect(
+        pixCashier.connect(cashier).cashIn(user.address, tokenAmount, TRANSACTION_ID1)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TOKEN_MINTING_FAILURE);
+    });
+
     it("Mints correct amount of tokens and emits the correct event", async () => {
       await expect(
-        pixCashier.connect(cashier).cashIn(user.address, tokenAmount, TRANSACTION_ID)
+        pixCashier.connect(cashier).cashIn(user.address, tokenAmount, TRANSACTION_ID1)
       ).to.changeTokenBalances(
         tokenMock,
         [user, pixCashier],
@@ -143,232 +324,669 @@ describe("Contract 'PixCashier'", async () => {
       ).withArgs(
         user.address,
         tokenAmount,
-        TRANSACTION_ID
+        TRANSACTION_ID1
       );
     });
   });
 
-  describe("Function 'cashOut()'", async () => {
-    const tokenAmount: number = 100;
+  describe("Function 'requestCashOut()'", async () => {
+    let cashOut: TestCashOut;
 
     beforeEach(async () => {
-      await proveTx(tokenMock.connect(user).approve(pixCashier.address, ethers.constants.MaxUint256));
+      cashOut = {
+        account: user,
+        amount: 100,
+        txId: TRANSACTION_ID1,
+        status: CashOutStatus.Nonexistent,
+      };
+      await proveTx(tokenMock.connect(cashOut.account).approve(pixCashier.address, ethers.constants.MaxUint256));
     });
 
     it("Is reverted if the contract is paused", async () => {
       await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
       await proveTx(pixCashier.pause());
       await expect(
-        pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID)
+        pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller is blacklisted", async () => {
       await proveTx(pixCashier.grantRole(blacklisterRole, deployer.address));
-      await proveTx(pixCashier.blacklist(user.address));
+      await proveTx(pixCashier.blacklist(cashOut.account.address));
       await expect(
-        pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID)
+        pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
     });
 
     it("Is reverted if the token amount is zero", async () => {
       await expect(
-        pixCashier.connect(user).cashOut(0, TRANSACTION_ID)
+        pixCashier.connect(cashOut.account).requestCashOut(0, cashOut.txId)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_AMOUNT_IS_ZERO);
     });
 
     it("Is reverted if the off-chain transaction ID is zero", async () => {
-      await proveTx(tokenMock.mint(user.address, tokenAmount));
       await expect(
-        pixCashier.connect(user).cashOut(tokenAmount, ethers.constants.HashZero)
+        pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, ethers.constants.HashZero)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
     });
 
     it("Is reverted if the user has not enough tokens", async () => {
-      await proveTx(tokenMock.mint(user.address, tokenAmount - 1));
-      await expect(pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID))
-        .to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount - 1));
+      await expect(
+        pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
 
     it("Transfers tokens as expected, emits the correct event, changes cash-out balances accordingly", async () => {
-      await proveTx(tokenMock.mint(user.address, tokenAmount));
-      const oldCashOutBalance: number = await pixCashier.cashOutBalanceOf(user.address);
+      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
+      await checkPixCashierState([cashOut]);
       await expect(
-        pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID)
+        pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId)
       ).to.changeTokenBalances(
         tokenMock,
-        [user, pixCashier],
-        [-tokenAmount, +tokenAmount]
+        [cashOut.account, pixCashier],
+        [-cashOut.amount, +cashOut.amount]
       ).and.to.emit(
         pixCashier,
-        "CashOut"
+        "RequestCashOut"
       ).withArgs(
-        user.address,
-        tokenAmount,
-        tokenAmount,
-        TRANSACTION_ID
+        cashOut.account.address,
+        cashOut.amount,
+        cashOut.amount,
+        cashOut.txId,
+        cashOut.account.address
       );
-      const newCashOutBalance: number = await pixCashier.cashOutBalanceOf(user.address);
-      expect(newCashOutBalance - oldCashOutBalance).to.equal(tokenAmount);
+      cashOut.status = CashOutStatus.Pending;
+      await checkPixCashierState([cashOut]);
+    });
+
+    it("Is reverted if the cash-out with the provided txId is already pending", async () => {
+      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
+      await pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId);
+      expect(
+        pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId)
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Pending);
     });
   });
 
-  describe("Function 'cashOutConfirm()'", async () => {
-    const tokenAmount: number = 100;
+  describe("Function 'requestCashOutFrom()'", async () => {
+    let cashOut: TestCashOut;
 
     beforeEach(async () => {
-      await proveTx(tokenMock.connect(user).approve(pixCashier.address, ethers.constants.MaxUint256));
-      await proveTx(tokenMock.mint(user.address, tokenAmount));
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
-      await proveTx(pixCashier.pause());
-      await expect(
-        pixCashier.connect(user).cashOutConfirm(tokenAmount, TRANSACTION_ID)
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller is blacklisted", async () => {
-      await proveTx(pixCashier.grantRole(blacklisterRole, deployer.address));
-      await proveTx(pixCashier.blacklist(user.address));
-      await expect(
-        pixCashier.connect(user).cashOutConfirm(tokenAmount, TRANSACTION_ID)
-      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
-    });
-
-    it("Is reverted if the token amount is zero", async () => {
-      await expect(
-        pixCashier.connect(user).cashOutConfirm(0, TRANSACTION_ID)
-      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_AMOUNT_IS_ZERO);
-    });
-
-    it("Is reverted if the off-chain transaction ID is zero", async () => {
-      await proveTx(pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID));
-      await expect(
-        pixCashier.connect(user).cashOutConfirm(tokenAmount, ethers.constants.HashZero)
-      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
-    });
-
-    it("Is reverted if the user's cash-out balance is not enough", async () => {
-      await proveTx(pixCashier.connect(user).cashOut(tokenAmount - 1, TRANSACTION_ID));
-      await expect(
-        pixCashier.connect(user).cashOutConfirm(tokenAmount, TRANSACTION_ID)
-      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_BALANCE_IS_INSUFFICIENT);
-    });
-
-    it("Burns tokens as expected, emits the correct event, changes cash-out balances accordingly", async () => {
-      await proveTx(pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID));
-      const oldCashOutBalance: number = await pixCashier.cashOutBalanceOf(user.address);
-      await expect(
-        pixCashier.connect(user).cashOutConfirm(tokenAmount, TRANSACTION_ID)
-      ).to.changeTokenBalances(
-        tokenMock,
-        [pixCashier, user],
-        [-tokenAmount, 0]
-      ).and.to.emit(
-        pixCashier,
-        "CashOutConfirm"
-      ).withArgs(
-        user.address,
-        tokenAmount,
-        0,
-        TRANSACTION_ID
-      );
-      const newCashOutBalance: number = await pixCashier.cashOutBalanceOf(user.address);
-      expect(newCashOutBalance - oldCashOutBalance).to.equal(-tokenAmount);
-    });
-  });
-
-  describe("Function 'cashOutReverse()'", async () => {
-    const tokenAmount: number = 100;
-
-    beforeEach(async () => {
-      await proveTx(tokenMock.connect(user).approve(pixCashier.address, ethers.constants.MaxUint256));
-      await proveTx(tokenMock.mint(user.address, tokenAmount));
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
-      await proveTx(pixCashier.pause());
-      await expect(
-        pixCashier.connect(user).cashOutReverse(tokenAmount, TRANSACTION_ID)
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller is blacklisted", async () => {
-      await proveTx(pixCashier.grantRole(blacklisterRole, deployer.address));
-      await proveTx(pixCashier.blacklist(user.address));
-      await expect(
-        pixCashier.connect(user).cashOutReverse(tokenAmount, TRANSACTION_ID)
-      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
-    });
-
-    it("Is reverted if the token amount is zero", async () => {
-      await expect(
-        pixCashier.connect(user).cashOutReverse(0, TRANSACTION_ID)
-      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_AMOUNT_IS_ZERO);
-    });
-
-    it("Is reverted if the off-chain transaction ID is zero", async () => {
-      await proveTx(pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID));
-      await expect(
-        pixCashier.connect(user).cashOutReverse(tokenAmount, ethers.constants.HashZero)
-      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
-    });
-
-    it("Is reverted if the user's cash-out balance is not enough", async () => {
-      await proveTx(pixCashier.connect(user).cashOut(tokenAmount - 1, TRANSACTION_ID));
-      await expect(
-        pixCashier.connect(user).cashOutReverse(tokenAmount, TRANSACTION_ID)
-      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_BALANCE_IS_INSUFFICIENT);
-    });
-
-    it("Transfers tokens as expected, emits the correct event, changes cash-out balances accordingly", async () => {
-      await proveTx(pixCashier.connect(user).cashOut(tokenAmount, TRANSACTION_ID));
-      const oldCashOutBalance: number = await pixCashier.cashOutBalanceOf(user.address);
-      await expect(
-        pixCashier.connect(user).cashOutReverse(tokenAmount, TRANSACTION_ID)
-      ).to.changeTokenBalances(
-        tokenMock,
-        [user, pixCashier],
-        [+tokenAmount, -tokenAmount]
-      ).and.to.emit(
-        pixCashier,
-        "CashOutReverse"
-      ).withArgs(
-        user.address,
-        tokenAmount,
-        0,
-        TRANSACTION_ID
-      );
-      const newCashOutBalance: number = await pixCashier.cashOutBalanceOf(user.address);
-      expect(newCashOutBalance - oldCashOutBalance).to.equal(-tokenAmount);
-    });
-  });
-
-  describe("Complex scenario", async () => {
-    const cashInTokenAmount: number = 100;
-    const cashOutTokenAmount: number = 80;
-    const cashOutReverseTokenAmount: number = 20;
-    const cashOutConfirmTokenAmount: number = 50;
-    const userFinalTokenBalance: number = cashInTokenAmount - cashOutTokenAmount + cashOutReverseTokenAmount;
-    const userFinalCashOutBalance: number =
-      cashOutTokenAmount - cashOutReverseTokenAmount - cashOutConfirmTokenAmount;
-
-    beforeEach(async () => {
-      await proveTx(tokenMock.connect(user).approve(pixCashier.address, ethers.constants.MaxUint256));
-    });
-
-    it("Leads to correct balances when using several functions", async () => {
+      cashOut = {
+        account: user,
+        amount: 200,
+        txId: TRANSACTION_ID1,
+        status: CashOutStatus.Nonexistent,
+      };
+      await proveTx(tokenMock.connect(cashOut.account).approve(pixCashier.address, ethers.constants.MaxUint256));
       await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
-      await proveTx(pixCashier.connect(cashier).cashIn(user.address, cashInTokenAmount, TRANSACTION_ID));
-      await proveTx(pixCashier.connect(user).cashOut(cashOutTokenAmount, TRANSACTION_ID));
-      await proveTx(pixCashier.connect(user).cashOutReverse(cashOutReverseTokenAmount, TRANSACTION_ID));
-      await proveTx(pixCashier.connect(user).cashOutConfirm(cashOutConfirmTokenAmount, TRANSACTION_ID));
-      expect(await tokenMock.balanceOf(user.address)).to.equal(userFinalTokenBalance);
-      expect(await pixCashier.cashOutBalanceOf(user.address)).to.equal(userFinalCashOutBalance);
-      expect(await tokenMock.balanceOf(pixCashier.address)).to.equal(userFinalCashOutBalance);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the cashier role", async () => {
+      await expect(
+        pixCashier.connect(deployer).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
+    });
+
+    it("Is reverted if the account address is zero", async () => {
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFrom(ethers.constants.AddressZero, cashOut.amount, cashOut.txId)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_ZERO);
+    });
+
+    it("Is reverted if the token amount is zero", async () => {
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, 0, cashOut.txId)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_AMOUNT_IS_ZERO);
+    });
+
+    it("Is reverted if the off-chain transaction ID is zero", async () => {
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFrom(
+          cashOut.account.address,
+          cashOut.amount,
+          ethers.constants.HashZero
+        )
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the cash-out with the provided txId is already pending", async () => {
+      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
+      await pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId);
+      expect(
+        pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId)
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Pending);
+    });
+
+    it("Is reverted if the user has not enough tokens", async () => {
+      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount - 1));
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfers tokens as expected, emits the correct event, changes cash-out balances accordingly", async () => {
+      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
+      await checkPixCashierState([cashOut]);
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [cashOut.account, pixCashier, cashier],
+        [-cashOut.amount, +cashOut.amount, 0]
+      ).and.to.emit(
+        pixCashier,
+        "RequestCashOut"
+      ).withArgs(
+        cashOut.account.address,
+        cashOut.amount,
+        cashOut.amount,
+        cashOut.txId,
+        cashier.address
+      );
+      cashOut.status = CashOutStatus.Pending;
+      await checkPixCashierState([cashOut]);
+    });
+  });
+
+  describe("Function 'confirmCashOut()'", async () => {
+    let cashOut: TestCashOut;
+
+    beforeEach(async () => {
+      cashOut = {
+        account: user,
+        amount: 100,
+        txId: TRANSACTION_ID1,
+        status: CashOutStatus.Nonexistent,
+      };
+      await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
+      await setUpContractsForCashOuts([cashOut]);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(
+        pixCashier.connect(cashier).confirmCashOut(cashOut.txId)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the cashier role", async () => {
+      await expect(
+        pixCashier.connect(deployer).confirmCashOut(cashOut.txId)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
+    });
+
+    it("Is reverted if the off-chain transaction ID is zero", async () => {
+      await expect(
+        pixCashier.connect(cashier).confirmCashOut(ethers.constants.HashZero)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the cash-out with the provided txId was not requested previously", async () => {
+      await expect(
+        pixCashier.connect(cashier).confirmCashOut(cashOut.txId)
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Nonexistent);
+    });
+
+    it("Burns tokens as expected, emits the correct event, changes the contract state accordingly", async () => {
+      await proveTx(pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId));
+      cashOut.status = CashOutStatus.Pending;
+      await checkPixCashierState([cashOut]);
+      await expect(
+        pixCashier.connect(cashier).confirmCashOut(cashOut.txId)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [pixCashier, cashOut.account],
+        [-cashOut.amount, 0]
+      ).and.to.emit(
+        pixCashier,
+        "ConfirmCashOut"
+      ).withArgs(
+        cashOut.account.address,
+        cashOut.amount,
+        0,
+        cashOut.txId
+      );
+      cashOut.status = CashOutStatus.Confirmed;
+      await checkPixCashierState([cashOut]);
+    });
+  });
+
+  describe("Function 'confirmCashOuts()'", async () => {
+    let cashOuts: TestCashOut[];
+    let txIds: string[];
+
+    beforeEach(async () => {
+      cashOuts = [
+        {
+          account: user,
+          amount: 100,
+          txId: TRANSACTION_ID1,
+          status: CashOutStatus.Nonexistent,
+        },
+        {
+          account: deployer,
+          amount: 200,
+          txId: TRANSACTION_ID2,
+          status: CashOutStatus.Nonexistent,
+        },
+      ];
+      txIds = cashOuts.map(cashOut => cashOut.txId);
+      await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
+      await setUpContractsForCashOuts(cashOuts);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(
+        pixCashier.connect(cashier).confirmCashOuts(txIds)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the cashier role", async () => {
+      await expect(
+        pixCashier.connect(deployer).confirmCashOuts(txIds)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
+    });
+
+    it("Is reverted if the off-chain transaction IDs array is empty", async () => {
+      await expect(
+        pixCashier.connect(cashier).confirmCashOuts([])
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_EMPTY_TRANSACTION_IDS_ARRAY);
+    });
+
+    it("Burns tokens as expected, emits the correct event, changes the contract state accordingly", async () => {
+      await requestCashOuts(cashOuts);
+      await checkPixCashierState(cashOuts);
+      const totalTokens = countNumberArrayTotal(cashOuts.map(cashOut => cashOut.amount));
+      await expect(
+        pixCashier.connect(cashier).confirmCashOuts(txIds)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [pixCashier, ...cashOuts.map(cashOut => cashOut.account)],
+        [-totalTokens, ...cashOuts.map(() => 0)]
+      ).and.to.emit(
+        pixCashier,
+        "ConfirmCashOut"
+      ).withArgs(
+        cashOuts[0].account.address,
+        cashOuts[0].amount,
+        0,
+        cashOuts[0].txId
+      ).and.to.emit(
+        pixCashier,
+        "ConfirmCashOut"
+      ).withArgs(
+        cashOuts[1].account.address,
+        cashOuts[1].amount,
+        0,
+        cashOuts[1].txId
+      );
+      cashOuts.forEach(cashOut => cashOut.status = CashOutStatus.Confirmed);
+      await checkPixCashierState(cashOuts);
+    });
+
+    it("Is reverted if one of the off-chain transaction IDs is zero", async () => {
+      await requestCashOuts(cashOuts);
+      txIds[txIds.length - 1] = ethers.constants.HashZero;
+      await expect(
+        pixCashier.connect(cashier).confirmCashOuts(txIds)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if one of the cash-outs was not requested previously", async () => {
+      await requestCashOuts(cashOuts);
+      txIds[txIds.length - 1] = TRANSACTION_ID3;
+      await expect(
+        pixCashier.connect(cashier).confirmCashOuts(txIds)
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(TRANSACTION_ID3, CashOutStatus.Nonexistent);
+    });
+  });
+
+  describe("Function 'reverseCashOut()'", async () => {
+    let cashOut: TestCashOut;
+
+    beforeEach(async () => {
+      cashOut = {
+        account: user,
+        amount: 100,
+        txId: TRANSACTION_ID1,
+        status: CashOutStatus.Nonexistent,
+      };
+      await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
+      await setUpContractsForCashOuts([cashOut]);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(
+        pixCashier.connect(cashier).reverseCashOut(cashOut.txId)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the cashier role", async () => {
+      await expect(
+        pixCashier.connect(deployer).reverseCashOut(cashOut.txId)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
+    });
+
+    it("Is reverted if the off-chain transaction ID is zero", async () => {
+      await expect(
+        pixCashier.connect(cashier).reverseCashOut(ethers.constants.HashZero)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the cash-out with the provided txId was not requested previously", async () => {
+      await expect(
+        pixCashier.connect(cashier).reverseCashOut(cashOut.txId)
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Nonexistent);
+    });
+
+    it("Transfers tokens as expected, emits the correct event, changes the contract state accordingly", async () => {
+      await proveTx(pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId));
+      cashOut.status = CashOutStatus.Pending;
+      await checkPixCashierState([cashOut]);
+      await expect(
+        pixCashier.connect(cashier).reverseCashOut(cashOut.txId)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [cashOut.account, pixCashier, cashier],
+        [+cashOut.amount, -cashOut.amount, 0]
+      ).and.to.emit(
+        pixCashier,
+        "ReverseCashOut"
+      ).withArgs(
+        cashOut.account.address,
+        cashOut.amount,
+        0,
+        cashOut.txId
+      );
+      cashOut.status = CashOutStatus.Reversed;
+      await checkPixCashierState([cashOut]);
+    });
+  });
+
+  describe("Function 'reverseCashOuts()'", async () => {
+    let cashOuts: TestCashOut[];
+    let txIds: string[];
+
+    beforeEach(async () => {
+      cashOuts = [
+        {
+          account: user,
+          amount: 123,
+          txId: TRANSACTION_ID1,
+          status: CashOutStatus.Nonexistent,
+        },
+        {
+          account: deployer,
+          amount: 456,
+          txId: TRANSACTION_ID2,
+          status: CashOutStatus.Nonexistent,
+        },
+      ];
+      txIds = cashOuts.map(cashOut => cashOut.txId);
+      await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
+      await setUpContractsForCashOuts(cashOuts);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(
+        pixCashier.connect(cashier).reverseCashOuts(txIds)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the cashier role", async () => {
+      await expect(
+        pixCashier.connect(deployer).reverseCashOuts(txIds)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
+    });
+
+    it("Is reverted if the off-chain transaction IDs array is empty", async () => {
+      await expect(
+        pixCashier.connect(cashier).reverseCashOuts([])
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_EMPTY_TRANSACTION_IDS_ARRAY);
+    });
+
+    it("Transfers tokens as expected, emits the correct event, changes the contract state accordingly", async () => {
+      await requestCashOuts(cashOuts);
+      await checkPixCashierState(cashOuts);
+      const totalTokens = countNumberArrayTotal(cashOuts.map(cashOut => cashOut.amount));
+      await expect(
+        pixCashier.connect(cashier).reverseCashOuts(txIds)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [pixCashier, cashier, ...cashOuts.map(cashOut => cashOut.account)],
+        [-totalTokens, 0, ...cashOuts.map(cashOut => cashOut.amount)]
+      ).and.to.emit(
+        pixCashier,
+        "ReverseCashOut"
+      ).withArgs(
+        cashOuts[0].account.address,
+        cashOuts[0].amount,
+        0,
+        cashOuts[0].txId
+      ).and.to.emit(
+        pixCashier,
+        "ReverseCashOut"
+      ).withArgs(
+        cashOuts[1].account.address,
+        cashOuts[1].amount,
+        0,
+        cashOuts[1].txId
+      );
+      cashOuts.forEach(cashOut => cashOut.status = CashOutStatus.Reversed);
+      await checkPixCashierState(cashOuts);
+    });
+
+    it("Is reverted if one of the off-chain transaction IDs is zero", async () => {
+      await requestCashOuts(cashOuts);
+      txIds[txIds.length - 1] = ethers.constants.HashZero;
+      await expect(
+        pixCashier.connect(cashier).reverseCashOuts(txIds)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if one of the cash-outs was not requested previously", async () => {
+      await requestCashOuts(cashOuts);
+      txIds[txIds.length - 1] = TRANSACTION_ID3;
+      await expect(
+        pixCashier.connect(cashier).reverseCashOuts(txIds)
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(TRANSACTION_ID3, CashOutStatus.Nonexistent);
+    });
+  });
+
+  describe("Function 'getPendingCashOutTxIds()'", async () => {
+    let cashOuts: TestCashOut[];
+    let txIds: string[];
+
+    beforeEach(async () => {
+      cashOuts = [
+        {
+          account: user,
+          amount: 100,
+          txId: TRANSACTION_ID1,
+          status: CashOutStatus.Nonexistent,
+        },
+        {
+          account: deployer,
+          amount: 200,
+          txId: TRANSACTION_ID2,
+          status: CashOutStatus.Nonexistent,
+        },
+        {
+          account: user,
+          amount: 300,
+          txId: TRANSACTION_ID3,
+          status: CashOutStatus.Nonexistent,
+        },
+      ];
+      txIds = cashOuts.map(cashOut => cashOut.txId);
+      await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
+      await setUpContractsForCashOuts(cashOuts);
+    });
+
+    it("Returns expected values in different cases", async () => {
+      await requestCashOuts(cashOuts);
+      let actualTxIds: string[];
+
+      actualTxIds = await pixCashier.getPendingCashOutTxIds(0, 50);
+      expect(actualTxIds).to.be.deep.equal(txIds);
+
+      actualTxIds = await pixCashier.getPendingCashOutTxIds(0, 2);
+      expect(actualTxIds).to.be.deep.equal([txIds[0], txIds[1]]);
+
+      actualTxIds = await pixCashier.getPendingCashOutTxIds(1, 2);
+      expect(actualTxIds).to.be.deep.equal([txIds[1], txIds[2]]);
+
+      actualTxIds = await pixCashier.getPendingCashOutTxIds(1, 1);
+      expect(actualTxIds).to.be.deep.equal([txIds[1]]);
+
+      actualTxIds = await pixCashier.getPendingCashOutTxIds(1, 50);
+      expect(actualTxIds).to.be.deep.equal([txIds[1], txIds[2]]);
+
+      actualTxIds = await pixCashier.getPendingCashOutTxIds(3, 50);
+      expect(actualTxIds).to.be.deep.equal([]);
+
+      actualTxIds = await pixCashier.getPendingCashOutTxIds(1, 0);
+      expect(actualTxIds).to.be.deep.equal([]);
+    });
+  });
+
+  describe("Complex scenarios", async () => {
+    const cashInTokenAmount: number = 100;
+    let cashOut: TestCashOut;
+
+    beforeEach(async () => {
+      cashOut = {
+        account: user,
+        amount: 80,
+        txId: TRANSACTION_ID1,
+        status: CashOutStatus.Nonexistent,
+      };
+      await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
+      await proveTx(tokenMock.connect(cashOut.account).approve(pixCashier.address, ethers.constants.MaxUint256));
+    });
+
+    it("Scenario 1 with cash-out reversing executes successfully", async () => {
+      await proveTx(pixCashier.connect(cashier).cashIn(cashOut.account.address, cashInTokenAmount, cashOut.txId));
+      await proveTx(pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId));
+      await proveTx(pixCashier.connect(cashier).reverseCashOut(cashOut.txId));
+      cashOut.status = CashOutStatus.Reversed;
+      await checkPixCashierState([cashOut]);
+
+      // After reversing a cash-out with the same txId can't be reversed again.
+      await expect(
+        pixCashier.connect(cashier).reverseCashOut(cashOut.txId)
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Reversed);
+      await expect(
+        pixCashier.connect(cashier).reverseCashOuts([cashOut.txId])
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Reversed);
+
+      // After reversing a cash-out with the same txId can't be confirmed.
+      await expect(
+        pixCashier.connect(cashier).confirmCashOut(cashOut.txId)
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Reversed);
+      await expect(
+        pixCashier.connect(cashier).confirmCashOuts([cashOut.txId])
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Reversed);
+
+      expect(await tokenMock.balanceOf(cashOut.account.address)).to.equal(cashInTokenAmount);
+
+      // After reversing a cash-out with the same txId can be requested again.
+      await proveTx(pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId));
+      cashOut.status = CashOutStatus.Pending;
+      await checkPixCashierState([cashOut], 1);
+      expect(await tokenMock.balanceOf(cashOut.account.address)).to.equal(cashInTokenAmount - cashOut.amount);
+    });
+
+    it("Scenario 2 with cash-out confirming executes successfully", async () => {
+      await proveTx(pixCashier.connect(cashier).cashIn(cashOut.account.address, cashInTokenAmount, cashOut.txId));
+      await proveTx(pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId));
+      await proveTx(pixCashier.connect(cashier).confirmCashOut(cashOut.txId));
+      cashOut.status = CashOutStatus.Confirmed;
+      await checkPixCashierState([cashOut]);
+
+      // After confirming a cash-out with the same txId can't be reversed again.
+      await expect(
+        pixCashier.connect(cashier).reverseCashOut(cashOut.txId)
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Confirmed);
+      await expect(
+        pixCashier.connect(cashier).reverseCashOuts([cashOut.txId])
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Confirmed);
+
+      // After confirming a cash-out with the same txId can't be confirmed.
+      await expect(
+        pixCashier.connect(cashier).confirmCashOut(cashOut.txId)
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Confirmed);
+      await expect(
+        pixCashier.connect(cashier).confirmCashOuts([cashOut.txId])
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Confirmed);
+
+      expect(await tokenMock.balanceOf(cashOut.account.address)).to.equal(cashInTokenAmount - cashOut.amount);
+
+      // After confirming a cash-out with the same txId can be requested again.
+      cashOut.amount = cashInTokenAmount - cashOut.amount;
+      await proveTx(pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId));
+      cashOut.status = CashOutStatus.Pending;
+      await checkPixCashierState([cashOut], 1);
+      expect(await tokenMock.balanceOf(cashOut.account.address)).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
### Main changes
1. The logic of the `PixCashier` contract has been redefined with intensive usage of the off-chain transaction identifier (`txId`).
2. Functions related to cash-out operations have been renamed.
3. The new `requestCashOutFrom()` function has been introduced to allow accounts with the `CASHIER_ROLE` role request a cash-out of other accounts.
4. Now all the cash-out operations except requesting can be done only through the appropriate `txId`.
5. Now all the cash-out operations except requesting can be executed only by accounts with the `CASHIER_ROLE` role.
6. The tests have been updated according to the changes in contracts.

### Testing and coverage
The tests have been successfully run on the internal Hardhat net.

Coverage:
![image](https://user-images.githubusercontent.com/97302011/212462789-d55038fa-7ec4-407a-8b68-3ba68a8d9898.png)



