### PR TITLE
PIX Cashier. Remove the direct user call of the contract

### DIFF
--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -212,6 +212,7 @@ contract PixCashier is
      *
      * - The contract must not be paused.
      * - The caller must have the {CASHIER_ROLE} role.
+     * - The `account` must must not be blacklisted.
      * - The provided `account`, `amount`, and `txId` values must not be zero.
      * - The cash-out operation with the provided `txId` must not be already pending.
      */
@@ -219,7 +220,7 @@ contract PixCashier is
         address account,
         uint256 amount,
         bytes32 txId
-    ) external whenNotPaused onlyRole(CASHIER_ROLE) {
+    ) external whenNotPaused onlyRole(CASHIER_ROLE) notBlacklisted(account) {
         if (account == address(0)) {
             revert ZeroAccount();
         }

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -206,21 +206,6 @@ contract PixCashier is
     }
 
     /**
-     * @dev See {IPixCashier-requestCashOut}.
-     *
-     * Requirements:
-     *
-     * - The contract must not be paused.
-     * - The caller must must not be blacklisted.
-     * - The provided `amount` and `txId` values must not be zero.
-     * - The cash-out operation with the provided `txId` must not be already pending.
-     */
-    function requestCashOut(uint256 amount, bytes32 txId) external whenNotPaused notBlacklisted(_msgSender()) {
-        address sender = _msgSender();
-        _requestCashOut(sender, sender, amount, txId);
-    }
-
-    /**
      * @dev See {IPixCashier-requestCashOutFrom}.
      *
      * Requirements:

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -137,19 +137,6 @@ interface IPixCashier is IPixCashierTypes {
     ) external;
 
     /**
-     * @dev Initiates a cash-out operation.
-     *
-     * Transfers tokens from the caller to the contract.
-     * This function is expected to be called by any account.
-     *
-     * Emits a {CashOut} event.
-     *
-     * @param amount The amount of tokens to be cash-outed.
-     * @param txId The off-chain transaction identifier of the operation.
-     */
-    function requestCashOut(uint256 amount, bytes32 txId) external;
-
-    /**
      * @dev Initiates a cash-out operation from some other account.
      *
      * Transfers tokens from the account to the contract.

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -358,6 +358,14 @@ describe("Contract 'PixCashier'", async () => {
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
     });
 
+    it("Is reverted if the account is blacklisted", async () => {
+      await proveTx(pixCashier.grantRole(blacklisterRole, deployer.address));
+      await proveTx(pixCashier.blacklist(cashOut.account.address));
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
     it("Is reverted if the account address is zero", async () => {
       await expect(
         pixCashier.connect(cashier).requestCashOutFrom(ethers.constants.AddressZero, cashOut.amount, cashOut.txId)

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -129,7 +129,8 @@ describe("Contract 'PixCashier'", async () => {
   async function requestCashOuts(cashOuts: TestCashOut[]) {
     for (let cashOut of cashOuts) {
       await proveTx(
-        pixCashier.connect(cashOut.account).requestCashOut(
+        pixCashier.connect(cashier).requestCashOutFrom(
+          cashOut.account.address,
           cashOut.amount,
           cashOut.txId
         )
@@ -329,89 +330,6 @@ describe("Contract 'PixCashier'", async () => {
     });
   });
 
-  describe("Function 'requestCashOut()'", async () => {
-    let cashOut: TestCashOut;
-
-    beforeEach(async () => {
-      cashOut = {
-        account: user,
-        amount: 100,
-        txId: TRANSACTION_ID1,
-        status: CashOutStatus.Nonexistent,
-      };
-      await proveTx(tokenMock.connect(cashOut.account).approve(pixCashier.address, ethers.constants.MaxUint256));
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
-      await proveTx(pixCashier.pause());
-      await expect(
-        pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId)
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller is blacklisted", async () => {
-      await proveTx(pixCashier.grantRole(blacklisterRole, deployer.address));
-      await proveTx(pixCashier.blacklist(cashOut.account.address));
-      await expect(
-        pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId)
-      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
-    });
-
-    it("Is reverted if the token amount is zero", async () => {
-      await expect(
-        pixCashier.connect(cashOut.account).requestCashOut(0, cashOut.txId)
-      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_AMOUNT_IS_ZERO);
-    });
-
-    it("Is reverted if the off-chain transaction ID is zero", async () => {
-      await expect(
-        pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, ethers.constants.HashZero)
-      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
-    });
-
-    it("Is reverted if the user has not enough tokens", async () => {
-      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount - 1));
-      await expect(
-        pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId)
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
-    });
-
-    it("Transfers tokens as expected, emits the correct event, changes cash-out balances accordingly", async () => {
-      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
-      await checkPixCashierState([cashOut]);
-      await expect(
-        pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId)
-      ).to.changeTokenBalances(
-        tokenMock,
-        [cashOut.account, pixCashier],
-        [-cashOut.amount, +cashOut.amount]
-      ).and.to.emit(
-        pixCashier,
-        "RequestCashOut"
-      ).withArgs(
-        cashOut.account.address,
-        cashOut.amount,
-        cashOut.amount,
-        cashOut.txId,
-        cashOut.account.address
-      );
-      cashOut.status = CashOutStatus.Pending;
-      await checkPixCashierState([cashOut]);
-    });
-
-    it("Is reverted if the cash-out with the provided txId is already pending", async () => {
-      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
-      await pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId);
-      expect(
-        pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId)
-      ).to.be.revertedWithCustomError(
-        pixCashier,
-        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
-      ).withArgs(cashOut.txId, CashOutStatus.Pending);
-    });
-  });
-
   describe("Function 'requestCashOutFrom()'", async () => {
     let cashOut: TestCashOut;
 
@@ -464,7 +382,7 @@ describe("Contract 'PixCashier'", async () => {
 
     it("Is reverted if the cash-out with the provided txId is already pending", async () => {
       await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
-      await pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId);
+      await pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId);
       expect(
         pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId)
       ).to.be.revertedWithCustomError(
@@ -548,7 +466,7 @@ describe("Contract 'PixCashier'", async () => {
     });
 
     it("Burns tokens as expected, emits the correct event, changes the contract state accordingly", async () => {
-      await proveTx(pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId));
+      await requestCashOuts([cashOut]);
       cashOut.status = CashOutStatus.Pending;
       await checkPixCashierState([cashOut]);
       await expect(
@@ -710,7 +628,7 @@ describe("Contract 'PixCashier'", async () => {
     });
 
     it("Transfers tokens as expected, emits the correct event, changes the contract state accordingly", async () => {
-      await proveTx(pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId));
+      await requestCashOuts([cashOut]);
       cashOut.status = CashOutStatus.Pending;
       await checkPixCashierState([cashOut]);
       await expect(
@@ -902,7 +820,7 @@ describe("Contract 'PixCashier'", async () => {
 
     it("Scenario 1 with cash-out reversing executes successfully", async () => {
       await proveTx(pixCashier.connect(cashier).cashIn(cashOut.account.address, cashInTokenAmount, cashOut.txId));
-      await proveTx(pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId));
+      await requestCashOuts([cashOut]);
       await proveTx(pixCashier.connect(cashier).reverseCashOut(cashOut.txId));
       cashOut.status = CashOutStatus.Reversed;
       await checkPixCashierState([cashOut]);
@@ -938,15 +856,14 @@ describe("Contract 'PixCashier'", async () => {
       expect(await tokenMock.balanceOf(cashOut.account.address)).to.equal(cashInTokenAmount);
 
       // After reversing a cash-out with the same txId can be requested again.
-      await proveTx(pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId));
-      cashOut.status = CashOutStatus.Pending;
+      await requestCashOuts([cashOut]);
       await checkPixCashierState([cashOut], 1);
       expect(await tokenMock.balanceOf(cashOut.account.address)).to.equal(cashInTokenAmount - cashOut.amount);
     });
 
     it("Scenario 2 with cash-out confirming executes successfully", async () => {
       await proveTx(pixCashier.connect(cashier).cashIn(cashOut.account.address, cashInTokenAmount, cashOut.txId));
-      await proveTx(pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId));
+      await requestCashOuts([cashOut]);
       await proveTx(pixCashier.connect(cashier).confirmCashOut(cashOut.txId));
       cashOut.status = CashOutStatus.Confirmed;
       await checkPixCashierState([cashOut]);
@@ -983,7 +900,7 @@ describe("Contract 'PixCashier'", async () => {
 
       // After confirming a cash-out with the same txId can be requested again.
       cashOut.amount = cashInTokenAmount - cashOut.amount;
-      await proveTx(pixCashier.connect(cashOut.account).requestCashOut(cashOut.amount, cashOut.txId));
+      await requestCashOuts([cashOut]);
       cashOut.status = CashOutStatus.Pending;
       await checkPixCashierState([cashOut], 1);
       expect(await tokenMock.balanceOf(cashOut.account.address)).to.equal(0);


### PR DESCRIPTION
### Main changes
1. The `requestCashOut()` function has been removed from the `PixCashier` contract. Because of that only accounts with the `CASHIER_ROLE` role can now request cash-out operations for some account (through the `requestCashOutFrom()` function). Previously any account could do the request through the removed function.
2. The blacklist checking option has been added to the `requestCashOutFrom()`. If an account for which a cash-out is requested is in the blacklist the `requestCashOutFrom()`  function will be reverted.
3. The tests have been updated accordingly. 

### Testing and coverage

All contracts are 100% covered with tests:
![image](https://user-images.githubusercontent.com/97302011/212939260-0b87c162-5167-4d10-8ea9-32eb9b7b606d.png)
