### PR TITLE
Add the "correlationId" parameter to some functions and events of CPP

### DIFF
--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -221,11 +221,11 @@ contract CardPaymentProcessor is
      * - The payment linked with the authorization ID must have the "uncleared" status.
      * - The new amount must not exceed the existing refund amount.
      */
-    function updatePaymentAmount(uint256 newAmount, bytes16 authorizationId)
-        external
-        whenNotPaused
-        onlyRole(EXECUTOR_ROLE)
-    {
+    function updatePaymentAmount(
+        uint256 newAmount,
+        bytes16 authorizationId,
+        bytes16 correlationId
+    ) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
         if (authorizationId == 0) {
             revert ZeroAuthorizationId();
         }
@@ -277,6 +277,7 @@ contract CardPaymentProcessor is
 
         emit UpdatePaymentAmount(
             authorizationId,
+            correlationId,
             account,
             oldPaymentAmount,
             newAmount
@@ -478,11 +479,11 @@ contract CardPaymentProcessor is
      * - The caller must have the {EXECUTOR_ROLE} role.
      * - The input authorization ID of the payment must not be zero.
      */
-    function refundPayment(uint256 amount, bytes16 authorizationId)
-        external
-        whenNotPaused
-        onlyRole(EXECUTOR_ROLE)
-    {
+    function refundPayment(
+        uint256 amount,
+        bytes16 authorizationId,
+        bytes16 correlationId
+    ) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
         if (authorizationId == 0) {
             revert ZeroAuthorizationId();
         }
@@ -530,6 +531,7 @@ contract CardPaymentProcessor is
 
         emit RefundPayment(
             authorizationId,
+            correlationId,
             account,
             amount,
             sentAmount,

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -822,7 +822,16 @@ contract CardPaymentProcessor is
 
         Payment storage payment = _payments[authorizationId];
 
-        checkUnclearedStatus(payment.status);
+        PaymentStatus status = payment.status;
+        if (status == PaymentStatus.Nonexistent) {
+            revert PaymentNotExist();
+        }
+        if (status == PaymentStatus.Cleared) {
+            revert PaymentAlreadyCleared();
+        }
+        if (status != PaymentStatus.Uncleared) {
+            revert InappropriatePaymentStatus(status);
+        }
         payment.status = PaymentStatus.Cleared;
 
         address account = payment.account;
@@ -850,7 +859,16 @@ contract CardPaymentProcessor is
 
         Payment storage payment = _payments[authorizationId];
 
-        checkClearedStatus(payment.status);
+        PaymentStatus status = payment.status;
+        if (status == PaymentStatus.Nonexistent) {
+            revert PaymentNotExist();
+        }
+        if (status == PaymentStatus.Uncleared) {
+            revert PaymentAlreadyUncleared();
+        }
+        if (status != PaymentStatus.Cleared) {
+            revert InappropriatePaymentStatus(status);
+        }
         payment.status = PaymentStatus.Uncleared;
 
         address account = payment.account;
@@ -878,7 +896,13 @@ contract CardPaymentProcessor is
 
         Payment storage payment = _payments[authorizationId];
 
-        checkClearedStatus(payment.status);
+        PaymentStatus status = payment.status;
+        if (status == PaymentStatus.Nonexistent) {
+            revert PaymentNotExist();
+        }
+        if (status != PaymentStatus.Cleared) {
+            revert InappropriatePaymentStatus(status);
+        }
         payment.status = PaymentStatus.Confirmed;
 
         address account = payment.account;
@@ -1021,30 +1045,6 @@ contract CardPaymentProcessor is
             } else {
                 emit IncreaseCashbackFailure(distributor, amount, cashbackNonce);
             }
-        }
-    }
-
-    function checkClearedStatus(PaymentStatus status) internal pure {
-        if (status == PaymentStatus.Nonexistent) {
-            revert PaymentNotExist();
-        }
-        if (status == PaymentStatus.Uncleared) {
-            revert PaymentAlreadyUncleared();
-        }
-        if (status != PaymentStatus.Cleared) {
-            revert InappropriatePaymentStatus(status);
-        }
-    }
-
-    function checkUnclearedStatus(PaymentStatus status) internal pure {
-        if (status == PaymentStatus.Nonexistent) {
-            revert PaymentNotExist();
-        }
-        if (status == PaymentStatus.Cleared) {
-            revert PaymentAlreadyCleared();
-        }
-        if (status != PaymentStatus.Uncleared) {
-            revert InappropriatePaymentStatus(status);
         }
     }
 

--- a/contracts/CashbackDistributor.sol
+++ b/contracts/CashbackDistributor.sol
@@ -37,6 +37,15 @@ contract CashbackDistributor is
     /// @dev The role of distributor that is allowed to execute the cashback operations.
     bytes32 public constant DISTRIBUTOR_ROLE = keccak256("DISTRIBUTOR_ROLE");
 
+    /// @dev A helper structure to store context of function execution and avoid stack overflow error.
+    struct ExecutionContext {
+        address token;
+        CashbackStatus cashbackStatus;
+        bytes32 externalId;
+        address recipient;
+        address sender;
+    }
+
     // -------------------- Errors -----------------------------------
 
     /// @dev The cashback operations are already enabled.
@@ -169,37 +178,43 @@ contract CashbackDistributor is
         uint256 amount
     ) external whenNotPaused onlyRole(DISTRIBUTOR_ROLE) returns (bool success) {
         Cashback storage cashback = _cashbacks[nonce];
+        ExecutionContext memory context = ExecutionContext({
+            token : cashback.token,
+            cashbackStatus : cashback.status,
+            externalId : cashback.externalId,
+            recipient : cashback.recipient,
+            sender: _msgSender()
+        });
 
-        address sender = _msgSender();
         RevocationStatus revocationStatus = RevocationStatus.Success;
 
-        if (cashback.status != CashbackStatus.Success) {
+        if (context.cashbackStatus != CashbackStatus.Success) {
             revocationStatus = RevocationStatus.Inapplicable;
-        } else if (amount > IERC20Upgradeable(cashback.token).balanceOf(sender)) {
+        } else if (amount > IERC20Upgradeable(context.token).balanceOf(context.sender)) {
             revocationStatus = RevocationStatus.OutOfFunds;
-        } else if (amount > IERC20Upgradeable(cashback.token).allowance(sender, address(this))) {
+        } else if (amount > IERC20Upgradeable(context.token).allowance(context.sender, address(this))) {
             revocationStatus = RevocationStatus.OutOfAllowance;
         } else if (amount > cashback.amount - cashback.revokedAmount) {
             revocationStatus = RevocationStatus.OutOfBalance;
         }
 
         emit RevokeCashback(
-            cashback.token,
+            context.token,
             cashback.kind,
-            cashback.status,
+            context.cashbackStatus,
             revocationStatus,
-            cashback.externalId,
-            cashback.recipient,
+            context.externalId,
+            context.recipient,
             amount,
-            sender,
+            context.sender,
             nonce
         );
 
         if (revocationStatus == RevocationStatus.Success) {
             cashback.revokedAmount += amount;
-            _totalCashbackByTokenAndRecipient[cashback.token][cashback.recipient] -= amount;
-            _totalCashbackByTokenAndExternalId[cashback.token][cashback.externalId] -= amount;
-            IERC20Upgradeable(cashback.token).safeTransferFrom(sender, address(this), amount);
+            _totalCashbackByTokenAndRecipient[context.token][context.recipient] -= amount;
+            _totalCashbackByTokenAndExternalId[context.token][context.externalId] -= amount;
+            IERC20Upgradeable(context.token).safeTransferFrom(context.sender, address(this), amount);
             success = true;
         }
     }
@@ -217,37 +232,43 @@ contract CashbackDistributor is
         uint256 amount
     ) external whenNotPaused onlyRole(DISTRIBUTOR_ROLE) returns (bool success) {
         Cashback storage cashback = _cashbacks[nonce];
+        ExecutionContext memory context = ExecutionContext({
+            token : cashback.token,
+            cashbackStatus : cashback.status,
+            externalId : cashback.externalId,
+            recipient : cashback.recipient,
+            sender: _msgSender()
+        });
 
-        address sender = _msgSender();
         IncreaseStatus status = IncreaseStatus.Success;
 
-        if (cashback.status != CashbackStatus.Success) {
+        if (context.cashbackStatus != CashbackStatus.Success) {
             status = IncreaseStatus.Inapplicable;
         } else if (!_enabled) {
             status = IncreaseStatus.Disabled;
-        } else if (isBlacklisted(cashback.recipient)) {
+        } else if (isBlacklisted(context.recipient)) {
             status = IncreaseStatus.Blacklisted;
-        } else if (IERC20Upgradeable(cashback.token).balanceOf(address(this)) < amount) {
+        } else if (IERC20Upgradeable(context.token).balanceOf(address(this)) < amount) {
             status = IncreaseStatus.OutOfFunds;
         }
 
         emit IncreaseCashback(
-            cashback.token,
+            context.token,
             cashback.kind,
-            cashback.status,
+            context.cashbackStatus,
             status,
-            cashback.externalId,
-            cashback.recipient,
+            context.externalId,
+            context.recipient,
             amount,
-            sender,
+            context.sender,
             nonce
         );
 
         if (status == IncreaseStatus.Success) {
             cashback.amount += amount;
-            _totalCashbackByTokenAndRecipient[cashback.token][cashback.recipient] += amount;
-            _totalCashbackByTokenAndExternalId[cashback.token][cashback.externalId] += amount;
-            IERC20Upgradeable(cashback.token).safeTransfer(cashback.recipient, amount);
+            _totalCashbackByTokenAndRecipient[context.token][context.recipient] += amount;
+            _totalCashbackByTokenAndExternalId[context.token][context.externalId] += amount;
+            IERC20Upgradeable(context.token).safeTransfer(context.recipient, amount);
             success = true;
         }
     }

--- a/contracts/interfaces/ICardPaymentCashback.sol
+++ b/contracts/interfaces/ICardPaymentCashback.sol
@@ -47,7 +47,7 @@ interface ICardPaymentCashback is ICardPaymentCashbackTypes {
     event SendCashbackFailure(address indexed cashbackDistributor, uint256 amount, uint256 nonce);
 
     /**
-     * @dev Emitted when a cashback revoke request succeeded.
+     * @dev Emitted when a cashback revocation request succeeded.
      * @param cashbackDistributor The address of the cashback distributor.
      * @param amount The amount of the revoked cashback.
      * @param nonce The nonce of the cashback.
@@ -55,12 +55,28 @@ interface ICardPaymentCashback is ICardPaymentCashbackTypes {
     event RevokeCashbackSuccess(address indexed cashbackDistributor, uint256 amount, uint256 nonce);
 
     /**
-     * @dev Emitted when a cashback revoke request failed.
+     * @dev Emitted when a cashback revocation request failed.
      * @param cashbackDistributor The address of the cashback distributor.
      * @param amount The amount of the revoked cashback.
      * @param nonce The nonce of the cashback.
      */
     event RevokeCashbackFailure(address indexed cashbackDistributor, uint256 amount, uint256 nonce);
+
+    /**
+     * @dev Emitted when a cashback increase request succeeded.
+     * @param cashbackDistributor The address of the cashback distributor.
+     * @param amount The amount of the cashback increase.
+     * @param nonce The nonce of the cashback.
+     */
+    event IncreaseCashbackSuccess(address indexed cashbackDistributor, uint256 amount, uint256 nonce);
+
+    /**
+     * @dev Emitted when a cashback increase request failed.
+     * @param cashbackDistributor The address of the cashback distributor.
+     * @param amount The amount of the cashback increase.
+     * @param nonce The nonce of the cashback.
+     */
+    event IncreaseCashbackFailure(address indexed cashbackDistributor, uint256 amount, uint256 nonce);
 
     /// @dev Emitted when cashback operations are enabled.
     event EnableCashback();

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -63,6 +63,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
     /// @dev Emitted when the amount of a payment is updated.
     event UpdatePaymentAmount(
         bytes16 indexed authorizationId,
+        bytes16 indexed correlationId,
         address indexed account,
         uint256 oldAmount,
         uint256 newAmount
@@ -126,6 +127,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
     /// @dev Emitted when a payment is refunded.
     event RefundPayment(
         bytes16 indexed authorizationId,
+        bytes16 indexed correlationId,
         address indexed account,
         uint256 refundAmount,
         uint256 sentAmount,
@@ -203,7 +205,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param amount The amount of tokens to be transferred to this contract because of the payment.
      * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
-     * @param correlationId The ID that is correlated to call of this function in the off-chain card processing backend.
+     * @param correlationId The ID that is correlated to this function call in the off-chain card processing backend.
      */
     function makePayment(
         uint256 amount,
@@ -222,7 +224,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      * @param account The account on that behalf the payment is made.
      * @param amount The amount of tokens to be transferred to this contract because of the payment.
      * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
-     * @param correlationId The ID that is correlated to call of this function in the off-chain card processing backend.
+     * @param correlationId The ID that is correlated to this function call in the off-chain card processing backend.
      */
     function makePaymentFrom(
         address account,
@@ -241,10 +243,12 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param newAmount The new amount of the payment.
      * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
+     * @param correlationId The ID that is correlated to this function call in the off-chain card processing backend.
      */
     function updatePaymentAmount(
         uint256 newAmount,
-        bytes16 authorizationId
+        bytes16 authorizationId,
+        bytes16 correlationId
     ) external;
 
     /**
@@ -301,7 +305,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      * Emits a {ReversePayment} event for the payment.
      *
      * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
-     * @param correlationId The ID that is correlated to call of this function in the off-chain card processing backend.
+     * @param correlationId The ID that is correlated to this function call in the off-chain card processing backend.
      * @param parentTxHash The hash of the transaction where the payment was made.
      */
     function reversePayment(
@@ -320,7 +324,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      * Emits a {RevokePayment} event for the payment.
      *
      * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
-     * @param correlationId The ID that is correlated to call of this function in the off-chain card processing backend.
+     * @param correlationId The ID that is correlated to this function call in the off-chain card processing backend.
      * @param parentTxHash The hash of the transaction where the payment was made.
      */
     function revokePayment(
@@ -362,6 +366,11 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param amount The amount of tokens to refund.
      * @param authorizationId The card transaction authorization ID.
+     * @param correlationId The ID that is correlated to this function call in the off-chain card processing backend.
      */
-    function refundPayment(uint256 amount, bytes16 authorizationId) external;
+    function refundPayment(
+        uint256 amount,
+        bytes16 authorizationId,
+        bytes16 correlationId
+    ) external;
 }

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -60,6 +60,14 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
         address sender
     );
 
+    /// @dev Emitted when the amount of a payment is updated.
+    event UpdatePaymentAmount(
+        bytes16 indexed authorizationId,
+        address indexed account,
+        uint256 oldAmount,
+        uint256 newAmount
+    );
+
     /// @dev Emitted when a payment is cleared.
     event ClearPayment(
         bytes16 indexed authorizationId,
@@ -221,6 +229,22 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
         uint256 amount,
         bytes16 authorizationId,
         bytes16 correlationId
+    ) external;
+
+    /**
+     * @dev Updates the amount of a previously made payment.
+     *
+     * Transfers the underlying tokens from the account to this contract or vise versa.
+     * This function can be called by a limited number of accounts that are allowed to execute processing operations.
+     *
+     * Emits a {UpdatePaymentAmount} event.
+     *
+     * @param newAmount The new amount of the payment.
+     * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
+     */
+    function updatePaymentAmount(
+        uint256 newAmount,
+        bytes16 authorizationId
     ) external;
 
     /**

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1,26 +1,17 @@
-import { ethers } from "hardhat";
+import { ethers, network, upgrades } from "hardhat";
 import { expect } from "chai";
 import { BigNumber, Contract, ContractFactory } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { proveTx } from "../test-utils/eth";
 import { countNumberArrayTotal, createBytesString, createRevertMessageDueToMissingRole } from "../test-utils/misc";
 import { TransactionResponse } from "@ethersproject/abstract-provider";
 
-const REVOCATION_LIMIT = 123;
-const REVOCATION_LIMIT_DEFAULT_VALUE = 255;
+const MAX_UINT256 = ethers.constants.MaxUint256;
+const ZERO_ADDRESS = ethers.constants.AddressZero;
+const ZERO_TRANSACTION_HASH: string = ethers.constants.HashZero;
 const BYTES16_LENGTH: number = 16;
 const BYTES32_LENGTH: number = 32;
-const ZERO_AUTHORIZATION_ID: string = createBytesString("00", BYTES16_LENGTH);
-const ZERO_TRANSACTION_HASH: string = ethers.constants.HashZero;
-const REVERSING_PAYMENT_CORRELATION_ID: string = createBytesString("ABC1", BYTES16_LENGTH);
-const CORRELATION_ID: string = createBytesString("ABC2", BYTES16_LENGTH);
-const PARENT_TRANSACTION_HASH: string = createBytesString("ABC3", BYTES32_LENGTH);
-const CASHBACK_DISTRIBUTOR_ADDRESS_STUB1 = "0x0000000000000000000000000000000000000001";
-const CASHBACK_DISTRIBUTOR_ADDRESS_STUB2 = "0x0000000000000000000000000000000000000002";
-const MAX_CASHBACK_RATE_IN_PERMIL = 250;
-const CASHBACK_RATE_IN_PERMIL = 100; // 10%
-const ZERO_CASHBACK_RATE = 0;
-const CASHBACK_NONCE = 111222333;
 
 enum PaymentStatus {
   Nonexistent = 0,
@@ -37,13 +28,13 @@ enum CashbackKind {
 }
 
 interface TestPayment {
-  authorizationId: number;
+  authorizationId: string;
   account: SignerWithAddress;
   amount: number;
   status: PaymentStatus;
   revocationCounter?: number;
-  makingPaymentCorrelationId: number;
-  parentTxHash?: string;
+  correlationId: string;
+  parentTxHash: string;
   compensationAmount?: number;
   cashbackNonce?: number;
   cashbackRateInPermil?: number;
@@ -56,12 +47,19 @@ interface CashbackDistributorMockConfig {
   revokeCashbackSuccessResult: boolean;
 }
 
+interface Fixture {
+  cardPaymentProcessor: Contract;
+  tokenMock: Contract;
+  cashbackDistributorMock: Contract;
+  cashbackDistributorMockConfig: CashbackDistributorMockConfig;
+}
+
 function checkNonexistentPayment(
   actualOnChainPayment: any,
   paymentIndex: number
 ) {
   expect(actualOnChainPayment.account).to.equal(
-    ethers.constants.AddressZero,
+    ZERO_ADDRESS,
     `payment[${paymentIndex}].account is incorrect`
   );
   expect(actualOnChainPayment.amount).to.equal(
@@ -117,8 +115,18 @@ function checkEquality(
   }
 }
 
-function calculateCashback(payment: TestPayment): number {
-  return Math.floor((payment.amount - (payment.refundAmount || 0)) * (payment.cashbackRateInPermil || 0) / 1000);
+function increaseBytesString(bytesString: string, targetLength: number) {
+  return createBytesString(
+    parseInt(bytesString.substring(2), 16) + 1,
+    targetLength
+  );
+}
+
+function calculateCashback(
+  payment: TestPayment,
+  cashbackRateInPermil = payment.cashbackRateInPermil || 0
+): number {
+  return Math.floor((payment.amount - (payment.refundAmount || 0)) * cashbackRateInPermil / 1000);
 }
 
 function calculateInitialCashback(payment: TestPayment): number {
@@ -133,40 +141,46 @@ function calculateCompensationAmount(payment: TestPayment): number {
   return (payment.refundAmount || 0) + calculateCashback(payment);
 }
 
-function setCashbackRate(payment: TestPayment, newCashbackRateInPermil: number) {
-  payment.cashbackRateInPermil = newCashbackRateInPermil;
-  payment.compensationAmount = calculateCompensationAmount(payment);
-}
-
-function setRefundAmount(payment: TestPayment, newRefundAmount: number) {
-  payment.refundAmount = newRefundAmount;
-  payment.compensationAmount = calculateCompensationAmount(payment);
-}
-
-async function deployCashbackDistributorMock():
-  Promise<{ cashbackDistributorMock: Contract, cashbackDistributorMockConfig: CashbackDistributorMockConfig }> {
-
-  const cashbackDistributorMockConfig: CashbackDistributorMockConfig = {
-    sendCashbackSuccessResult: true,
-    sendCashbackNonceResult: CASHBACK_NONCE,
-    revokeCashbackSuccessResult: true,
-  };
-
-  const CashbackDistributor: ContractFactory = await ethers.getContractFactory("CashbackDistributorMock");
-  const cashbackDistributorMock: Contract = await CashbackDistributor.deploy(
-    cashbackDistributorMockConfig.sendCashbackSuccessResult,
-    cashbackDistributorMockConfig.sendCashbackNonceResult,
-    cashbackDistributorMockConfig.revokeCashbackSuccessResult,
-  );
-  await cashbackDistributorMock.deployed();
-
-  return {
-    cashbackDistributorMock,
-    cashbackDistributorMockConfig
-  };
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
 }
 
 describe("Contract 'CardPaymentProcessor'", async () => {
+  const REVOCATION_LIMIT = 123;
+  const REVOCATION_LIMIT_DEFAULT_VALUE = 255;
+  const ZERO_AUTHORIZATION_ID: string = createBytesString("00", BYTES16_LENGTH);
+  const PAYMENT_REVERSING_CORRELATION_ID_STUB: string = createBytesString("ABC1", BYTES16_LENGTH);
+  const PAYMENT_REVOKING_CORRELATION_ID_STUB: string = createBytesString("ABC2", BYTES16_LENGTH);
+  const CASHBACK_DISTRIBUTOR_ADDRESS_STUB1 = "0x0000000000000000000000000000000000000001";
+  const CASHBACK_DISTRIBUTOR_ADDRESS_STUB2 = "0x0000000000000000000000000000000000000002";
+  const MAX_CASHBACK_RATE_IN_PERMIL = 250; // 25%
+  const CASHBACK_RATE_IN_PERMIL = 100; // 10%
+  const CASHBACK_NONCE = 111222333;
+
+  const EVENT_NAME_CONFIRM_PAYMENT = "ConfirmPayment";
+  const EVENT_NAME_CLEAR_PAYMENT = "ClearPayment";
+  const EVENT_NAME_ENABLE_CASHBACK = "EnableCashback";
+  const EVENT_NAME_DISABLE_CASHBACK = "DisableCashback";
+  const EVENT_NAME_MAKE_PAYMENT = "MakePayment";
+  const EVENT_NAME_REFUND_PAYMENT = "RefundPayment";
+  const EVENT_NAME_REVERSE_PAYMENT = "ReversePayment";
+  const EVENT_NAME_REVOKE_CASHBACK_FAILURE = "RevokeCashbackFailure";
+  const EVENT_NAME_REVOKE_CASHBACK_MOCK = "RevokeCashbackMock";
+  const EVENT_NAME_REVOKE_CASHBACK_SUCCESS = "RevokeCashbackSuccess";
+  const EVENT_NAME_REVOKE_PAYMENT = "RevokePayment";
+  const EVENT_NAME_SEND_CASHBACK_FAILURE = "SendCashbackFailure";
+  const EVENT_NAME_SEND_CASHBACK_MOCK = "SendCashbackMock";
+  const EVENT_NAME_SEND_CASHBACK_SUCCESS = "SendCashbackSuccess";
+  const EVENT_NAME_SET_CASH_OUT_ACCOUNT = "SetCashOutAccount";
+  const EVENT_NAME_SET_CASHBACK_DISTRIBUTOR = "SetCashbackDistributor";
+  const EVENT_NAME_SET_CASHBACK_RATE = "SetCashbackRate";
+  const EVENT_NAME_SET_REVOCATION_LIMIT = "SetRevocationLimit";
+  const EVENT_NAME_UNCLEAR_PAYMENT = "UnclearPayment";
+
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
   const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
   const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
@@ -194,183 +208,260 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   const REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO = "ZeroCashOutAccount";
   const REVERT_ERROR_IF_REFUND_AMOUNT_IS_INAPPROPRIATE = "InappropriateRefundAmount";
 
-  let CardPaymentProcessor: ContractFactory;
-  let cardPaymentProcessor: Contract;
-  let tokenMock: Contract;
+  const ownerRole: string = ethers.utils.id("OWNER_ROLE");
+  const blacklisterRole: string = ethers.utils.id("BLACKLISTER_ROLE");
+  const pauserRole: string = ethers.utils.id("PAUSER_ROLE");
+  const rescuerRole: string = ethers.utils.id("RESCUER_ROLE");
+  const executorRole: string = ethers.utils.id("EXECUTOR_ROLE");
+
+  let cardPaymentProcessorFactory: ContractFactory;
+  let cashbackDistributorMockFactory: ContractFactory;
+  let tokenMockFactory: ContractFactory;
+
   let deployer: SignerWithAddress;
   let cashOutAccount: SignerWithAddress;
   let executor: SignerWithAddress;
   let user1: SignerWithAddress;
   let user2: SignerWithAddress;
-  let ownerRole: string;
-  let blacklisterRole: string;
-  let pauserRole: string;
-  let rescuerRole: string;
-  let executorRole: string;
 
-  async function setUpContractsForPayments(payments: TestPayment[]) {
-    for (let payment of payments) {
-      await proveTx(tokenMock.mint(payment.account.address, payment.amount));
-      const allowance: BigNumber = await tokenMock.allowance(payment.account.address, cardPaymentProcessor.address);
-      if (allowance.lt(BigNumber.from(ethers.constants.MaxUint256))) {
-        await proveTx(
-          tokenMock.connect(payment.account).approve(
-            cardPaymentProcessor.address,
-            ethers.constants.MaxUint256
-          )
-        );
-      }
-    }
+  before(async () => {
+    cardPaymentProcessorFactory = await ethers.getContractFactory("CardPaymentProcessor");
+    cashbackDistributorMockFactory = await ethers.getContractFactory("CashbackDistributorMock");
+    tokenMockFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+
+    [deployer, cashOutAccount, executor, user1, user2] = await ethers.getSigners();
+  });
+
+  async function deployTokenMock(): Promise<{ tokenMock: Contract }> {
+    const name = "ERC20 Test";
+    const symbol = "TEST";
+
+    const tokenMock: Contract = await upgrades.deployProxy(tokenMockFactory, [name, symbol]);
+    await tokenMock.deployed();
+
+    return { tokenMock };
   }
 
-  async function setUpAndEnableCashback():
-    Promise<{ cashbackDistributorMock: Contract, cashbackDistributorMockConfig: CashbackDistributorMockConfig }> {
-    const { cashbackDistributorMock, cashbackDistributorMockConfig } = await deployCashbackDistributorMock();
-    await proveTx(cardPaymentProcessor.setCashbackDistributor(cashbackDistributorMock.address));
-    await proveTx(cardPaymentProcessor.setCashbackRate(CASHBACK_RATE_IN_PERMIL));
-    await proveTx(cardPaymentProcessor.enableCashback());
+  async function deployTokenMockAndCardPaymentProcessor(): Promise<{
+    cardPaymentProcessor: Contract,
+    tokenMock: Contract
+  }> {
+    const { tokenMock } = await deployTokenMock();
+
+    const cardPaymentProcessor: Contract = await upgrades.deployProxy(
+      cardPaymentProcessorFactory,
+      [tokenMock.address]
+    );
+    await cardPaymentProcessor.deployed();
+
+    return {
+      cardPaymentProcessor,
+      tokenMock
+    };
+  }
+
+  async function deployCashbackDistributorMock(): Promise<{
+    cashbackDistributorMock: Contract,
+    cashbackDistributorMockConfig: CashbackDistributorMockConfig
+  }> {
+    const cashbackDistributorMockConfig: CashbackDistributorMockConfig = {
+      sendCashbackSuccessResult: true,
+      sendCashbackNonceResult: CASHBACK_NONCE,
+      revokeCashbackSuccessResult: true,
+    };
+
+    const cashbackDistributorMock: Contract = await cashbackDistributorMockFactory.deploy(
+      cashbackDistributorMockConfig.sendCashbackSuccessResult,
+      cashbackDistributorMockConfig.sendCashbackNonceResult,
+      cashbackDistributorMockConfig.revokeCashbackSuccessResult,
+    );
+    await cashbackDistributorMock.deployed();
+
     return {
       cashbackDistributorMock,
       cashbackDistributorMockConfig
     };
   }
 
-  async function makePayments(payments: TestPayment[]) {
+  async function deployAndConfigureAllContracts(): Promise<Fixture> {
+    const { cardPaymentProcessor, tokenMock } = await deployTokenMockAndCardPaymentProcessor();
+    const { cashbackDistributorMock, cashbackDistributorMockConfig } = await deployCashbackDistributorMock();
+
+    await proveTx(cardPaymentProcessor.grantRole(executorRole, executor.address));
+    await proveTx(cardPaymentProcessor.setCashbackDistributor(cashbackDistributorMock.address));
+    await proveTx(cardPaymentProcessor.setCashbackRate(CASHBACK_RATE_IN_PERMIL));
+
+    await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
+    await proveTx(tokenMock.connect(cashOutAccount).approve(cardPaymentProcessor.address, MAX_UINT256));
+
+    return {
+      cardPaymentProcessor,
+      tokenMock,
+      cashbackDistributorMock,
+      cashbackDistributorMockConfig
+    };
+  }
+
+  async function setUpContractsForPayments(fixture: Fixture, payments: TestPayment[]) {
+    const { tokenMock, cardPaymentProcessor } = fixture;
+    for (let payment of payments) {
+      await proveTx(tokenMock.mint(payment.account.address, payment.amount));
+      const allowance: BigNumber = await tokenMock.allowance(payment.account.address, cardPaymentProcessor.address);
+      if (allowance.lt(MAX_UINT256)) {
+        await proveTx(
+          tokenMock.connect(payment.account).approve(
+            cardPaymentProcessor.address,
+            MAX_UINT256
+          )
+        );
+      }
+    }
+  }
+
+  function setCashbackNonce(payment: TestPayment, fixture: Fixture) {
+    payment.cashbackNonce = fixture.cashbackDistributorMockConfig.sendCashbackNonceResult;
+  }
+
+  function setCashback(
+    payment: TestPayment,
+    fixture: Fixture,
+    newCashbackRateInPermil: number = CASHBACK_RATE_IN_PERMIL
+  ) {
+    payment.cashbackRateInPermil = newCashbackRateInPermil;
+    payment.compensationAmount = calculateCompensationAmount(payment);
+    setCashbackNonce(payment, fixture);
+  }
+
+  function setRefundAmount(payment: TestPayment, newRefundAmount: number) {
+    payment.refundAmount = newRefundAmount;
+    payment.compensationAmount = calculateCompensationAmount(payment);
+  }
+
+  async function pauseContract(contract: Contract) {
+    await proveTx(contract.grantRole(pauserRole, deployer.address));
+    await proveTx(contract.pause());
+  }
+
+  async function makePayments(cardPaymentProcessor: Contract, payments: TestPayment[]) {
     for (let payment of payments) {
       await proveTx(
         cardPaymentProcessor.connect(payment.account).makePayment(
           payment.amount,
-          createBytesString(payment.authorizationId, BYTES16_LENGTH),
-          createBytesString(payment.makingPaymentCorrelationId, BYTES16_LENGTH)
+          payment.authorizationId,
+          payment.correlationId,
         )
       );
       payment.status = PaymentStatus.Uncleared;
+      if (!!payment.revocationCounter) {
+        payment.parentTxHash = increaseBytesString(payment.parentTxHash, BYTES32_LENGTH);
+      }
     }
   }
 
-  async function clearPayments(payments: TestPayment[]) {
+  async function clearPayments(cardPaymentProcessor: Contract, payments: TestPayment[]) {
     const authorizationIds: string[] = [];
     payments.forEach((payment: TestPayment) => {
-      authorizationIds.push(createBytesString(payment.authorizationId, BYTES16_LENGTH));
+      authorizationIds.push(payment.authorizationId);
       payment.status = PaymentStatus.Cleared;
     });
     await proveTx(cardPaymentProcessor.connect(executor).clearPayments(authorizationIds));
   }
 
-  async function setExecutorRole(account: SignerWithAddress) {
-    await proveTx(cardPaymentProcessor.grantRole(executorRole, account.address));
-  }
-
-  function defineBalancesPerAccount(payments: TestPayment[], targetPaymentStatus: PaymentStatus): Map<string, number> {
-    const balancesPerAccount: Map<string, number> = new Map<string, number>();
-
+  async function unclearPayments(cardPaymentProcessor: Contract, payments: TestPayment[]) {
+    const authorizationIds: string[] = [];
     payments.forEach((payment: TestPayment) => {
-      const address: string = payment.account.address;
-      let newBalance: number = balancesPerAccount.get(address) || 0;
-      if (payment.status == targetPaymentStatus) {
-        newBalance += payment.amount - (payment.refundAmount || 0);
-      }
-      balancesPerAccount.set(address, newBalance);
+      authorizationIds.push(payment.authorizationId);
+      payment.status = PaymentStatus.Uncleared;
     });
-
-    return balancesPerAccount;
+    await proveTx(cardPaymentProcessor.connect(executor).unclearPayments(authorizationIds));
   }
 
-  async function checkPaymentStructures(payments: TestPayment[]) {
+  async function confirmPayments(cardPaymentProcessor: Contract, payments: TestPayment[]) {
+    const authorizationIds: string[] = [];
+    payments.forEach((payment: TestPayment) => {
+      authorizationIds.push(payment.authorizationId);
+      payment.status = PaymentStatus.Confirmed;
+    });
+    await proveTx(cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds));
+  }
+
+  async function checkPaymentStructures(cardPaymentProcessor: Contract, payments: TestPayment[]) {
     for (let i = 0; i < payments.length; ++i) {
       const expectedPayment: TestPayment = payments[i];
-      const actualPayment = await cardPaymentProcessor.paymentFor(
-        createBytesString(expectedPayment.authorizationId, BYTES16_LENGTH)
-      );
+      const actualPayment = await cardPaymentProcessor.paymentFor(expectedPayment.authorizationId);
       checkEquality(actualPayment, expectedPayment, i);
       if (!!expectedPayment.parentTxHash) {
         expect(
           await cardPaymentProcessor.isPaymentReversed(expectedPayment.parentTxHash)
         ).to.equal(
-          expectedPayment.status == PaymentStatus.Reversed
+          expectedPayment.status == PaymentStatus.Reversed,
+          `The reversing status of payment[${i}] is wrong`
         );
         expect(
           await cardPaymentProcessor.isPaymentRevoked(expectedPayment.parentTxHash)
         ).to.equal(
-          expectedPayment.status == PaymentStatus.Revoked
+          expectedPayment.status == PaymentStatus.Revoked,
+          `The revoking status of payment[${i}] is wrong`
         );
       }
     }
   }
 
-  async function checkBalancesOnBlockchain(
-    expectedBalancesPerAccount: Map<string, number>,
-    isClearedBalance: boolean
-  ) {
-    for (const account of expectedBalancesPerAccount.keys()) {
-      const expectedBalance = expectedBalancesPerAccount.get(account);
-      if (!expectedBalance) {
-        continue;
-      }
-      if (isClearedBalance) {
-        expect(
-          await cardPaymentProcessor.clearedBalanceOf(account)
-        ).to.equal(
-          expectedBalance,
-          `The cleared balance for account ${account} is wrong`
-        );
-      } else {
-        expect(
-          await cardPaymentProcessor.unclearedBalanceOf(account)
-        ).to.equal(
-          expectedBalance,
-          `The uncleared balance for account ${account} is wrong`
-        );
-      }
-    }
-  }
-
-  async function checkCashbackNonces(payments: TestPayment[]) {
+  async function checkCashbackNonces(cardPaymentProcessor: Contract, payments: TestPayment[]) {
     for (let i = 0; i < payments.length; ++i) {
       const payment: TestPayment = payments[i];
       const expectedNonce: BigNumber = payment.status != PaymentStatus.Nonexistent
         ? BigNumber.from(payment.cashbackNonce || 0)
         : ethers.constants.Zero;
-      const cashback = await cardPaymentProcessor.getCashback(
-        createBytesString(payment.authorizationId, BYTES16_LENGTH)
-      );
+      const cashback = await cardPaymentProcessor.getCashback(payment.authorizationId);
       expect(cashback.lastCashbackNonce).to.equal(expectedNonce);
     }
   }
 
-  async function checkUnclearedBalances(payments: TestPayment[]) {
-    const expectedBalancesPerAccount: Map<string, number> = defineBalancesPerAccount(payments, PaymentStatus.Uncleared);
-    await checkBalancesOnBlockchain(expectedBalancesPerAccount, false);
-  }
+  async function checkClearedAndUnclearedBalances(cardPaymentProcessor: Contract, payments: TestPayment[]) {
+    const expectedBalancesPerAccount: Map<string, { unclearedBalance: number, clearedBalance: number, }> = new Map();
+    let expectedTotalUnclearedBalance = 0;
+    let expectedTotalClearedBalance = 0;
 
-  async function checkClearedBalances(payments: TestPayment[]) {
-    const expectedBalancesPerAccount: Map<string, number> = defineBalancesPerAccount(payments, PaymentStatus.Cleared);
-    await checkBalancesOnBlockchain(expectedBalancesPerAccount, true);
-  }
+    payments.forEach((payment: TestPayment) => {
+      const address: string = payment.account.address;
+      let newBalances = expectedBalancesPerAccount.get(address) || { unclearedBalance: 0, clearedBalance: 0 };
+      const amount = payment.amount - (payment.refundAmount || 0);
+      if (payment.status == PaymentStatus.Uncleared) {
+        newBalances.unclearedBalance += amount;
+        expectedTotalUnclearedBalance += amount;
+      } else if (payment.status == PaymentStatus.Cleared) {
+        newBalances.clearedBalance += amount;
+        expectedTotalClearedBalance += amount;
+      }
+      expectedBalancesPerAccount.set(address, newBalances);
+    });
 
-  async function checkTotalUnclearedBalance(payments: TestPayment[]) {
-    const expectedTotalUnclearedBalance: number = countNumberArrayTotal(payments.map(
-        function (payment: TestPayment): number {
-          return payment.status == PaymentStatus.Uncleared ? payment.amount - (payment.refundAmount || 0) : 0;
-        }
-      )
-    );
+    for (const account of expectedBalancesPerAccount.keys()) {
+      const expectedBalances = expectedBalancesPerAccount.get(account);
+      if (!expectedBalances) {
+        continue;
+      }
+      expect(
+        await cardPaymentProcessor.clearedBalanceOf(account)
+      ).to.equal(
+        expectedBalances.clearedBalance,
+        `The cleared balance for account ${account} is wrong`
+      );
+      expect(
+        await cardPaymentProcessor.unclearedBalanceOf(account)
+      ).to.equal(
+        expectedBalances.unclearedBalance,
+        `The uncleared balance for account ${account} is wrong`
+      );
+    }
     expect(
       await cardPaymentProcessor.totalUnclearedBalance()
     ).to.equal(
       expectedTotalUnclearedBalance,
       `The total uncleared balance is wrong`
     );
-  }
 
-  async function checkTotalClearedBalance(payments: TestPayment[]) {
-    const expectedTotalClearedBalance: number = countNumberArrayTotal(
-      payments.map(
-        function (payment: TestPayment): number {
-          return payment.status == PaymentStatus.Cleared ? payment.amount - (payment.refundAmount || 0) : 0;
-        }
-      )
-    );
     expect(
       await cardPaymentProcessor.totalClearedBalance()
     ).to.equal(
@@ -379,7 +470,8 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     );
   }
 
-  async function checkTokenBalance(payments: TestPayment[]) {
+  async function checkTokenBalance(fixture: Fixture, payments: TestPayment[]) {
+    const { cardPaymentProcessor, tokenMock } = fixture;
     const expectedTokenBalance: number = countNumberArrayTotal(
       payments.map(
         function (payment: TestPayment): number {
@@ -404,134 +496,143 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     );
   }
 
-  async function checkCardPaymentProcessorState(payments: TestPayment[]) {
-    await checkPaymentStructures(payments);
-    await checkCashbackNonces(payments);
-    await checkUnclearedBalances(payments);
-    await checkClearedBalances(payments);
-    await checkTotalUnclearedBalance(payments);
-    await checkTotalClearedBalance(payments);
-    await checkTokenBalance(payments);
+  async function checkCardPaymentProcessorState(fixture: Fixture, payments: TestPayment[]) {
+    await checkPaymentStructures(fixture.cardPaymentProcessor, payments);
+    await checkCashbackNonces(fixture.cardPaymentProcessor, payments);
+    await checkClearedAndUnclearedBalances(fixture.cardPaymentProcessor, payments);
+    await checkTokenBalance(fixture, payments);
   }
 
-  beforeEach(async () => {
-    // Deploy the token mock contract
-    const TokenMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
-    tokenMock = await TokenMock.deploy();
-    await tokenMock.deployed();
-    await proveTx(tokenMock.initialize("ERC20 Test", "TEST"));
+  function createTestPayments(): TestPayment[] {
+    return [
+      {
+        authorizationId: createBytesString(123, BYTES16_LENGTH),
+        account: user1,
+        amount: 234,
+        status: PaymentStatus.Nonexistent,
+        correlationId: createBytesString(345, BYTES16_LENGTH),
+        parentTxHash: createBytesString("aaa1", BYTES32_LENGTH),
+        compensationAmount: 0,
+        refundAmount: 0,
+      },
+      {
+        authorizationId: createBytesString(456, BYTES16_LENGTH),
+        account: user2,
+        amount: 567,
+        status: PaymentStatus.Nonexistent,
+        correlationId: createBytesString(789, BYTES16_LENGTH),
+        parentTxHash: createBytesString("aaa2", BYTES32_LENGTH),
+        compensationAmount: 0,
+        refundAmount: 0,
+      },
+    ];
+  }
 
-    // Deploy the contract under test
-    CardPaymentProcessor = await ethers.getContractFactory("CardPaymentProcessor");
-    cardPaymentProcessor = await CardPaymentProcessor.deploy();
-    await cardPaymentProcessor.deployed();
-    await proveTx(cardPaymentProcessor.initialize(tokenMock.address));
+  async function prepareForSinglePayment(): Promise<{ fixture: Fixture, payment: TestPayment }> {
+    const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
+    const [payment] = createTestPayments();
 
-    // Accounts
-    [deployer, cashOutAccount, executor, user1, user2] = await ethers.getSigners();
+    return { fixture, payment };
+  }
 
-    // Roles
-    ownerRole = (await cardPaymentProcessor.OWNER_ROLE()).toLowerCase();
-    blacklisterRole = (await cardPaymentProcessor.BLACKLISTER_ROLE()).toLowerCase();
-    pauserRole = (await cardPaymentProcessor.PAUSER_ROLE()).toLowerCase();
-    rescuerRole = (await cardPaymentProcessor.RESCUER_ROLE()).toLowerCase();
-    executorRole = (await cardPaymentProcessor.EXECUTOR_ROLE()).toLowerCase();
-  });
+  async function beforeMakingPayment(): Promise<{ fixture: Fixture, payment: TestPayment }> {
+    const { fixture, payment } = await prepareForSinglePayment();
+    await setUpContractsForPayments(fixture, [payment]);
 
-  it("The initialize function can't be called more than once", async () => {
-    await expect(
-      cardPaymentProcessor.initialize(tokenMock.address)
-    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
-  });
+    return { fixture, payment };
+  }
 
-  it("The initialize function is reverted if the passed token address is zero", async () => {
-    const anotherCardPaymentProcessor: Contract = await CardPaymentProcessor.deploy();
-    await anotherCardPaymentProcessor.deployed();
+  describe("Function 'initialize()'", async () => {
+    it("Configures the contract as expected", async () => {
+      const { cardPaymentProcessor, tokenMock } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
 
-    await expect(
-      anotherCardPaymentProcessor.initialize(ethers.constants.AddressZero)
-    ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_TOKEN_ADDRESS_IZ_ZERO);
-  });
+      // The underlying contract address
+      expect(await cardPaymentProcessor.underlyingToken()).to.equal(tokenMock.address);
 
-  it("The initial contract configuration should be as expected", async () => {
-    // The underlying contract address
-    expect(await cardPaymentProcessor.underlyingToken()).to.equal(tokenMock.address);
+      // The revocation limit
+      expect(await cardPaymentProcessor.revocationLimit()).to.equal(255);
 
-    // The revocation limit
-    expect(await cardPaymentProcessor.revocationLimit()).to.equal(255);
+      // The admins of roles
+      expect(await cardPaymentProcessor.getRoleAdmin(ownerRole)).to.equal(ownerRole);
+      expect(await cardPaymentProcessor.getRoleAdmin(blacklisterRole)).to.equal(ownerRole);
+      expect(await cardPaymentProcessor.getRoleAdmin(pauserRole)).to.equal(ownerRole);
+      expect(await cardPaymentProcessor.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
+      expect(await cardPaymentProcessor.getRoleAdmin(executorRole)).to.equal(ownerRole);
 
-    // The admins of roles
-    expect(await cardPaymentProcessor.getRoleAdmin(ownerRole)).to.equal(ownerRole);
-    expect(await cardPaymentProcessor.getRoleAdmin(blacklisterRole)).to.equal(ownerRole);
-    expect(await cardPaymentProcessor.getRoleAdmin(pauserRole)).to.equal(ownerRole);
-    expect(await cardPaymentProcessor.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
-    expect(await cardPaymentProcessor.getRoleAdmin(executorRole)).to.equal(ownerRole);
+      // The deployer should have the owner role, but not the other roles
+      expect(await cardPaymentProcessor.hasRole(ownerRole, deployer.address)).to.equal(true);
+      expect(await cardPaymentProcessor.hasRole(blacklisterRole, deployer.address)).to.equal(false);
+      expect(await cardPaymentProcessor.hasRole(pauserRole, deployer.address)).to.equal(false);
+      expect(await cardPaymentProcessor.hasRole(rescuerRole, deployer.address)).to.equal(false);
+      expect(await cardPaymentProcessor.hasRole(executorRole, deployer.address)).to.equal(false);
 
-    // The deployer should have the owner role, but not the other roles
-    expect(await cardPaymentProcessor.hasRole(ownerRole, deployer.address)).to.equal(true);
-    expect(await cardPaymentProcessor.hasRole(blacklisterRole, deployer.address)).to.equal(false);
-    expect(await cardPaymentProcessor.hasRole(pauserRole, deployer.address)).to.equal(false);
-    expect(await cardPaymentProcessor.hasRole(rescuerRole, deployer.address)).to.equal(false);
-    expect(await cardPaymentProcessor.hasRole(executorRole, deployer.address)).to.equal(false);
+      // The initial contract state is unpaused
+      expect(await cardPaymentProcessor.paused()).to.equal(false);
 
-    // The initial contract state is unpaused
-    expect(await cardPaymentProcessor.paused()).to.equal(false);
+      // Cashback related values
+      expect(await cardPaymentProcessor.cashbackDistributor()).to.equal(ZERO_ADDRESS);
+      expect(await cardPaymentProcessor.cashbackEnabled()).to.equal(false);
+      expect(await cardPaymentProcessor.cashbackRate()).to.equal(0);
+      expect(await cardPaymentProcessor.MAX_CASHBACK_RATE_IN_PERMIL()).to.equal(MAX_CASHBACK_RATE_IN_PERMIL);
 
-    // Cashback related values
-    expect(await cardPaymentProcessor.cashbackDistributor()).to.equal(ethers.constants.AddressZero);
-    expect(await cardPaymentProcessor.cashbackEnabled()).to.equal(false);
-    expect(await cardPaymentProcessor.cashbackRate()).to.equal(0);
-    expect(await cardPaymentProcessor.MAX_CASHBACK_RATE_IN_PERMIL()).to.equal(MAX_CASHBACK_RATE_IN_PERMIL);
+      // The cash-out account
+      expect(await cardPaymentProcessor.cashOutAccount()).to.equal(ZERO_ADDRESS);
+    });
 
-    // The cash-out account
-    expect(await cardPaymentProcessor.cashOutAccount()).to.equal(ethers.constants.AddressZero);
+    it("Is reverted if it is called a second time", async () => {
+      const { cardPaymentProcessor, tokenMock } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+      await expect(
+        cardPaymentProcessor.initialize(tokenMock.address)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("Is reverted if the passed token address is zero", async () => {
+      const anotherCardPaymentProcessor: Contract =
+        await upgrades.deployProxy(cardPaymentProcessorFactory, [], { initializer: false });
+
+      await expect(
+        anotherCardPaymentProcessor.initialize(ZERO_ADDRESS)
+      ).to.be.revertedWithCustomError(cardPaymentProcessorFactory, REVERT_ERROR_IF_TOKEN_ADDRESS_IZ_ZERO);
+    });
   });
 
   describe("Function 'setRevocationLimit()'", async () => {
-    it("Is reverted if is called not by the account with the owner role", async () => {
-      await expect(
-        cardPaymentProcessor.connect(user1).setRevocationLimit(REVOCATION_LIMIT)
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
-    });
-
-    it("Emits the correct event, changes the revocation counter limit properly", async () => {
+    it("Executes as expected and emits the correct event", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       expect(await cardPaymentProcessor.revocationLimit()).to.equal(REVOCATION_LIMIT_DEFAULT_VALUE);
 
       await expect(
         cardPaymentProcessor.setRevocationLimit(REVOCATION_LIMIT)
       ).to.emit(
         cardPaymentProcessor,
-        "SetRevocationLimit"
+        EVENT_NAME_SET_REVOCATION_LIMIT
       ).withArgs(
         REVOCATION_LIMIT_DEFAULT_VALUE,
         REVOCATION_LIMIT
       );
     });
 
-    it("Does not emit events if the new value equals the old one", async () => {
+    it("Does not emit an event if the new value equals the old one", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await expect(
         cardPaymentProcessor.setRevocationLimit(REVOCATION_LIMIT_DEFAULT_VALUE)
       ).not.to.emit(
         cardPaymentProcessor,
-        "SetRevocationLimit"
+        EVENT_NAME_SET_REVOCATION_LIMIT
       );
+    });
+
+    it("Is reverted if the caller does not have the owner role", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+      await expect(
+        cardPaymentProcessor.connect(user1).setRevocationLimit(REVOCATION_LIMIT)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
     });
   });
 
   describe("Function 'setCashbackDistributor()'", async () => {
-    it("Is reverted if the caller does not have the owner role", async () => {
-      await expect(
-        cardPaymentProcessor.connect(user1).setCashbackDistributor(CASHBACK_DISTRIBUTOR_ADDRESS_STUB1)
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
-    });
-
-    it("Is reverted if the new cashback distributor address is zero", async () => {
-      await expect(
-        cardPaymentProcessor.setCashbackDistributor(ethers.constants.AddressZero)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASHBACK_DISTRIBUTOR_IS_ZERO);
-    });
-
     it("Executes as expected and emits the correct event", async () => {
+      const { cardPaymentProcessor, tokenMock } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       expect(
         await tokenMock.allowance(cardPaymentProcessor.address, CASHBACK_DISTRIBUTOR_ADDRESS_STUB1)
       ).to.equal(0);
@@ -540,19 +641,34 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         cardPaymentProcessor.setCashbackDistributor(CASHBACK_DISTRIBUTOR_ADDRESS_STUB1)
       ).to.emit(
         cardPaymentProcessor,
-        "SetCashbackDistributor"
+        EVENT_NAME_SET_CASHBACK_DISTRIBUTOR
       ).withArgs(
-        ethers.constants.AddressZero,
+        ZERO_ADDRESS,
         CASHBACK_DISTRIBUTOR_ADDRESS_STUB1
       );
 
       expect(await cardPaymentProcessor.cashbackDistributor()).to.equal(CASHBACK_DISTRIBUTOR_ADDRESS_STUB1);
       expect(
         await tokenMock.allowance(cardPaymentProcessor.address, CASHBACK_DISTRIBUTOR_ADDRESS_STUB1)
-      ).to.equal(ethers.constants.MaxUint256);
+      ).to.equal(MAX_UINT256);
+    });
+
+    it("Is reverted if the caller does not have the owner role", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+      await expect(
+        cardPaymentProcessor.connect(user1).setCashbackDistributor(CASHBACK_DISTRIBUTOR_ADDRESS_STUB1)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
+    });
+
+    it("Is reverted if the new cashback distributor address is zero", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+      await expect(
+        cardPaymentProcessor.setCashbackDistributor(ZERO_ADDRESS)
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASHBACK_DISTRIBUTOR_IS_ZERO);
     });
 
     it("Is reverted if the cashback distributor has been already configured", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await proveTx(cardPaymentProcessor.setCashbackDistributor(CASHBACK_DISTRIBUTOR_ADDRESS_STUB1));
 
       await expect(
@@ -562,24 +678,14 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   });
 
   describe("Function 'setCashbackRate()'", async () => {
-    it("Is reverted if the caller does not have the owner role", async () => {
-      await expect(
-        cardPaymentProcessor.connect(user1).setCashbackRate(CASHBACK_RATE_IN_PERMIL)
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
-    });
-
-    it("Is reverted if the new rate exceeds the allowable maximum", async () => {
-      await expect(
-        cardPaymentProcessor.setCashbackRate(MAX_CASHBACK_RATE_IN_PERMIL + 1)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASHBACK_RATE_EXCESS);
-    });
-
     it("Executes as expected and emits the correct event", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+
       await expect(
         cardPaymentProcessor.setCashbackRate(CASHBACK_RATE_IN_PERMIL)
       ).to.emit(
         cardPaymentProcessor,
-        "SetCashbackRate"
+        EVENT_NAME_SET_CASHBACK_RATE
       ).withArgs(
         0,
         CASHBACK_RATE_IN_PERMIL
@@ -588,7 +694,22 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       expect(await cardPaymentProcessor.cashbackRate()).to.equal(CASHBACK_RATE_IN_PERMIL);
     });
 
+    it("Is reverted if the caller does not have the owner role", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+      await expect(
+        cardPaymentProcessor.connect(user1).setCashbackRate(CASHBACK_RATE_IN_PERMIL)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
+    });
+
+    it("Is reverted if the new rate exceeds the allowable maximum", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+      await expect(
+        cardPaymentProcessor.setCashbackRate(MAX_CASHBACK_RATE_IN_PERMIL + 1)
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASHBACK_RATE_EXCESS);
+    });
+
     it("Is reverted if called with the same argument twice", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await proveTx(cardPaymentProcessor.setCashbackRate(CASHBACK_RATE_IN_PERMIL));
 
       await expect(
@@ -598,32 +719,36 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   });
 
   describe("Function 'enableCashback()'", async () => {
-    it("Is reverted if the caller does not have the owner role", async () => {
-      await expect(
-        cardPaymentProcessor.connect(user1).enableCashback()
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
-    });
-
-    it("Is reverted if the cashback distributor was not configured", async () => {
-      await expect(
-        cardPaymentProcessor.enableCashback()
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASHBACK_DISTRIBUTOR_NOT_CONFIGURED);
-    });
-
     it("Executes as expected and emits the correct event", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await proveTx(cardPaymentProcessor.setCashbackDistributor(CASHBACK_DISTRIBUTOR_ADDRESS_STUB1));
 
       await expect(
         cardPaymentProcessor.enableCashback()
       ).to.emit(
         cardPaymentProcessor,
-        "EnableCashback"
+        EVENT_NAME_ENABLE_CASHBACK
       );
 
       expect(await cardPaymentProcessor.cashbackEnabled()).to.equal(true);
     });
 
+    it("Is reverted if the caller does not have the owner role", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+      await expect(
+        cardPaymentProcessor.connect(user1).enableCashback()
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
+    });
+
+    it("Is reverted if the cashback distributor was not configured", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+      await expect(
+        cardPaymentProcessor.enableCashback()
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASHBACK_DISTRIBUTOR_NOT_CONFIGURED);
+    });
+
     it("Is reverted if the cashback operations are already enabled", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await proveTx(cardPaymentProcessor.setCashbackDistributor(CASHBACK_DISTRIBUTOR_ADDRESS_STUB1));
       await proveTx(cardPaymentProcessor.enableCashback());
 
@@ -633,20 +758,9 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     });
   });
 
-  describe("Function 'disableCashbackCashback()'", async () => {
-    it("Is reverted if the caller does not have the owner role", async () => {
-      await expect(
-        cardPaymentProcessor.connect(user1).disableCashback()
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
-    });
-
-    it("Is reverted if the cashback operations are already disabled", async () => {
-      await expect(
-        cardPaymentProcessor.disableCashback()
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASHBACK_ALREADY_DISABLED);
-    });
-
+  describe("Function 'disableCashback()'", async () => {
     it("Executes as expected and emits the correct event", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await proveTx(cardPaymentProcessor.setCashbackDistributor(CASHBACK_DISTRIBUTOR_ADDRESS_STUB1));
       await proveTx(cardPaymentProcessor.enableCashback());
       expect(await cardPaymentProcessor.cashbackEnabled()).to.equal(true);
@@ -655,49 +769,68 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         cardPaymentProcessor.disableCashback()
       ).to.emit(
         cardPaymentProcessor,
-        "DisableCashback"
+        EVENT_NAME_DISABLE_CASHBACK
       );
 
       expect(await cardPaymentProcessor.cashbackEnabled()).to.equal(false);
     });
-  });
 
-  describe("Function 'setCashOutAccount()'", async () => {
     it("Is reverted if the caller does not have the owner role", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await expect(
-        cardPaymentProcessor.connect(user1).setCashOutAccount(cashOutAccount.address)
+        cardPaymentProcessor.connect(user1).disableCashback()
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
     });
 
+    it("Is reverted if the cashback operations are already disabled", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+      await expect(
+        cardPaymentProcessor.disableCashback()
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASHBACK_ALREADY_DISABLED);
+    });
+  });
+
+  describe("Function 'setCashOutAccount()'", async () => {
     it("Executes as expected and emits the correct event", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+
       await expect(
         cardPaymentProcessor.setCashOutAccount(cashOutAccount.address)
       ).to.emit(
         cardPaymentProcessor,
-        "SetCashOutAccount"
+        EVENT_NAME_SET_CASH_OUT_ACCOUNT
       ).withArgs(
-        ethers.constants.AddressZero,
+        ZERO_ADDRESS,
         cashOutAccount.address
       );
 
       expect(await cardPaymentProcessor.cashOutAccount()).to.equal(cashOutAccount.address);
 
+      // Can set the zero address
       await expect(
-        cardPaymentProcessor.setCashOutAccount(ethers.constants.AddressZero)
+        cardPaymentProcessor.setCashOutAccount(ZERO_ADDRESS)
       ).to.emit(
         cardPaymentProcessor,
-        "SetCashOutAccount"
+        EVENT_NAME_SET_CASH_OUT_ACCOUNT
       ).withArgs(
         cashOutAccount.address,
-        ethers.constants.AddressZero
+        ZERO_ADDRESS
       );
 
-      expect(await cardPaymentProcessor.cashOutAccount()).to.equal(ethers.constants.AddressZero);
+      expect(await cardPaymentProcessor.cashOutAccount()).to.equal(ZERO_ADDRESS);
+    });
+
+    it("Is reverted if the caller does not have the owner role", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+      await expect(
+        cardPaymentProcessor.connect(user1).setCashOutAccount(cashOutAccount.address)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
     });
 
     it("Is reverted if the new cash-out account is the same as the previous set one", async () => {
+      const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await expect(
-        cardPaymentProcessor.setCashOutAccount(ethers.constants.AddressZero)
+        cardPaymentProcessor.setCashOutAccount(ZERO_ADDRESS)
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASH_OUT_ACCOUNT_IS_UNCHANGED);
 
       await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
@@ -709,576 +842,499 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   });
 
   describe("Function 'makePayment()'", async () => {
-    let cashbackDistributorMock: Contract;
-    let cashbackDistributorMockConfig: CashbackDistributorMockConfig;
-    let payment: TestPayment;
-    let authorizationId: string;
-    let correlationId: string;
-
-    beforeEach(async () => {
-      ({ cashbackDistributorMock, cashbackDistributorMockConfig } = await setUpAndEnableCashback());
-      payment = {
-        authorizationId: 123,
-        account: user1,
-        amount: 234,
-        status: PaymentStatus.Nonexistent,
-        makingPaymentCorrelationId: 345,
-        cashbackNonce: cashbackDistributorMockConfig.sendCashbackNonceResult,
-        cashbackRateInPermil: CASHBACK_RATE_IN_PERMIL,
-      };
-      payment.compensationAmount = calculateCompensationAmount(payment);
-      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
-      correlationId = createBytesString(payment.makingPaymentCorrelationId, BYTES16_LENGTH);
-      await setUpContractsForPayments([payment]);
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
-      await proveTx(cardPaymentProcessor.pause());
-
-      await expect(
-        cardPaymentProcessor.connect(payment.account).makePayment(
-          payment.amount,
-          authorizationId,
-          correlationId
-        )
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller is blacklisted", async () => {
-      await proveTx(cardPaymentProcessor.grantRole(blacklisterRole, deployer.address));
-      await proveTx(cardPaymentProcessor.blacklist(payment.account.address));
-
-      await expect(
-        cardPaymentProcessor.connect(payment.account).makePayment(
-          payment.amount,
-          authorizationId,
-          correlationId
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
-    });
-
-    it("Is reverted if the payment authorization ID is zero", async () => {
-      await expect(
-        cardPaymentProcessor.connect(payment.account).makePayment(
-          payment.amount,
-          ZERO_AUTHORIZATION_ID,
-          correlationId
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
-    });
-
-    it("Is reverted if the user has not enough token balance", async () => {
-      const excessTokenAmount: number = payment.amount + 1;
-
-      await expect(
-        cardPaymentProcessor.connect(payment.account).makePayment(
-          excessTokenAmount,
-          authorizationId,
-          correlationId
-        )
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
-    });
-
-    async function checkPaymentMaking() {
+    async function checkPaymentMakingWithCashback(fixture: Fixture, payment: TestPayment) {
+      const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+      await proveTx(fixture.cardPaymentProcessor.enableCashback());
+      setCashback(payment, fixture);
       const cashbackAmount: number = calculateCashback(payment);
-      await checkCardPaymentProcessorState([payment]);
 
-      const txResponse: TransactionResponse = await cardPaymentProcessor.connect(payment.account).makePayment(
+      await checkCardPaymentProcessorState(fixture, [payment]);
+
+      const tx: TransactionResponse = await cardPaymentProcessor.connect(payment.account).makePayment(
         payment.amount,
-        authorizationId,
-        correlationId
+        payment.authorizationId,
+        payment.correlationId
       );
-      await expect(
-        txResponse
-      ).to.changeTokenBalances(
+      await expect(tx).to.changeTokenBalances(
         tokenMock,
         [cardPaymentProcessor, payment.account],
         [+payment.amount, -payment.amount]
       ).and.to.emit(
         cardPaymentProcessor,
-        "MakePayment"
+        EVENT_NAME_MAKE_PAYMENT
       ).withArgs(
-        authorizationId,
-        correlationId,
+        payment.authorizationId,
+        payment.correlationId,
         payment.account.address,
         payment.amount,
         payment.revocationCounter || 0,
         payment.account.address
       );
-      await expect(
-        txResponse
-      ).and.to.emit(
+      await expect(tx).and.to.emit(
         cardPaymentProcessor,
-        "SendCashbackSuccess"
+        EVENT_NAME_SEND_CASHBACK_SUCCESS
       ).withArgs(
         cashbackDistributorMock.address,
         cashbackAmount,
-        payment.cashbackNonce
+        payment.cashbackNonce || 0
       );
-      await expect(
-        txResponse
-      ).to.emit(
+      await expect(tx).to.emit(
         cashbackDistributorMock,
-        "SendCashbackMock"
+        EVENT_NAME_SEND_CASHBACK_MOCK
       ).withArgs(
         cardPaymentProcessor.address,
         tokenMock.address,
         CashbackKind.CardPayment,
-        createBytesString(payment.authorizationId, BYTES16_LENGTH).padEnd(BYTES32_LENGTH * 2 + 2, "0"),
+        payment.authorizationId.padEnd(BYTES32_LENGTH * 2 + 2, "0"),
         payment.account.address,
         cashbackAmount
       );
 
       payment.status = PaymentStatus.Uncleared;
-      await checkCardPaymentProcessorState([payment]);
+      await checkCardPaymentProcessorState(fixture, [payment]);
     }
 
-    it("Executes as expected and emits the correct events if the payment amount is nonzero", async () => {
-      await checkPaymentMaking();
+    describe("Executes as expected if the cashback is enabled and the payment amount is", async () => {
+      it("Nonzero", async () => {
+        const { fixture, payment } = await beforeMakingPayment();
+        await checkPaymentMakingWithCashback(fixture, payment);
+      });
+
+      it("Zero", async () => {
+        const { fixture, payment } = await beforeMakingPayment();
+        payment.amount = 0;
+        payment.compensationAmount = calculateCompensationAmount(payment);
+        await checkPaymentMakingWithCashback(fixture, payment);
+      });
+
+      it("Nonzero even if the revocation limit of payments is zero", async () => {
+        const { fixture, payment } = await beforeMakingPayment();
+        await proveTx(fixture.cardPaymentProcessor.setRevocationLimit(0));
+        await checkPaymentMakingWithCashback(fixture, payment);
+      });
     });
 
-    it("Executes as expected and emits the correct events if the payment amount is zero", async () => {
-      payment.amount = 0;
-      payment.compensationAmount = calculateCompensationAmount(payment);
-      await checkPaymentMaking();
-    });
+    describe("Executes successfully if the payment amount is nonzero but does not send cashback if", async () => {
+      it("Cashback is disabled", async () => {
+        const { fixture, payment } = await beforeMakingPayment();
+        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
 
-    it("Executes successfully even if the revocation limit of payments is zero", async () => {
-      await proveTx(cardPaymentProcessor.setRevocationLimit(0));
-      await checkPaymentMaking();
-    });
+        await expect(
+          cardPaymentProcessor.connect(payment.account).makePayment(
+            payment.amount,
+            payment.authorizationId,
+            payment.correlationId
+          )
+        ).to.changeTokenBalances(
+          tokenMock,
+          [cardPaymentProcessor, payment.account],
+          [+payment.amount, -payment.amount]
+        ).and.to.emit(
+          cardPaymentProcessor,
+          EVENT_NAME_MAKE_PAYMENT
+        ).and.not.to.emit(
+          cashbackDistributorMock,
+          EVENT_NAME_SEND_CASHBACK_MOCK
+        );
 
-    it("Executes successfully but do not send a cashback if it is disabled", async () => {
-      await proveTx(cardPaymentProcessor.disableCashback());
-      setCashbackRate(payment, ZERO_CASHBACK_RATE);
-      payment.cashbackNonce = undefined;
+        payment.status = PaymentStatus.Uncleared;
+        await checkCardPaymentProcessorState(fixture, [payment]);
+      });
 
-      await expect(
-        cardPaymentProcessor.connect(payment.account).makePayment(
+      it("Cashback sending fails", async () => {
+        const { fixture, payment } = await beforeMakingPayment();
+        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+        await proveTx(cashbackDistributorMock.setSendCashbackSuccessResult(false));
+        await proveTx(cardPaymentProcessor.enableCashback());
+
+        const cashbackAmount: number = calculateCashback(payment, CASHBACK_RATE_IN_PERMIL);
+        setCashbackNonce(payment, fixture);
+
+        const tx: TransactionResponse = await cardPaymentProcessor.connect(payment.account).makePayment(
           payment.amount,
-          authorizationId,
-          correlationId
-        )
-      ).to.changeTokenBalances(
-        tokenMock,
-        [cardPaymentProcessor, payment.account],
-        [+payment.amount, -payment.amount]
-      ).and.to.emit(
-        cardPaymentProcessor,
-        "MakePayment"
-      ).and.not.to.emit(
-        cardPaymentProcessor,
-        "SendCashbackSuccess"
-      ).and.not.to.emit(
-        cashbackDistributorMock,
-        "SendCashbackMock"
-      );
+          payment.authorizationId,
+          payment.correlationId
+        );
+        await expect(tx).to.changeTokenBalances(
+          tokenMock,
+          [cardPaymentProcessor, payment.account],
+          [+payment.amount, -payment.amount]
+        ).and.to.emit(
+          cardPaymentProcessor,
+          EVENT_NAME_MAKE_PAYMENT
+        ).withArgs(
+          payment.authorizationId,
+          payment.correlationId,
+          payment.account.address,
+          payment.amount,
+          payment.revocationCounter || 0,
+          payment.account.address
+        ).and.not.to.emit(
+          cardPaymentProcessor,
+          EVENT_NAME_SEND_CASHBACK_SUCCESS
+        );
+        await expect(tx).to.emit(
+          cardPaymentProcessor,
+          EVENT_NAME_SEND_CASHBACK_FAILURE
+        ).withArgs(
+          cashbackDistributorMock.address,
+          cashbackAmount,
+          payment.cashbackNonce || 0
+        );
+        await expect(tx).to.emit(
+          cashbackDistributorMock,
+          EVENT_NAME_SEND_CASHBACK_MOCK
+        ).withArgs(
+          cardPaymentProcessor.address,
+          tokenMock.address,
+          CashbackKind.CardPayment,
+          payment.authorizationId.padEnd(BYTES32_LENGTH * 2 + 2, "0"),
+          payment.account.address,
+          cashbackAmount,
+        );
 
-      payment.status = PaymentStatus.Uncleared;
-      await checkCardPaymentProcessorState([payment]);
+        payment.status = PaymentStatus.Uncleared;
+        await checkCardPaymentProcessorState(fixture, [payment]);
+      });
     });
 
-    it("Executes successfully and emits the correct events if cashback sending fails", async () => {
-      const cashbackAmount: number = calculateCashback(payment);
-      await proveTx(cashbackDistributorMock.setSendCashbackSuccessResult(false));
-      setCashbackRate(payment, ZERO_CASHBACK_RATE);
+    describe("Is reverted if", async () => {
+      it("The contract is paused", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await pauseContract(cardPaymentProcessor);
 
-      const txResponse: TransactionResponse = await cardPaymentProcessor.connect(payment.account).makePayment(
-        payment.amount,
-        authorizationId,
-        correlationId
-      );
-      await expect(
-        txResponse
-      ).to.changeTokenBalances(
-        tokenMock,
-        [cardPaymentProcessor, payment.account],
-        [+payment.amount, -payment.amount]
-      ).and.to.emit(
-        cardPaymentProcessor,
-        "MakePayment"
-      ).withArgs(
-        authorizationId,
-        correlationId,
-        payment.account.address,
-        payment.amount,
-        payment.revocationCounter || 0,
-        payment.account.address
-      ).and.not.to.emit(
-        cardPaymentProcessor,
-        "SendCashbackSuccess"
-      );
-      await expect(
-        txResponse
-      ).to.emit(
-        cardPaymentProcessor,
-        "SendCashbackFailure"
-      ).withArgs(
-        cashbackDistributorMock.address,
-        cashbackAmount,
-        payment.cashbackNonce
-      );
-      await expect(
-        txResponse
-      ).to.emit(
-        cashbackDistributorMock,
-        "SendCashbackMock"
-      ).withArgs(
-        cardPaymentProcessor.address,
-        tokenMock.address,
-        CashbackKind.CardPayment,
-        createBytesString(payment.authorizationId, BYTES16_LENGTH).padEnd(BYTES32_LENGTH * 2 + 2, "0"),
-        payment.account.address,
-        cashbackAmount,
-      );
+        await expect(
+          cardPaymentProcessor.connect(payment.account).makePayment(
+            payment.amount,
+            payment.authorizationId,
+            payment.correlationId
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
 
-      payment.status = PaymentStatus.Uncleared;
-      await checkCardPaymentProcessorState([payment]);
-    });
+      it("The caller is blacklisted", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await proveTx(cardPaymentProcessor.grantRole(blacklisterRole, deployer.address));
+        await proveTx(cardPaymentProcessor.blacklist(payment.account.address));
 
-    it("Is reverted if the payment authorization ID already exists", async () => {
-      await makePayments([payment]);
-      const otherMakingPaymentCorrelationsId: string = createBytesString(
-        payment.makingPaymentCorrelationId + 1,
-        BYTES16_LENGTH
-      );
+        await expect(
+          cardPaymentProcessor.connect(payment.account).makePayment(
+            payment.amount,
+            payment.authorizationId,
+            payment.correlationId
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
+      });
 
-      await expect(
-        cardPaymentProcessor.connect(payment.account).makePayment(
-          payment.amount + 1,
-          authorizationId,
-          otherMakingPaymentCorrelationsId
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
+      it("The payment authorization ID is zero", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(payment.account).makePayment(
+            payment.amount,
+            ZERO_AUTHORIZATION_ID,
+            payment.correlationId
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      });
+
+      it("The account has not enough token balance", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
+        const excessTokenAmount: number = payment.amount + 1;
+
+        await expect(
+          cardPaymentProcessor.connect(payment.account).makePayment(
+            excessTokenAmount,
+            payment.authorizationId,
+            payment.correlationId
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+      });
+
+      it("The payment with the provided authorization ID already exists", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
+        await makePayments(cardPaymentProcessor, [payment]);
+        const otherMakingPaymentCorrelationsId: string = increaseBytesString(
+          payment.correlationId,
+          BYTES16_LENGTH
+        );
+
+        await expect(
+          cardPaymentProcessor.connect(payment.account).makePayment(
+            payment.amount + 1,
+            payment.authorizationId,
+            otherMakingPaymentCorrelationsId
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
+      });
     });
   });
 
   describe("Function 'makePaymentFrom()'", async () => {
-    let cashbackDistributorMock: Contract;
-    let cashbackDistributorMockConfig: CashbackDistributorMockConfig;
-    let payment: TestPayment;
-    let authorizationId: string;
-    let correlationId: string;
-
-    beforeEach(async () => {
-      ({ cashbackDistributorMock, cashbackDistributorMockConfig } = await setUpAndEnableCashback());
-      payment = {
-        authorizationId: 234,
-        account: user1,
-        amount: 345,
-        status: PaymentStatus.Nonexistent,
-        makingPaymentCorrelationId: 456,
-        cashbackNonce: cashbackDistributorMockConfig.sendCashbackNonceResult,
-        cashbackRateInPermil: CASHBACK_RATE_IN_PERMIL,
-      };
-      payment.compensationAmount = calculateCompensationAmount(payment);
-      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
-      correlationId = createBytesString(payment.makingPaymentCorrelationId, BYTES16_LENGTH);
-      await setUpContractsForPayments([payment]);
-      await setExecutorRole(executor);
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
-      await proveTx(cardPaymentProcessor.pause());
-
-      await expect(
-        cardPaymentProcessor.connect(executor).makePaymentFrom(
-          payment.account.address,
-          payment.amount,
-          authorizationId,
-          correlationId
-        )
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller does not have the executor role", async () => {
-      await expect(
-        cardPaymentProcessor.connect(payment.account).makePaymentFrom(
-          payment.account.address,
-          payment.amount,
-          authorizationId,
-          correlationId
-        )
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(payment.account.address, executorRole));
-    });
-
-    it("Is reverted if the payment account address is zero", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).makePaymentFrom(
-          ethers.constants.AddressZero,
-          payment.amount,
-          authorizationId,
-          correlationId
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ACCOUNT_IS_ZERO);
-    });
-
-    it("Is reverted if the payment authorization ID is zero", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).makePaymentFrom(
-          payment.account.address,
-          payment.amount,
-          ZERO_AUTHORIZATION_ID,
-          correlationId
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
-    });
-
-    it("Is reverted if the user has not enough token balance", async () => {
-      const excessTokenAmount: number = payment.amount + 1;
-
-      await expect(
-        cardPaymentProcessor.connect(executor).makePaymentFrom(
-          payment.account.address,
-          excessTokenAmount,
-          authorizationId,
-          correlationId
-        )
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
-    });
-
-    async function checkPaymentMakingFrom() {
+    async function checkPaymentMakingFromWithCashback(fixture: Fixture, payment: TestPayment) {
+      const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+      await proveTx(fixture.cardPaymentProcessor.enableCashback());
+      setCashback(payment, fixture);
       const cashbackAmount: number = calculateCashback(payment);
-      await checkCardPaymentProcessorState([payment]);
 
-      const txResponse: TransactionResponse = await cardPaymentProcessor.connect(executor).makePaymentFrom(
+      await checkCardPaymentProcessorState(fixture, [payment]);
+
+      const tx: TransactionResponse = await cardPaymentProcessor.connect(executor).makePaymentFrom(
         payment.account.address,
         payment.amount,
-        authorizationId,
-        correlationId
+        payment.authorizationId,
+        payment.correlationId
       );
-      await expect(
-        txResponse
-      ).to.changeTokenBalances(
+      await expect(tx).to.changeTokenBalances(
         tokenMock,
         [cardPaymentProcessor, payment.account, executor],
         [+payment.amount, -payment.amount, 0]
       ).and.to.emit(
         cardPaymentProcessor,
-        "MakePayment"
+        EVENT_NAME_MAKE_PAYMENT
       ).withArgs(
-        authorizationId,
-        correlationId,
+        payment.authorizationId,
+        payment.correlationId,
         payment.account.address,
         payment.amount,
         payment.revocationCounter || 0,
         executor.address
       );
-      await expect(
-        txResponse
-      ).to.emit(
+      await expect(tx).to.emit(
         cardPaymentProcessor,
-        "SendCashbackSuccess"
+        EVENT_NAME_SEND_CASHBACK_SUCCESS
       ).withArgs(
         cashbackDistributorMock.address,
         cashbackAmount,
-        payment.cashbackNonce
+        payment.cashbackNonce || 0
       );
-      await expect(
-        txResponse
-      ).to.emit(
+      await expect(tx).to.emit(
         cashbackDistributorMock,
-        "SendCashbackMock"
+        EVENT_NAME_SEND_CASHBACK_MOCK
       ).withArgs(
         cardPaymentProcessor.address,
         tokenMock.address,
         CashbackKind.CardPayment,
-        createBytesString(payment.authorizationId, BYTES16_LENGTH).padEnd(BYTES32_LENGTH * 2 + 2, "0"),
+        payment.authorizationId.padEnd(BYTES32_LENGTH * 2 + 2, "0"),
         payment.account.address,
         cashbackAmount
       );
 
       payment.status = PaymentStatus.Uncleared;
-      await checkCardPaymentProcessorState([payment]);
+      await checkCardPaymentProcessorState(fixture, [payment]);
     }
 
-    it("Executes as expected and emits the correct events if the payment amount is nonzero", async () => {
-      await checkPaymentMakingFrom();
+    describe("Executes as expected if the cashback is enabled and the payment amount is", async () => {
+      it("Nonzero", async () => {
+        const { fixture, payment } = await beforeMakingPayment();
+        await checkPaymentMakingFromWithCashback(fixture, payment);
+      });
+
+      it("Zero", async () => {
+        const { fixture, payment } = await beforeMakingPayment();
+        payment.amount = 0;
+        payment.compensationAmount = calculateCompensationAmount(payment);
+        await checkPaymentMakingFromWithCashback(fixture, payment);
+      });
+
+      it("Nonzero even if the revocation limit of payments is zero", async () => {
+        const { fixture, payment } = await beforeMakingPayment();
+        await proveTx(fixture.cardPaymentProcessor.setRevocationLimit(0));
+        await checkPaymentMakingFromWithCashback(fixture, payment);
+      });
     });
 
-    it("Executes as expected and emits the correct events if the payment amount is zero", async () => {
-      payment.amount = 0;
-      payment.compensationAmount = calculateCompensationAmount(payment);
-      await checkPaymentMakingFrom();
-    });
+    describe("Executes successfully if the payment amount is nonzero but does not send cashback if", async () => {
+      it("Cashback is disabled", async () => {
+        const { fixture, payment } = await beforeMakingPayment();
+        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
 
-    it("Executes successfully even if the revocation limit of payments is zero", async () => {
-      await proveTx(cardPaymentProcessor.setRevocationLimit(0));
-      await checkPaymentMakingFrom();
-    });
+        await expect(
+          cardPaymentProcessor.connect(executor).makePaymentFrom(
+            payment.account.address,
+            payment.amount,
+            payment.authorizationId,
+            payment.correlationId
+          )
+        ).to.changeTokenBalances(
+          tokenMock,
+          [cardPaymentProcessor, payment.account],
+          [+payment.amount, -payment.amount]
+        ).and.to.emit(
+          cardPaymentProcessor,
+          EVENT_NAME_MAKE_PAYMENT
+        ).and.not.to.emit(
+          cashbackDistributorMock,
+          EVENT_NAME_SEND_CASHBACK_MOCK
+        );
 
-    it("Executes successfully but do not send a cashback if it is disabled", async () => {
-      await proveTx(cardPaymentProcessor.disableCashback());
-      setCashbackRate(payment, ZERO_CASHBACK_RATE);
-      payment.cashbackNonce = undefined;
+        payment.status = PaymentStatus.Uncleared;
+        await checkCardPaymentProcessorState(fixture, [payment]);
+      });
 
-      await expect(
-        cardPaymentProcessor.connect(executor).makePaymentFrom(
+      it("Cashback sending fails", async () => {
+        const { fixture, payment } = await beforeMakingPayment();
+        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+        await proveTx(cashbackDistributorMock.setSendCashbackSuccessResult(false));
+        await proveTx(cardPaymentProcessor.enableCashback());
+
+        const cashbackAmount: number = calculateCashback(payment, CASHBACK_RATE_IN_PERMIL);
+        setCashbackNonce(payment, fixture);
+
+        const tx: TransactionResponse = await cardPaymentProcessor.connect(executor).makePaymentFrom(
           payment.account.address,
           payment.amount,
-          authorizationId,
-          correlationId
-        )
-      ).to.emit(
-        cardPaymentProcessor,
-        "MakePayment"
-      ).withArgs(
-        authorizationId,
-        correlationId,
-        payment.account.address,
-        payment.amount,
-        payment.revocationCounter || 0,
-        executor.address
-      ).and.not.to.emit(
-        cardPaymentProcessor,
-        "SendCashbackSuccess"
-      ).and.not.to.emit(
-        cashbackDistributorMock,
-        "SendCashbackMock"
-      );
-
-      payment.status = PaymentStatus.Uncleared;
-      await checkCardPaymentProcessorState([payment]);
-    });
-
-    it("Executes successfully and emits the correct events if cashback sending fails", async () => {
-      const cashbackAmount: number = calculateCashback(payment);
-      await proveTx(cashbackDistributorMock.setSendCashbackSuccessResult(false));
-      setCashbackRate(payment, ZERO_CASHBACK_RATE);
-
-      const txResponse: TransactionResponse = cardPaymentProcessor.connect(executor).makePaymentFrom(
-        payment.account.address,
-        payment.amount,
-        authorizationId,
-        correlationId
-      );
-      await expect(
-        txResponse
-      ).to.emit(
-        cardPaymentProcessor,
-        "MakePayment"
-      ).withArgs(
-        authorizationId,
-        correlationId,
-        payment.account.address,
-        payment.amount,
-        payment.revocationCounter || 0,
-        executor.address
-      ).and.not.to.emit(
-        cardPaymentProcessor,
-        "SendCashbackSuccess"
-      );
-      await expect(
-        txResponse
-      ).to.emit(
-        cardPaymentProcessor,
-        "SendCashbackFailure"
-      ).withArgs(
-        cashbackDistributorMock.address,
-        cashbackAmount,
-        payment.cashbackNonce
-      );
-      await expect(
-        txResponse
-      ).to.emit(
-        cashbackDistributorMock,
-        "SendCashbackMock"
-      ).withArgs(
-        cardPaymentProcessor.address,
-        tokenMock.address,
-        CashbackKind.CardPayment,
-        createBytesString(payment.authorizationId, BYTES16_LENGTH).padEnd(BYTES32_LENGTH * 2 + 2, "0"),
-        payment.account.address,
-        cashbackAmount
-      );
-
-      payment.status = PaymentStatus.Uncleared;
-      await checkCardPaymentProcessorState([payment]);
-    });
-
-    it("Is reverted if the payment authorization ID already exists", async () => {
-      await makePayments([payment]);
-      const otherMakingPaymentCorrelationsId: string = createBytesString(
-        payment.makingPaymentCorrelationId + 1,
-        BYTES16_LENGTH
-      );
-
-      await expect(
-        cardPaymentProcessor.connect(executor).makePaymentFrom(
+          payment.authorizationId,
+          payment.correlationId
+        );
+        await expect(tx).to.changeTokenBalances(
+          tokenMock,
+          [cardPaymentProcessor, payment.account],
+          [+payment.amount, -payment.amount]
+        ).and.to.emit(
+          cardPaymentProcessor,
+          EVENT_NAME_MAKE_PAYMENT
+        ).withArgs(
+          payment.authorizationId,
+          payment.correlationId,
           payment.account.address,
           payment.amount,
-          authorizationId,
-          otherMakingPaymentCorrelationsId
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
+          payment.revocationCounter || 0,
+          executor.address
+        ).and.not.to.emit(
+          cardPaymentProcessor,
+          EVENT_NAME_SEND_CASHBACK_SUCCESS
+        );
+        await expect(tx).to.emit(
+          cardPaymentProcessor,
+          EVENT_NAME_SEND_CASHBACK_FAILURE
+        ).withArgs(
+          cashbackDistributorMock.address,
+          cashbackAmount,
+          payment.cashbackNonce || 0
+        );
+        await expect(tx).to.emit(
+          cashbackDistributorMock,
+          EVENT_NAME_SEND_CASHBACK_MOCK
+        ).withArgs(
+          cardPaymentProcessor.address,
+          tokenMock.address,
+          CashbackKind.CardPayment,
+          payment.authorizationId.padEnd(BYTES32_LENGTH * 2 + 2, "0"),
+          payment.account.address,
+          cashbackAmount,
+        );
+
+        payment.status = PaymentStatus.Uncleared;
+        await checkCardPaymentProcessorState(fixture, [payment]);
+      });
+    });
+
+    describe("Is reverted if", async () => {
+      it("The contract is paused", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await pauseContract(cardPaymentProcessor);
+
+        await expect(
+          cardPaymentProcessor.connect(executor).makePaymentFrom(
+            payment.account.address,
+            payment.amount,
+            payment.authorizationId,
+            payment.correlationId
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The caller does not have the executor role", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(payment.account).makePaymentFrom(
+            payment.account.address,
+            payment.amount,
+            payment.authorizationId,
+            payment.correlationId
+          )
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(payment.account.address, executorRole));
+      });
+
+      it("The payment account address is zero", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(executor).makePaymentFrom(
+            ZERO_ADDRESS,
+            payment.amount,
+            payment.authorizationId,
+            payment.correlationId
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ACCOUNT_IS_ZERO);
+      });
+
+      it("The payment authorization ID is zero", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(executor).makePaymentFrom(
+            payment.account.address,
+            payment.amount,
+            ZERO_AUTHORIZATION_ID,
+            payment.correlationId
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      });
+
+      it("The account has not enough token balance", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
+        const excessTokenAmount: number = payment.amount + 1;
+
+        await expect(
+          cardPaymentProcessor.connect(executor).makePaymentFrom(
+            payment.account.address,
+            excessTokenAmount,
+            payment.authorizationId,
+            payment.correlationId
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+      });
+
+      it("The payment with the provided authorization ID already exists", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
+        await makePayments(cardPaymentProcessor, [payment]);
+        const otherMakingPaymentCorrelationsId: string = increaseBytesString(
+          payment.correlationId,
+          BYTES16_LENGTH
+        );
+
+        await expect(
+          cardPaymentProcessor.connect(executor).makePaymentFrom(
+            payment.account.address,
+            payment.amount,
+            payment.authorizationId,
+            otherMakingPaymentCorrelationsId
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
+      });
     });
   });
 
   describe("Function 'clearPayment()'", async () => {
-    let payment: TestPayment;
-    let authorizationId: string;
-
-    beforeEach(async () => {
-      payment = {
-        authorizationId: 123,
-        account: user1,
-        amount: 234,
-        status: PaymentStatus.Nonexistent,
-        makingPaymentCorrelationId: 345,
-      };
-      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
-      await setUpContractsForPayments([payment]);
-      await setExecutorRole(executor);
-      await makePayments([payment]);
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
-      await proveTx(cardPaymentProcessor.pause());
-
-      await expect(
-        cardPaymentProcessor.connect(executor).clearPayment(authorizationId)
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller does not have the executor role", async () => {
-      await expect(
-        cardPaymentProcessor.connect(deployer).clearPayment(authorizationId)
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
-    });
-
-    it("Is reverted if the payment authorization ID is zero", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).clearPayment(ZERO_AUTHORIZATION_ID)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
-    });
-
-    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).clearPayment(
-          createBytesString(payment.authorizationId + 1, BYTES16_LENGTH)
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
-    });
-
     it("Executes as expected, emits the correct event, and does not transfer tokens", async () => {
-      await checkCardPaymentProcessorState([payment]);
+      const { fixture, payment } = await beforeMakingPayment();
+      const { cardPaymentProcessor, tokenMock } = fixture;
+      await makePayments(fixture.cardPaymentProcessor, [payment]);
       const expectedClearedBalance: number = payment.amount;
       const expectedUnclearedBalance: number = 0;
 
+      await checkCardPaymentProcessorState(fixture, [payment]);
+
       await expect(
-        cardPaymentProcessor.connect(executor).clearPayment(authorizationId)
+        cardPaymentProcessor.connect(executor).clearPayment(payment.authorizationId)
       ).to.changeTokenBalances(
         tokenMock,
         [cardPaymentProcessor, payment.account],
         [0, 0]
       ).and.to.emit(
         cardPaymentProcessor,
-        "ClearPayment"
+        EVENT_NAME_CLEAR_PAYMENT
       ).withArgs(
-        authorizationId,
+        payment.authorizationId,
         payment.account.address,
         payment.amount,
         expectedClearedBalance,
@@ -1287,114 +1343,88 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       );
 
       payment.status = PaymentStatus.Cleared;
-      await checkCardPaymentProcessorState([payment]);
+      await checkCardPaymentProcessorState(fixture, [payment]);
+    });
+
+    it("Is reverted if the caller does not have the executor role", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      await expect(
+        cardPaymentProcessor.connect(deployer).clearPayment(payment.authorizationId)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      await pauseContract(cardPaymentProcessor);
+
+      await expect(
+        cardPaymentProcessor.connect(executor).clearPayment(payment.authorizationId)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the payment authorization ID is zero", async () => {
+      const { fixture: { cardPaymentProcessor } } = await prepareForSinglePayment();
+      await expect(
+        cardPaymentProcessor.connect(executor).clearPayment(ZERO_AUTHORIZATION_ID)
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      await expect(
+        cardPaymentProcessor.connect(executor).clearPayment(payment.authorizationId)
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Is reverted if the payment has already been cleared", async () => {
-      await proveTx(cardPaymentProcessor.connect(executor).clearPayment(authorizationId));
+      const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
+      await makePayments(cardPaymentProcessor, [payment]);
+      await proveTx(cardPaymentProcessor.connect(executor).clearPayment(payment.authorizationId));
 
       await expect(
-        cardPaymentProcessor.connect(executor).clearPayment(authorizationId)
+        cardPaymentProcessor.connect(executor).clearPayment(payment.authorizationId)
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_CLEARED);
     });
   });
 
   describe("Function 'clearPayments()'", async () => {
-    let payments: TestPayment[];
-    let authorizationIds: string[];
-    let accountAddresses: string[];
-    let expectedClearedBalances: number[];
-    let expectedUnclearedBalances: number[];
+    async function beforeClearingPayments(): Promise<{
+      fixture: Fixture,
+      payments: TestPayment[],
+      accountAddresses: string[],
+      authorizationIds: string[]
+    }> {
+      const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
+      const payments: TestPayment[] = createTestPayments().slice(0, 2);
+      await setUpContractsForPayments(fixture, payments);
+      await makePayments(fixture.cardPaymentProcessor, payments);
+      const accountAddresses: string[] = payments.map(payment => payment.account.address);
+      const authorizationIds: string[] = payments.map(payment => payment.authorizationId);
 
-    beforeEach(async () => {
-      payments = [
-        {
-          authorizationId: 123,
-          account: user1,
-          amount: 234,
-          status: PaymentStatus.Nonexistent,
-          makingPaymentCorrelationId: 345,
-        },
-        {
-          authorizationId: 456,
-          account: user2,
-          amount: 567,
-          status: PaymentStatus.Nonexistent,
-          makingPaymentCorrelationId: 789,
-        },
-      ];
-      authorizationIds = payments.map(
-        (payment: TestPayment) => createBytesString(payment.authorizationId, BYTES16_LENGTH)
-      );
-      accountAddresses = payments.map(
-        (payment: TestPayment) => payment.account.address
-      );
-      expectedClearedBalances = payments.map((payment: TestPayment) => payment.amount);
-      expectedUnclearedBalances = payments.map(() => 0);
-      await setUpContractsForPayments(payments);
-      await setExecutorRole(executor);
-      await makePayments(payments);
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
-      await proveTx(cardPaymentProcessor.pause());
-
-      await expect(
-        cardPaymentProcessor.connect(executor).clearPayments(authorizationIds)
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller does not have the executor role", async () => {
-      await expect(
-        cardPaymentProcessor.connect(deployer).clearPayments(authorizationIds)
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
-    });
-
-    it("Is reverted if the payment authorization IDs array is empty", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).clearPayments([])
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
-    });
-
-    it("Is reverted if one of the payment authorization IDs is zero", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).clearPayments([authorizationIds[0], ZERO_AUTHORIZATION_ID])
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
-    });
-
-    it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).clearPayments(
-          [
-            authorizationIds[0],
-            createBytesString(payments[payments.length - 1].authorizationId + 1, BYTES16_LENGTH),
-          ]
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
-    });
-
-    it("Is reverted if one of the payments has been already cleared", async () => {
-      await proveTx(cardPaymentProcessor.connect(executor).clearPayment(authorizationIds[0]));
-
-      await expect(
-        cardPaymentProcessor.connect(executor).clearPayments(authorizationIds)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_CLEARED);
-    });
+      return {
+        fixture,
+        payments,
+        accountAddresses,
+        authorizationIds
+      };
+    }
 
     it("Executes as expected, emits the correct event, and does not transfer tokens", async () => {
-      await checkCardPaymentProcessorState(payments);
+      const { fixture, payments, accountAddresses, authorizationIds } = await beforeClearingPayments();
+      const { cardPaymentProcessor, tokenMock } = fixture;
+      const expectedClearedBalances: number[] = payments.map((payment: TestPayment) => payment.amount);
+      const expectedUnclearedBalances: number[] = payments.map(() => 0);
 
-      const txResponse: TransactionResponse = cardPaymentProcessor.connect(executor).clearPayments(authorizationIds);
-      await expect(
-        txResponse
-      ).to.changeTokenBalances(
+      await checkCardPaymentProcessorState(fixture, payments);
+
+      const tx: TransactionResponse = cardPaymentProcessor.connect(executor).clearPayments(authorizationIds);
+      await expect(tx).to.changeTokenBalances(
         tokenMock,
         [cardPaymentProcessor, ...accountAddresses],
         [0, ...accountAddresses.map(() => 0)]
       ).and.to.emit(
         cardPaymentProcessor,
-        "ClearPayment"
+        EVENT_NAME_CLEAR_PAYMENT
       ).withArgs(
         authorizationIds[0],
         payments[0].account.address,
@@ -1403,11 +1433,9 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         expectedUnclearedBalances[0],
         payments[0].revocationCounter || 0
       );
-      await expect(
-        txResponse
-      ).to.emit(
+      await expect(tx).to.emit(
         cardPaymentProcessor,
-        "ClearPayment"
+        EVENT_NAME_CLEAR_PAYMENT
       ).withArgs(
         authorizationIds[1],
         payments[1].account.address,
@@ -1418,74 +1446,83 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       );
 
       payments.forEach((payment: TestPayment) => payment.status = PaymentStatus.Cleared);
-      await checkCardPaymentProcessorState(payments);
-    });
-  });
-
-  describe("Function 'unclearPayment()'", async () => {
-    let payment: TestPayment;
-    let authorizationId: string;
-
-    beforeEach(async () => {
-      payment = {
-        authorizationId: 543,
-        account: user1,
-        amount: 432,
-        status: PaymentStatus.Nonexistent,
-        makingPaymentCorrelationId: 321,
-      };
-      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
-      await setUpContractsForPayments([payment]);
-      await setExecutorRole(executor);
-      await makePayments([payment]);
-      await clearPayments([payment]);
+      await checkCardPaymentProcessorState(fixture, payments);
     });
 
     it("Is reverted if the contract is paused", async () => {
-      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
-      await proveTx(cardPaymentProcessor.pause());
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      await pauseContract(cardPaymentProcessor);
 
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayment(authorizationId)
+        cardPaymentProcessor.connect(executor).clearPayments([payment.authorizationId])
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the executor role", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
       await expect(
-        cardPaymentProcessor.connect(deployer).unclearPayment(authorizationId)
+        cardPaymentProcessor.connect(deployer).clearPayments([payment.authorizationId])
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
-    it("Is reverted if the payment authorization ID is zero", async () => {
+    it("Is reverted if the payment authorization IDs array is empty", async () => {
+      const { fixture: { cardPaymentProcessor } } = await prepareForSinglePayment();
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayment(ZERO_AUTHORIZATION_ID)
+        cardPaymentProcessor.connect(executor).clearPayments([])
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
+    });
+
+    it("Is reverted if one of the payment authorization IDs is zero", async () => {
+      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeClearingPayments();
+      await expect(
+        cardPaymentProcessor.connect(executor).clearPayments([authorizationIds[0], ZERO_AUTHORIZATION_ID])
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
     });
 
-    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
+    it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
+      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeClearingPayments();
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayment(
-          createBytesString(payment.authorizationId + 1, BYTES16_LENGTH)
+        cardPaymentProcessor.connect(executor).clearPayments(
+          [
+            authorizationIds[0],
+            increaseBytesString(authorizationIds[1], BYTES16_LENGTH)
+          ]
         )
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
+    it("Is reverted if one of the payments has been already cleared", async () => {
+      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeClearingPayments();
+      await proveTx(cardPaymentProcessor.connect(executor).clearPayment(authorizationIds[0]));
+
+      await expect(
+        cardPaymentProcessor.connect(executor).clearPayments(authorizationIds)
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_CLEARED);
+    });
+  });
+
+  describe("Function 'unclearPayment()'", async () => {
     it("Executes as expected, emits the correct event, and does not transfer tokens", async () => {
-      await checkCardPaymentProcessorState([payment]);
+      const { fixture, payment } = await beforeMakingPayment();
+      const { cardPaymentProcessor, tokenMock } = fixture;
+      await makePayments(cardPaymentProcessor, [payment]);
+      await clearPayments(cardPaymentProcessor, [payment]);
       const expectedClearedBalance: number = 0;
       const expectedUnclearedBalance: number = payment.amount;
 
+      await checkCardPaymentProcessorState(fixture, [payment]);
+
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayment(authorizationId)
+        cardPaymentProcessor.connect(executor).unclearPayment(payment.authorizationId)
       ).to.changeTokenBalances(
         tokenMock,
         [cardPaymentProcessor, payment.account],
         [0, 0]
       ).and.to.emit(
         cardPaymentProcessor,
-        "UnclearPayment"
+        EVENT_NAME_UNCLEAR_PAYMENT
       ).withArgs(
-        authorizationId,
+        payment.authorizationId,
         payment.account.address,
         payment.amount,
         expectedClearedBalance,
@@ -1494,114 +1531,90 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       );
 
       payment.status = PaymentStatus.Uncleared;
-      await checkCardPaymentProcessorState([payment]);
+      await checkCardPaymentProcessorState(fixture, [payment]);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      await pauseContract(cardPaymentProcessor);
+
+      await expect(
+        cardPaymentProcessor.connect(executor).unclearPayment(payment.authorizationId)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the executor role", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      await expect(
+        cardPaymentProcessor.connect(deployer).unclearPayment(payment.authorizationId)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+    });
+
+    it("Is reverted if the payment authorization ID is zero", async () => {
+      const { fixture: { cardPaymentProcessor } } = await prepareForSinglePayment();
+      await expect(
+        cardPaymentProcessor.connect(executor).unclearPayment(ZERO_AUTHORIZATION_ID)
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      await expect(
+        cardPaymentProcessor.connect(executor).unclearPayment(payment.authorizationId)
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Is reverted if the payment is uncleared", async () => {
-      await proveTx(cardPaymentProcessor.connect(executor).unclearPayment(authorizationId));
+      const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
+      await makePayments(cardPaymentProcessor, [payment]);
+      await clearPayments(cardPaymentProcessor, [payment]);
+      await proveTx(cardPaymentProcessor.connect(executor).unclearPayment(payment.authorizationId));
 
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayment(authorizationId)
+        cardPaymentProcessor.connect(executor).unclearPayment(payment.authorizationId)
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
     });
   });
 
   describe("Function 'unclearPayments()'", async () => {
-    let payments: TestPayment[];
+    async function beforeUnclearingPayments(): Promise<{
+      fixture: Fixture,
+      payments: TestPayment[],
+      accountAddresses: string[],
+      authorizationIds: string[]
+    }> {
+      const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
+      const payments: TestPayment[] = createTestPayments().slice(0, 2);
+      await setUpContractsForPayments(fixture, payments);
+      await makePayments(fixture.cardPaymentProcessor, payments);
+      await clearPayments(fixture.cardPaymentProcessor, payments);
+      const accountAddresses: string[] = payments.map(payment => payment.account.address);
+      const authorizationIds: string[] = payments.map(payment => payment.authorizationId);
 
-    let authorizationIds: string[];
-    let accountAddresses: string[];
-    let expectedClearedBalances: number[];
-    let expectedUnclearedBalances: number[];
-
-    beforeEach(async () => {
-      payments = [
-        {
-          authorizationId: 987,
-          account: user1,
-          amount: 876,
-          status: PaymentStatus.Nonexistent,
-          makingPaymentCorrelationId: 765,
-        },
-        {
-          authorizationId: 654,
-          account: user2,
-          amount: 543,
-          status: PaymentStatus.Nonexistent,
-          makingPaymentCorrelationId: 432,
-        },
-      ];
-      authorizationIds = payments.map(
-        (payment: TestPayment) => createBytesString(payment.authorizationId, BYTES16_LENGTH)
-      );
-      accountAddresses = payments.map((payment: TestPayment) => payment.account.address);
-      expectedClearedBalances = payments.map(() => 0);
-      expectedUnclearedBalances = payments.map((payment: TestPayment) => payment.amount);
-      await setUpContractsForPayments(payments);
-      await setExecutorRole(executor);
-      await makePayments(payments);
-      await clearPayments(payments);
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
-      await proveTx(cardPaymentProcessor.pause());
-
-      await expect(
-        cardPaymentProcessor.connect(executor).unclearPayments(authorizationIds)
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller does not have the executor role", async () => {
-      await expect(
-        cardPaymentProcessor.connect(deployer).unclearPayments(authorizationIds)
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
-    });
-
-    it("Is reverted if the payment authorization IDs array is empty", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).unclearPayments([])
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
-    });
-
-    it("Is reverted if one of the payment authorization IDs is zero", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).unclearPayments([authorizationIds[0], ZERO_AUTHORIZATION_ID])
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
-    });
-
-    it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).unclearPayments(
-          [
-            authorizationIds[0],
-            createBytesString(payments[payments.length - 1].authorizationId + 1, BYTES16_LENGTH)
-          ]
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
-    });
-
-    it("Is reverted if one of the payments is uncleared", async () => {
-      await proveTx(cardPaymentProcessor.connect(executor).unclearPayment(authorizationIds[0]));
-
-      await expect(
-        cardPaymentProcessor.connect(executor).unclearPayments(authorizationIds)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
-    });
+      return {
+        fixture,
+        payments,
+        accountAddresses,
+        authorizationIds
+      };
+    }
 
     it("Executes as expected, emits the correct event, and does not transfer tokens", async () => {
-      await checkCardPaymentProcessorState(payments);
+      const { fixture, payments, accountAddresses, authorizationIds } = await beforeUnclearingPayments();
+      const { cardPaymentProcessor, tokenMock } = fixture;
+      const expectedClearedBalances: number[] = payments.map(() => 0);
+      const expectedUnclearedBalances: number[] = payments.map((payment: TestPayment) => payment.amount);
 
-      const txResponse: TransactionResponse = cardPaymentProcessor.connect(executor).unclearPayments(authorizationIds);
-      await expect(
-        txResponse
-      ).to.changeTokenBalances(
+      await checkCardPaymentProcessorState(fixture, payments);
+
+      const tx: TransactionResponse = cardPaymentProcessor.connect(executor).unclearPayments(authorizationIds);
+      await expect(tx).to.changeTokenBalances(
         tokenMock,
         [cardPaymentProcessor, ...accountAddresses],
         [0, ...accountAddresses.map(() => 0)]
       ).and.to.emit(
         cardPaymentProcessor,
-        "UnclearPayment"
+        EVENT_NAME_UNCLEAR_PAYMENT
       ).withArgs(
         authorizationIds[0],
         payments[0].account.address,
@@ -1610,11 +1623,9 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         expectedUnclearedBalances[0],
         payments[0].revocationCounter || 0
       );
-      await expect(
-        txResponse
-      ).to.emit(
+      await expect(tx).to.emit(
         cardPaymentProcessor,
-        "UnclearPayment"
+        EVENT_NAME_UNCLEAR_PAYMENT
       ).withArgs(
         authorizationIds[1],
         payments[1].account.address,
@@ -1625,189 +1636,147 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       );
 
       payments.forEach((payment: TestPayment) => payment.status = PaymentStatus.Uncleared);
-      await checkCardPaymentProcessorState(payments);
-    });
-  });
-
-  describe("Function 'revokePayment()'", async () => {
-    let cashbackDistributorMock: Contract;
-    let cashbackDistributorMockConfig: CashbackDistributorMockConfig;
-    let payment: TestPayment;
-    let authorizationId: string;
-
-    beforeEach(async () => {
-      ({ cashbackDistributorMock, cashbackDistributorMockConfig } = await setUpAndEnableCashback());
-      payment = {
-        authorizationId: 987,
-        account: user1,
-        amount: 876,
-        status: PaymentStatus.Nonexistent,
-        revocationCounter: 0,
-        makingPaymentCorrelationId: 765,
-        parentTxHash: PARENT_TRANSACTION_HASH,
-        cashbackNonce: cashbackDistributorMockConfig.sendCashbackNonceResult,
-        cashbackRateInPermil: CASHBACK_RATE_IN_PERMIL,
-      };
-      payment.compensationAmount = calculateCompensationAmount(payment);
-      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
-      await setUpContractsForPayments([payment]);
-      await setExecutorRole(executor);
+      await checkCardPaymentProcessorState(fixture, payments);
     });
 
     it("Is reverted if the contract is paused", async () => {
-      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
-      await proveTx(cardPaymentProcessor.pause());
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      await pauseContract(cardPaymentProcessor);
 
       await expect(
-        cardPaymentProcessor.connect(executor).revokePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
-          payment.parentTxHash
-        )
+        cardPaymentProcessor.connect(executor).unclearPayments([payment.authorizationId])
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the executor role", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
       await expect(
-        cardPaymentProcessor.connect(deployer).revokePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
-          payment.parentTxHash
-        )
+        cardPaymentProcessor.connect(deployer).unclearPayments([payment.authorizationId])
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
-    it("Is reverted if the configured revocation limit of payments is zero", async () => {
-      await proveTx(cardPaymentProcessor.setRevocationLimit(0));
-
+    it("Is reverted if the payment authorization IDs array is empty", async () => {
+      const { fixture: { cardPaymentProcessor } } = await prepareForSinglePayment();
       await expect(
-        cardPaymentProcessor.connect(executor).revokePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
-          payment.parentTxHash
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_REVOCATION_COUNTER_REACHED_LIMIT);
+        cardPaymentProcessor.connect(executor).unclearPayments([])
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
     });
 
-    it("Is reverted if the payment authorization ID is zero", async () => {
+    it("Is reverted if one of the payment authorization IDs is zero", async () => {
+      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeUnclearingPayments();
       await expect(
-        cardPaymentProcessor.connect(executor).revokePayment(
-          ZERO_AUTHORIZATION_ID,
-          REVERSING_PAYMENT_CORRELATION_ID,
-          payment.parentTxHash
-        )
+        cardPaymentProcessor.connect(executor).unclearPayments([authorizationIds[0], ZERO_AUTHORIZATION_ID])
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
     });
 
-    it("Is reverted if the parent transaction hash is zero", async () => {
+    it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
+      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeUnclearingPayments();
       await expect(
-        cardPaymentProcessor.connect(executor).revokePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
-          ZERO_TRANSACTION_HASH,
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PARENT_TX_HASH_IS_ZERO);
-    });
-
-    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).revokePayment(
-          createBytesString(payment.authorizationId + 1, BYTES16_LENGTH),
-          REVERSING_PAYMENT_CORRELATION_ID,
-          payment.parentTxHash
+        cardPaymentProcessor.connect(executor).unclearPayments(
+          [
+            authorizationIds[0],
+            increaseBytesString(authorizationIds[1], BYTES16_LENGTH)
+          ]
         )
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
+    it("Is reverted if one of the payments is uncleared", async () => {
+      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeUnclearingPayments();
+      await proveTx(cardPaymentProcessor.connect(executor).unclearPayment(authorizationIds[1]));
+
+      await expect(
+        cardPaymentProcessor.connect(executor).unclearPayments(authorizationIds)
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
+    });
+  });
+
+  describe("Function 'revokePayment()'", async () => {
     describe("Executes as expected and emits the correct events if the payment status is", async () => {
       const expectedClearedBalance: number = 0;
       const expectedUnclearedBalance: number = 0;
       const expectedRevocationCounter: number = 1;
 
-      beforeEach(async () => {
-        await makePayments([payment]);
-      });
-
-      async function checkRevocation(wasPaymentCleared: boolean) {
-        await checkCardPaymentProcessorState([payment]);
+      async function checkRevocationWithCashback(props: { isPaymentCleared: boolean }) {
+        const { fixture, payment } = await beforeMakingPayment();
+        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+        setCashback(payment, fixture);
         const cashbackAmount: number = calculateCashback(payment);
         const revokedPaymentAmount: number = payment.amount - cashbackAmount;
+        await proveTx(cardPaymentProcessor.enableCashback());
+        await makePayments(cardPaymentProcessor, [payment]);
 
-        const txResponse: TransactionResponse = cardPaymentProcessor.connect(executor).revokePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
+        if (props.isPaymentCleared) {
+          await clearPayments(cardPaymentProcessor, [payment]);
+        }
+
+        await checkCardPaymentProcessorState(fixture, [payment]);
+
+        const tx: TransactionResponse = cardPaymentProcessor.connect(executor).revokePayment(
+          payment.authorizationId,
+          PAYMENT_REVOKING_CORRELATION_ID_STUB,
           payment.parentTxHash
         );
-        await expect(
-          txResponse
-        ).to.changeTokenBalances(
+        await expect(tx).to.changeTokenBalances(
           tokenMock,
           [cardPaymentProcessor, payment.account],
           [-revokedPaymentAmount, +revokedPaymentAmount]
         ).and.to.emit(
           cardPaymentProcessor,
-          "RevokePayment"
+          EVENT_NAME_REVOKE_PAYMENT
         ).withArgs(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
+          payment.authorizationId,
+          PAYMENT_REVOKING_CORRELATION_ID_STUB,
           payment.account.address,
           revokedPaymentAmount,
           expectedClearedBalance,
           expectedUnclearedBalance,
-          wasPaymentCleared,
+          props.isPaymentCleared,
           payment.parentTxHash,
           expectedRevocationCounter
         );
-        await expect(
-          txResponse
-        ).to.emit(
+        await expect(tx).to.emit(
           cardPaymentProcessor,
-          "RevokeCashbackSuccess"
+          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
         ).withArgs(
           cashbackDistributorMock.address,
           cashbackAmount,
-          payment.cashbackNonce
+          payment.cashbackNonce || 0
         );
-        await expect(
-          txResponse
-        ).to.emit(
+        await expect(tx).to.emit(
           cashbackDistributorMock,
-          "RevokeCashbackMock"
+          EVENT_NAME_REVOKE_CASHBACK_MOCK
         ).withArgs(
           cardPaymentProcessor.address,
-          payment.cashbackNonce,
+          payment.cashbackNonce || 0,
           cashbackAmount
         );
 
         payment.status = PaymentStatus.Revoked;
         payment.revocationCounter = expectedRevocationCounter;
         payment.compensationAmount = 0;
-        await checkCardPaymentProcessorState([payment]);
+        await checkCardPaymentProcessorState(fixture, [payment]);
       }
 
       it("Uncleared", async () => {
-        const wasPaymentCleared: boolean = false;
-        await checkRevocation(wasPaymentCleared);
+        await checkRevocationWithCashback({ isPaymentCleared: false });
       });
 
       it("Cleared", async () => {
-        const wasPaymentCleared: boolean = true;
-        await clearPayments([payment]);
-        await checkRevocation(wasPaymentCleared);
+        await checkRevocationWithCashback({ isPaymentCleared: true });
       });
     });
 
-    describe("Executes successfully and do the following with cashback operations", async () => {
+    describe("Executes successfully and does the following with cashback operations", async () => {
       it("Does not revoke a cashback if cashback operations are disabled before sending", async () => {
-        await proveTx(cardPaymentProcessor.disableCashback());
-        setCashbackRate(payment, ZERO_CASHBACK_RATE);
-        payment.cashbackNonce = undefined;
-        await makePayments([payment]);
+        const { fixture, payment } = await beforeMakingPayment();
+        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+        await makePayments(cardPaymentProcessor, [payment]);
 
         await expect(
           cardPaymentProcessor.connect(executor).revokePayment(
-            authorizationId,
-            REVERSING_PAYMENT_CORRELATION_ID,
+            payment.authorizationId,
+            PAYMENT_REVOKING_CORRELATION_ID_STUB,
             payment.parentTxHash
           )
         ).to.changeTokenBalances(
@@ -1816,286 +1785,273 @@ describe("Contract 'CardPaymentProcessor'", async () => {
           [-payment.amount, +payment.amount]
         ).and.to.emit(
           cardPaymentProcessor,
-          "RevokePayment"
+          EVENT_NAME_REVOKE_PAYMENT
         ).and.not.to.emit(
           cardPaymentProcessor,
-          "RevokeCashbackSuccess"
+          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
         ).and.not.to.emit(
           cashbackDistributorMock,
-          "RevokeCashbackMock"
+          EVENT_NAME_REVOKE_CASHBACK_MOCK
         );
 
         payment.status = PaymentStatus.Revoked;
         payment.revocationCounter = 1;
-        await checkCardPaymentProcessorState([payment]);
+        await checkCardPaymentProcessorState(fixture, [payment]);
       });
 
       it("Does revoke a cashback if cashback operations are disabled after sending", async () => {
-        await makePayments([payment]);
-        await proveTx(cardPaymentProcessor.disableCashback());
+        const { fixture, payment } = await beforeMakingPayment();
+        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+        setCashback(payment, fixture);
         const cashbackAmount: number = calculateCashback(payment);
         const revokedPaymentAmount: number = payment.amount - cashbackAmount;
 
-        const txResponse: TransactionResponse = await cardPaymentProcessor.connect(executor).revokePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
+        await proveTx(cardPaymentProcessor.enableCashback());
+        await makePayments(cardPaymentProcessor, [payment]);
+        await proveTx(cardPaymentProcessor.disableCashback());
+
+        const tx: TransactionResponse = await cardPaymentProcessor.connect(executor).revokePayment(
+          payment.authorizationId,
+          PAYMENT_REVOKING_CORRELATION_ID_STUB,
           payment.parentTxHash
         );
-        await expect(
-          txResponse
-        ).to.changeTokenBalances(
+        await expect(tx).to.changeTokenBalances(
           tokenMock,
           [cardPaymentProcessor, payment.account],
           [-revokedPaymentAmount, +revokedPaymentAmount]
         ).and.to.emit(
           cardPaymentProcessor,
-          "RevokePayment"
+          EVENT_NAME_REVOKE_PAYMENT
         );
-        await expect(
-          txResponse
-        ).to.emit(
+        await expect(tx).to.emit(
           cardPaymentProcessor,
-          "RevokeCashbackSuccess"
+          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
         ).withArgs(
           cashbackDistributorMock.address,
           cashbackAmount,
-          payment.cashbackNonce
+          payment.cashbackNonce || 0
         );
-        await expect(
-          txResponse
-        ).to.emit(
+        await expect(tx).to.emit(
           cashbackDistributorMock,
-          "RevokeCashbackMock"
+          EVENT_NAME_REVOKE_CASHBACK_MOCK
         ).withArgs(
           cardPaymentProcessor.address,
-          payment.cashbackNonce,
+          payment.cashbackNonce || 0,
           cashbackAmount
         );
 
         payment.status = PaymentStatus.Revoked;
         payment.revocationCounter = 1;
         payment.compensationAmount = 0;
-        await checkCardPaymentProcessorState([payment]);
+        await checkCardPaymentProcessorState(fixture, [payment]);
       });
 
       it("Emits correct events if cashback operations are enabled but cashback revoking fails", async () => {
-        await makePayments([payment]);
-        await proveTx(cashbackDistributorMock.setRevokeCashbackSuccessResult(false));
+        const { fixture, payment } = await beforeMakingPayment();
+        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+        setCashback(payment, fixture);
         const cashbackAmount: number = calculateCashback(payment);
         const revokedPaymentAmount: number = payment.amount - cashbackAmount;
 
-        const txResponse: TransactionResponse = cardPaymentProcessor.connect(executor).revokePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
+        await proveTx(cardPaymentProcessor.enableCashback());
+        await makePayments(cardPaymentProcessor, [payment]);
+        await proveTx(cashbackDistributorMock.setRevokeCashbackSuccessResult(false));
+
+        const tx: TransactionResponse = cardPaymentProcessor.connect(executor).revokePayment(
+          payment.authorizationId,
+          PAYMENT_REVOKING_CORRELATION_ID_STUB,
           payment.parentTxHash
         );
-        await expect(
-          txResponse
-        ).to.changeTokenBalances(
+        await expect(tx).to.changeTokenBalances(
           tokenMock,
           [cardPaymentProcessor, payment.account],
           [-revokedPaymentAmount, +revokedPaymentAmount]
         ).and.to.emit(
           cardPaymentProcessor,
-          "RevokePayment"
+          EVENT_NAME_REVOKE_PAYMENT
         ).and.not.to.emit(
           cardPaymentProcessor,
-          "RevokeCashbackSuccess"
+          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
         );
-        await expect(
-          txResponse
-        ).to.emit(
+        await expect(tx).to.emit(
           cardPaymentProcessor,
-          "RevokeCashbackFailure"
+          EVENT_NAME_REVOKE_CASHBACK_FAILURE
         ).withArgs(
           cashbackDistributorMock.address,
           cashbackAmount,
-          payment.cashbackNonce
+          payment.cashbackNonce || 0
         );
-        await expect(
-          txResponse
-        ).to.emit(
+        await expect(tx).to.emit(
           cashbackDistributorMock,
-          "RevokeCashbackMock"
+          EVENT_NAME_REVOKE_CASHBACK_MOCK
         ).withArgs(
           cardPaymentProcessor.address,
-          payment.cashbackNonce,
+          payment.cashbackNonce || 0,
           cashbackAmount
         );
 
         payment.status = PaymentStatus.Revoked;
         payment.revocationCounter = 1;
         payment.compensationAmount = 0;
-        await checkCardPaymentProcessorState([payment]);
+        await checkCardPaymentProcessorState(fixture, [payment]);
+      });
+    });
+
+    describe("Is reverted if", async () => {
+      it("The contract is paused", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await pauseContract(cardPaymentProcessor);
+
+        await expect(
+          cardPaymentProcessor.connect(executor).revokePayment(
+            payment.authorizationId,
+            PAYMENT_REVOKING_CORRELATION_ID_STUB,
+            payment.parentTxHash
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The caller does not have the executor role", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(deployer).revokePayment(
+            payment.authorizationId,
+            PAYMENT_REVOKING_CORRELATION_ID_STUB,
+            payment.parentTxHash
+          )
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+      });
+
+      it("The configured revocation limit of payments is zero", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await proveTx(cardPaymentProcessor.setRevocationLimit(0));
+
+        await expect(
+          cardPaymentProcessor.connect(executor).revokePayment(
+            payment.authorizationId,
+            PAYMENT_REVOKING_CORRELATION_ID_STUB,
+            payment.parentTxHash
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_REVOCATION_COUNTER_REACHED_LIMIT);
+      });
+
+      it("The payment authorization ID is zero", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(executor).revokePayment(
+            ZERO_AUTHORIZATION_ID,
+            PAYMENT_REVOKING_CORRELATION_ID_STUB,
+            payment.parentTxHash
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      });
+
+      it("The parent transaction hash is zero", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(executor).revokePayment(
+            payment.authorizationId,
+            PAYMENT_REVOKING_CORRELATION_ID_STUB,
+            ZERO_TRANSACTION_HASH,
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PARENT_TX_HASH_IS_ZERO);
+      });
+
+      it("The payment with the provided authorization ID does not exist", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(executor).revokePayment(
+            increaseBytesString(payment.authorizationId, BYTES16_LENGTH),
+            PAYMENT_REVOKING_CORRELATION_ID_STUB,
+            payment.parentTxHash
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
       });
     });
   });
 
   describe("Function 'reversePayment()'", async () => {
-    let cashbackDistributorMock: Contract;
-    let cashbackDistributorMockConfig: CashbackDistributorMockConfig;
-
-    let payment: TestPayment;
-    let authorizationId: string;
-
-    beforeEach(async () => {
-      ({ cashbackDistributorMock, cashbackDistributorMockConfig } = await setUpAndEnableCashback());
-      payment = {
-        authorizationId: 876,
-        account: user1,
-        amount: 765,
-        status: PaymentStatus.Nonexistent,
-        makingPaymentCorrelationId: 543,
-        parentTxHash: PARENT_TRANSACTION_HASH,
-        cashbackNonce: cashbackDistributorMockConfig.sendCashbackNonceResult,
-        cashbackRateInPermil: CASHBACK_RATE_IN_PERMIL,
-      };
-      payment.compensationAmount = calculateCompensationAmount(payment);
-      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
-      await setUpContractsForPayments([payment]);
-      await setExecutorRole(executor);
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
-      await proveTx(cardPaymentProcessor.pause());
-
-      await expect(
-        cardPaymentProcessor.connect(executor).reversePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
-          payment.parentTxHash
-        )
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller does not have the executor role", async () => {
-      await expect(
-        cardPaymentProcessor.connect(deployer).reversePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
-          payment.parentTxHash
-        )
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
-    });
-
-    it("Is reverted if the payment authorization ID is zero", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).reversePayment(
-          ZERO_AUTHORIZATION_ID,
-          REVERSING_PAYMENT_CORRELATION_ID,
-          payment.parentTxHash
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
-    });
-
-    it("Is reverted if the parent transaction hash is zero", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).reversePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
-          ZERO_TRANSACTION_HASH,
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PARENT_TX_HASH_IS_ZERO);
-    });
-
-    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).reversePayment(
-          createBytesString(payment.authorizationId + 1, BYTES16_LENGTH),
-          REVERSING_PAYMENT_CORRELATION_ID,
-          payment.parentTxHash
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
-    });
-
     describe("Executes as expected and emits the correct events if the payment is", async () => {
       const expectedClearedBalance: number = 0;
       const expectedUnclearedBalance: number = 0;
 
-      beforeEach(async () => {
-        await makePayments([payment]);
-      });
-
-      async function checkReversion(wasPaymentCleared: boolean) {
-        await checkCardPaymentProcessorState([payment]);
+      async function checkReversionWithCashback(props: { isPaymentCleared: boolean }) {
+        const { fixture, payment } = await beforeMakingPayment();
+        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+        setCashback(payment, fixture);
         const cashbackAmount: number = calculateCashback(payment);
         const revokedPaymentAmount: number = payment.amount - cashbackAmount;
+        await proveTx(cardPaymentProcessor.enableCashback());
+        await makePayments(cardPaymentProcessor, [payment]);
 
-        const txResponse: TransactionResponse = cardPaymentProcessor.connect(executor).reversePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
+        if (props.isPaymentCleared) {
+          await clearPayments(cardPaymentProcessor, [payment]);
+        }
+
+        const tx: TransactionResponse = cardPaymentProcessor.connect(executor).reversePayment(
+          payment.authorizationId,
+          PAYMENT_REVERSING_CORRELATION_ID_STUB,
           payment.parentTxHash
         );
-        await expect(
-          txResponse
-        ).to.changeTokenBalances(
+        await expect(tx).to.changeTokenBalances(
           tokenMock,
           [cardPaymentProcessor, payment.account],
           [-revokedPaymentAmount, +revokedPaymentAmount]
         ).and.to.emit(
           cardPaymentProcessor,
-          "ReversePayment"
+          EVENT_NAME_REVERSE_PAYMENT
         ).withArgs(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
+          payment.authorizationId,
+          PAYMENT_REVERSING_CORRELATION_ID_STUB,
           payment.account.address,
           revokedPaymentAmount,
           expectedClearedBalance,
           expectedUnclearedBalance,
-          wasPaymentCleared,
+          props.isPaymentCleared,
           payment.parentTxHash,
           payment.revocationCounter || 0
         );
-        await expect(
-          txResponse
-        ).to.emit(
+        await expect(tx).to.emit(
           cardPaymentProcessor,
-          "RevokeCashbackSuccess"
+          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
         ).withArgs(
           cashbackDistributorMock.address,
           cashbackAmount,
-          payment.cashbackNonce
+          payment.cashbackNonce || 0
         );
-        await expect(
-          txResponse
-        ).to.emit(
+        await expect(tx).to.emit(
           cashbackDistributorMock,
-          "RevokeCashbackMock"
+          EVENT_NAME_REVOKE_CASHBACK_MOCK
         ).withArgs(
           cardPaymentProcessor.address,
-          payment.cashbackNonce,
+          payment.cashbackNonce || 0,
           cashbackAmount
         );
 
         payment.status = PaymentStatus.Reversed;
         payment.compensationAmount = 0;
-        await checkCardPaymentProcessorState([payment]);
+        await checkCardPaymentProcessorState(fixture, [payment]);
       }
 
       it("Uncleared", async () => {
-        const wasPaymentCleared: boolean = false;
-        await checkReversion(wasPaymentCleared);
+        await checkReversionWithCashback({ isPaymentCleared: false });
       });
 
       it("Cleared", async () => {
-        const wasPaymentCleared: boolean = true;
-        await clearPayments([payment]);
-        await checkReversion(wasPaymentCleared);
+        await checkReversionWithCashback({ isPaymentCleared: true });
       });
     });
 
-    describe("Executes successfully and do the following with cashback operations", async () => {
+    describe("Executes successfully and does the following with cashback operations", async () => {
       it("Does not revoke a cashback if cashback operations are disabled before sending", async () => {
-        await proveTx(cardPaymentProcessor.disableCashback());
-        setCashbackRate(payment, ZERO_CASHBACK_RATE);
-        payment.cashbackNonce = undefined;
-        await makePayments([payment]);
+        const { fixture, payment } = await beforeMakingPayment();
+        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+        await makePayments(cardPaymentProcessor, [payment]);
 
         await expect(
           cardPaymentProcessor.connect(executor).reversePayment(
-            authorizationId,
-            REVERSING_PAYMENT_CORRELATION_ID,
+            payment.authorizationId,
+            PAYMENT_REVERSING_CORRELATION_ID_STUB,
             payment.parentTxHash
           )
         ).to.changeTokenBalances(
@@ -2104,196 +2060,197 @@ describe("Contract 'CardPaymentProcessor'", async () => {
           [-payment.amount, +payment.amount]
         ).and.to.emit(
           cardPaymentProcessor,
-          "ReversePayment"
+          EVENT_NAME_REVERSE_PAYMENT
         ).and.not.to.emit(
           cardPaymentProcessor,
-          "RevokeCashbackSuccess"
+          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
         ).and.not.to.emit(
           cashbackDistributorMock,
-          "RevokeCashbackMock"
+          EVENT_NAME_REVOKE_CASHBACK_MOCK
         );
 
         payment.status = PaymentStatus.Reversed;
-        await checkCardPaymentProcessorState([payment]);
+        await checkCardPaymentProcessorState(fixture, [payment]);
       });
 
       it("Does revoke a cashback if cashback operations are disabled after sending", async () => {
-        await makePayments([payment]);
-        await proveTx(cardPaymentProcessor.disableCashback());
+        const { fixture, payment } = await beforeMakingPayment();
+        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+        setCashback(payment, fixture);
         const cashbackAmount: number = calculateCashback(payment);
         const revokedPaymentAmount: number = payment.amount - cashbackAmount;
 
-        const txResponse: TransactionResponse = cardPaymentProcessor.connect(executor).reversePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
+        await proveTx(cardPaymentProcessor.enableCashback());
+        await makePayments(cardPaymentProcessor, [payment]);
+        await proveTx(cardPaymentProcessor.disableCashback());
+
+        const tx: TransactionResponse = cardPaymentProcessor.connect(executor).reversePayment(
+          payment.authorizationId,
+          PAYMENT_REVERSING_CORRELATION_ID_STUB,
           payment.parentTxHash
         );
-        await expect(
-          txResponse
-        ).to.changeTokenBalances(
+        await expect(tx).to.changeTokenBalances(
           tokenMock,
           [cardPaymentProcessor, payment.account],
           [-revokedPaymentAmount, +revokedPaymentAmount]
         ).and.to.emit(
           cardPaymentProcessor,
-          "ReversePayment"
+          EVENT_NAME_REVERSE_PAYMENT
         );
-        await expect(
-          txResponse
-        ).to.emit(
+        await expect(tx).to.emit(
           cardPaymentProcessor,
-          "RevokeCashbackSuccess"
+          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
         ).withArgs(
           cashbackDistributorMock.address,
           cashbackAmount,
-          payment.cashbackNonce
+          payment.cashbackNonce || 0
         );
-        await expect(
-          txResponse
-        ).to.emit(
+        await expect(tx).to.emit(
           cashbackDistributorMock,
-          "RevokeCashbackMock"
+          EVENT_NAME_REVOKE_CASHBACK_MOCK
         ).withArgs(
           cardPaymentProcessor.address,
-          payment.cashbackNonce,
+          payment.cashbackNonce || 0,
           cashbackAmount
         );
 
         payment.status = PaymentStatus.Reversed;
         payment.compensationAmount = 0;
-        await checkCardPaymentProcessorState([payment]);
+        await checkCardPaymentProcessorState(fixture, [payment]);
       });
 
       it("Emits correct events if cashback operations are enabled but cashback revoking fails", async () => {
-        await makePayments([payment]);
-        await proveTx(cashbackDistributorMock.setRevokeCashbackSuccessResult(false));
+        const { fixture, payment } = await beforeMakingPayment();
+        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+        setCashback(payment, fixture);
         const cashbackAmount: number = calculateCashback(payment);
         const revokedPaymentAmount: number = payment.amount - cashbackAmount;
 
-        const txResponse: TransactionResponse = cardPaymentProcessor.connect(executor).reversePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
+        await proveTx(cardPaymentProcessor.enableCashback());
+        await makePayments(cardPaymentProcessor, [payment]);
+        await proveTx(cashbackDistributorMock.setRevokeCashbackSuccessResult(false));
+
+        const tx: TransactionResponse = cardPaymentProcessor.connect(executor).reversePayment(
+          payment.authorizationId,
+          PAYMENT_REVERSING_CORRELATION_ID_STUB,
           payment.parentTxHash
         );
-        await expect(
-          txResponse
-        ).to.changeTokenBalances(
+        await expect(tx).to.changeTokenBalances(
           tokenMock,
           [cardPaymentProcessor, payment.account],
           [-revokedPaymentAmount, +revokedPaymentAmount]
         ).and.to.emit(
           cardPaymentProcessor,
-          "ReversePayment"
+          EVENT_NAME_REVERSE_PAYMENT
         ).and.not.to.emit(
           cardPaymentProcessor,
-          "RevokeCashbackSuccess"
+          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
         );
-        await expect(
-          txResponse
-        ).to.emit(
+        await expect(tx).to.emit(
           cardPaymentProcessor,
-          "RevokeCashbackFailure"
+          EVENT_NAME_REVOKE_CASHBACK_FAILURE
         ).withArgs(
           cashbackDistributorMock.address,
           cashbackAmount,
-          payment.cashbackNonce
+          payment.cashbackNonce || 0
         );
-        await expect(
-          txResponse
-        ).to.emit(
+        await expect(tx).to.emit(
           cashbackDistributorMock,
-          "RevokeCashbackMock"
+          EVENT_NAME_REVOKE_CASHBACK_MOCK
         ).withArgs(
           cardPaymentProcessor.address,
-          payment.cashbackNonce,
+          payment.cashbackNonce || 0,
           cashbackAmount
         );
 
         payment.status = PaymentStatus.Reversed;
         payment.compensationAmount = 0;
-        await checkCardPaymentProcessorState([payment]);
+        await checkCardPaymentProcessorState(fixture, [payment]);
+      });
+    });
+
+    describe("Is reverted if", async () => {
+      it("The contract is paused", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await pauseContract(cardPaymentProcessor);
+
+        await expect(
+          cardPaymentProcessor.connect(executor).reversePayment(
+            payment.authorizationId,
+            PAYMENT_REVERSING_CORRELATION_ID_STUB,
+            payment.parentTxHash
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The caller does not have the executor role", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(deployer).reversePayment(
+            payment.authorizationId,
+            PAYMENT_REVERSING_CORRELATION_ID_STUB,
+            payment.parentTxHash
+          )
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+      });
+
+      it("The payment authorization ID is zero", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(executor).reversePayment(
+            ZERO_AUTHORIZATION_ID,
+            PAYMENT_REVERSING_CORRELATION_ID_STUB,
+            payment.parentTxHash
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      });
+
+      it("The parent transaction hash is zero", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(executor).reversePayment(
+            payment.authorizationId,
+            PAYMENT_REVERSING_CORRELATION_ID_STUB,
+            ZERO_TRANSACTION_HASH,
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PARENT_TX_HASH_IS_ZERO);
+      });
+
+      it("The payment with the provided authorization ID does not exist", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(executor).reversePayment(
+            increaseBytesString(payment.authorizationId, BYTES16_LENGTH),
+            PAYMENT_REVERSING_CORRELATION_ID_STUB,
+            payment.parentTxHash
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
       });
     });
   });
 
   describe("Function 'confirmPayment()'", async () => {
-    let payment: TestPayment;
-    let authorizationId: string;
-
-    beforeEach(async () => {
-      payment = {
-        authorizationId: 123,
-        account: user1,
-        amount: 234,
-        status: PaymentStatus.Nonexistent,
-        makingPaymentCorrelationId: 345,
-      };
-      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
-      await setUpContractsForPayments([payment]);
-      await setExecutorRole(executor);
-      await makePayments([payment]);
-      await clearPayments([payment]);
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
-      await proveTx(cardPaymentProcessor.pause());
-
-      await expect(
-        cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller does not have the executor role", async () => {
-      await expect(
-        cardPaymentProcessor.connect(deployer).confirmPayment(authorizationId)
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
-    });
-
-    it("Is reverted if the payment authorization ID is zero", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).confirmPayment(ZERO_AUTHORIZATION_ID)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
-    });
-
-    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).confirmPayment(
-          createBytesString(payment.authorizationId + 1, BYTES16_LENGTH)
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
-    });
-
-    it("Is reverted if the payment is uncleared", async () => {
-      await proveTx(cardPaymentProcessor.connect(executor).unclearPayment(authorizationId));
-
-      await expect(
-        cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
-    });
-
-    it("Is reverted if the cash-out account is not set", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO);
-    });
-
     it("Executes as expected and emits the correct event", async () => {
-      await checkCardPaymentProcessorState([payment]);
-      await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
+      const { fixture, payment } = await beforeMakingPayment();
+      const { cardPaymentProcessor, tokenMock } = fixture;
       const expectedClearedBalance: number = 0;
 
+      await checkCardPaymentProcessorState(fixture, [payment]);
+
+      await makePayments(cardPaymentProcessor, [payment]);
+      await clearPayments(cardPaymentProcessor, [payment]);
+
       await expect(
-        cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
+        cardPaymentProcessor.connect(executor).confirmPayment(payment.authorizationId)
       ).to.changeTokenBalances(
         tokenMock,
         [cardPaymentProcessor, cashOutAccount, payment.account],
         [-payment.amount, +payment.amount, 0]
       ).and.to.emit(
         cardPaymentProcessor,
-        "ConfirmPayment"
+        EVENT_NAME_CONFIRM_PAYMENT
       ).withArgs(
-        authorizationId,
+        payment.authorizationId,
         payment.account.address,
         payment.amount,
         expectedClearedBalance,
@@ -2301,119 +2258,107 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       );
 
       payment.status = PaymentStatus.Confirmed;
-      await checkCardPaymentProcessorState([payment]);
+      await checkCardPaymentProcessorState(fixture, [payment]);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      await pauseContract(cardPaymentProcessor);
+
+      await expect(
+        cardPaymentProcessor.connect(executor).confirmPayment(payment.authorizationId)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the executor role", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      await expect(
+        cardPaymentProcessor.connect(deployer).confirmPayment(payment.authorizationId)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+    });
+
+    it("Is reverted if the payment authorization ID is zero", async () => {
+      const { fixture: { cardPaymentProcessor } } = await prepareForSinglePayment();
+      await expect(
+        cardPaymentProcessor.connect(executor).confirmPayment(ZERO_AUTHORIZATION_ID)
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      await expect(
+        cardPaymentProcessor.connect(executor).confirmPayment(
+          payment.authorizationId
+        )
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
+    });
+
+    it("Is reverted if the payment is uncleared", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
+      await makePayments(cardPaymentProcessor, [payment]);
+
+      await expect(
+        cardPaymentProcessor.connect(executor).confirmPayment(payment.authorizationId)
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
+    });
+
+    it("Is reverted if the cash-out account is the zero address", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
+      await makePayments(cardPaymentProcessor, [payment]);
+      await clearPayments(cardPaymentProcessor, [payment]);
+      await proveTx(cardPaymentProcessor.setCashOutAccount(ZERO_ADDRESS));
+
+      await expect(
+        cardPaymentProcessor.connect(executor).confirmPayment(payment.authorizationId)
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO);
     });
   });
 
   describe("Function 'confirmPayments()'", async () => {
-    let payments: TestPayment[];
-    let authorizationIds: string[];
-    let accountAddresses: string[];
-    let totalAmount: number;
+    async function beforeConfirmingPayments(): Promise<{
+      fixture: Fixture,
+      payments: TestPayment[],
+      accountAddresses: string[],
+      authorizationIds: string[]
+    }> {
+      const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
+      const payments: TestPayment[] = createTestPayments().slice(0, 2);
+      await setUpContractsForPayments(fixture, payments);
+      await makePayments(fixture.cardPaymentProcessor, payments);
+      await clearPayments(fixture.cardPaymentProcessor, payments);
+      const accountAddresses: string[] = payments.map(payment => payment.account.address);
+      const authorizationIds: string[] = payments.map(payment => payment.authorizationId);
 
-    beforeEach(async () => {
-      payments = [
-        {
-          authorizationId: 123,
-          account: user1,
-          amount: 234,
-          status: PaymentStatus.Nonexistent,
-          makingPaymentCorrelationId: 345,
-        },
-        {
-          authorizationId: 456,
-          account: user2,
-          amount: 567,
-          status: PaymentStatus.Nonexistent,
-          makingPaymentCorrelationId: 789,
-        },
-      ];
-      authorizationIds = payments.map(
-        (payment: TestPayment) => createBytesString(payment.authorizationId, BYTES16_LENGTH)
-      );
-      accountAddresses = payments.map((payment: TestPayment) => payment.account.address);
-      totalAmount = countNumberArrayTotal(
+      return {
+        fixture,
+        payments,
+        accountAddresses,
+        authorizationIds
+      };
+    }
+
+    it("Executes as expected and emits the correct event", async () => {
+      const { fixture, payments, accountAddresses, authorizationIds } = await beforeConfirmingPayments();
+      const { cardPaymentProcessor, tokenMock } = fixture;
+      const expectedClearedBalance: number = 0;
+      const totalAmount: number = countNumberArrayTotal(
         payments.map(
           function (payment: TestPayment): number {
             return payment.amount;
           }
         )
       );
-      await setUpContractsForPayments(payments);
-      await setExecutorRole(executor);
-      await makePayments(payments);
-      await clearPayments(payments);
-    });
 
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
-      await proveTx(cardPaymentProcessor.pause());
-      await expect(
-        cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds)
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
+      await checkCardPaymentProcessorState(fixture, payments);
 
-    it("Is reverted if the caller does not have the executor role", async () => {
-      await expect(
-        cardPaymentProcessor.connect(deployer).confirmPayments(authorizationIds)
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
-    });
-
-    it("Is reverted if the payment authorization IDs array is empty", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).confirmPayments([])
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
-    });
-
-    it("Is reverted if one of the payment authorization IDs is zero", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).confirmPayments(
-          [authorizationIds[0], ZERO_AUTHORIZATION_ID]
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
-    });
-
-    it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).confirmPayments(
-          [
-            authorizationIds[0],
-            createBytesString(payments[payments.length - 1].authorizationId + 1, BYTES16_LENGTH)
-          ]
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
-    });
-
-    it("Is reverted if one of the payments is uncleared", async () => {
-      await proveTx(cardPaymentProcessor.connect(executor).unclearPayment(authorizationIds[1]));
-
-      await expect(
-        cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
-    });
-
-    it("Is reverted if the cash-out account is not set", async () => {
-      await expect(
-        cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO);
-    });
-
-    it("Executes as expected and emits the correct event", async () => {
-      const expectedClearedBalance: number = 0;
-      await checkCardPaymentProcessorState(payments);
-      await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
-
-      const txResponse: TransactionResponse =
-        await cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds);
-      await expect(
-        txResponse
-      ).to.changeTokenBalances(
+      const tx: TransactionResponse = await cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds);
+      await expect(tx).to.changeTokenBalances(
         tokenMock,
         [cardPaymentProcessor, cashOutAccount, ...accountAddresses],
         [-totalAmount, +totalAmount, ...accountAddresses.map(() => 0)]
       ).and.to.emit(
         cardPaymentProcessor,
-        "ConfirmPayment"
+        EVENT_NAME_CONFIRM_PAYMENT
       ).withArgs(
         authorizationIds[0],
         payments[0].account.address,
@@ -2421,11 +2366,9 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         expectedClearedBalance,
         payments[0].revocationCounter || 0
       );
-      await expect(
-        txResponse
-      ).to.emit(
+      await expect(tx).to.emit(
         cardPaymentProcessor,
-        "ConfirmPayment"
+        EVENT_NAME_CONFIRM_PAYMENT
       ).withArgs(
         authorizationIds[1],
         payments[1].account.address,
@@ -2435,153 +2378,106 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       );
 
       payments.forEach((payment: TestPayment) => payment.status = PaymentStatus.Confirmed);
-      await checkCardPaymentProcessorState(payments);
-    });
-  });
-
-  describe("Function 'refundPayment()'", async () => {
-    let refundAmount = 123;
-    let cashbackDistributorMock: Contract;
-    let cashbackDistributorMockConfig: CashbackDistributorMockConfig;
-    let payment: TestPayment;
-    let authorizationId: string;
-
-    beforeEach(async () => {
-      ({ cashbackDistributorMock, cashbackDistributorMockConfig } = await setUpAndEnableCashback());
-      payment = {
-        authorizationId: 1234,
-        account: user1,
-        amount: 2345,
-        status: PaymentStatus.Nonexistent,
-        makingPaymentCorrelationId: 3456,
-        parentTxHash: PARENT_TRANSACTION_HASH,
-        cashbackNonce: cashbackDistributorMockConfig.sendCashbackNonceResult,
-        cashbackRateInPermil: CASHBACK_RATE_IN_PERMIL,
-      };
-      payment.compensationAmount = calculateCompensationAmount(payment);
-      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
-      await setUpContractsForPayments([payment]);
-      await setExecutorRole(executor);
+      await checkCardPaymentProcessorState(fixture, payments);
     });
 
     it("Is reverted if the contract is paused", async () => {
-      await proveTx(cardPaymentProcessor.grantRole(pauserRole, deployer.address));
-      await proveTx(cardPaymentProcessor.pause());
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      await pauseContract(cardPaymentProcessor);
 
       await expect(
-        cardPaymentProcessor.connect(executor).refundPayment(
-          refundAmount,
-          authorizationId
-        )
+        cardPaymentProcessor.connect(executor).confirmPayments([payment.authorizationId])
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the executor role", async () => {
+      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
       await expect(
-        cardPaymentProcessor.connect(deployer).refundPayment(
-          refundAmount,
-          authorizationId
-        )
+        cardPaymentProcessor.connect(deployer).confirmPayments([payment.authorizationId])
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
-    it("Is reverted if the payment authorization ID is zero", async () => {
-      // await makePayments([payment]);
+    it("Is reverted if the payment authorization IDs array is empty", async () => {
+      const { fixture: { cardPaymentProcessor } } = await prepareForSinglePayment();
       await expect(
-        cardPaymentProcessor.connect(executor).refundPayment(
-          refundAmount,
-          ZERO_AUTHORIZATION_ID
+        cardPaymentProcessor.connect(executor).confirmPayments([])
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
+    });
+
+    it("Is reverted if one of the payment authorization IDs is zero", async () => {
+      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeConfirmingPayments();
+      await expect(
+        cardPaymentProcessor.connect(executor).confirmPayments(
+          [authorizationIds[0], ZERO_AUTHORIZATION_ID]
         )
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
     });
 
-    it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
+    it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
+      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeConfirmingPayments();
       await expect(
-        cardPaymentProcessor.connect(executor).refundPayment(
-          refundAmount,
-          authorizationId
+        cardPaymentProcessor.connect(executor).confirmPayments(
+          [
+            authorizationIds[0],
+            increaseBytesString(authorizationIds[1], BYTES16_LENGTH)
+          ]
         )
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
-    it("Is reverted if the refund amount exceeds the payment amount", async () => {
-      await makePayments([payment]);
+    it("Is reverted if one of the payments is uncleared", async () => {
+      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeConfirmingPayments();
+      await proveTx(cardPaymentProcessor.connect(executor).unclearPayment(authorizationIds[1]));
 
       await expect(
-        cardPaymentProcessor.connect(executor).refundPayment(
-          payment.amount + 1,
-          authorizationId
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_REFUND_AMOUNT_IS_INAPPROPRIATE);
+        cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds)
+      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
     });
 
-    it("Is reverted if the payment is confirmed, but the cash-out amount address is zero", async () => {
-      await makePayments([payment]);
-      await clearPayments([payment]);
-      await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
-      await proveTx(
-        cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
-      );
-      payment.status = PaymentStatus.Confirmed;
-      await proveTx(cardPaymentProcessor.setCashOutAccount(ethers.constants.AddressZero));
+    it("Is reverted if the cash-out account is the zero address", async () => {
+      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeConfirmingPayments();
+      await proveTx(cardPaymentProcessor.setCashOutAccount(ZERO_ADDRESS));
 
       await expect(
-        cardPaymentProcessor.connect(executor).refundPayment(
-          refundAmount,
-          authorizationId
-        )
+        cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds)
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO);
     });
+  });
 
-    describe("Is reverted if the payment status is", async () => {
-      beforeEach(async () => {
-        await makePayments([payment]);
-      });
-
-      it("Revoked", async () => {
-        await proveTx(cardPaymentProcessor.connect(executor).revokePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
-          payment.parentTxHash
-        ));
-
-        await expect(
-          cardPaymentProcessor.connect(executor).refundPayment(
-            refundAmount,
-            authorizationId
-          )
-        ).to.be.revertedWithCustomError(
-          cardPaymentProcessor,
-          REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
-        ).withArgs(PaymentStatus.Revoked);
-      });
-
-      it("Reversed", async () => {
-        await proveTx(cardPaymentProcessor.connect(executor).reversePayment(
-          authorizationId,
-          REVERSING_PAYMENT_CORRELATION_ID,
-          payment.parentTxHash
-        ));
-
-        await expect(
-          cardPaymentProcessor.connect(executor).refundPayment(
-            refundAmount,
-            authorizationId
-          )
-        ).to.be.revertedWithCustomError(
-          cardPaymentProcessor,
-          REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
-        ).withArgs(PaymentStatus.Reversed);
-      });
-    });
-
+  describe("Function 'refundPayment()'", async () => {
     describe("Executes as expected and emits the correct events if the payment amount is", async () => {
-      beforeEach(async () => {
-        await makePayments([payment]);
-      });
+      enum RefundType {
+        Zero = 0,
+        Nonzero = 1,
+        Full = 2
+      }
 
-      async function checkRefunding(tokenSourceAccount: SignerWithAddress | Contract) {
-        await checkCardPaymentProcessorState([payment]);
+      async function checkRefunding(props: { refundType: RefundType, paymentStatus: PaymentStatus }) {
+        const { fixture, payment } = await beforeMakingPayment();
+        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+        setCashback(payment, fixture);
+        await proveTx(fixture.cardPaymentProcessor.enableCashback());
+        await makePayments(cardPaymentProcessor, [payment]);
+
+        let refundAmount = 0;
+        if (props.refundType === RefundType.Nonzero) {
+          refundAmount = Math.floor(payment.amount * 0.1);
+        } else if (props.refundType === RefundType.Full) {
+          refundAmount = payment.amount;
+        }
+
+        let tokenSourceAccount: SignerWithAddress | Contract = cardPaymentProcessor;
+        if (props.paymentStatus == PaymentStatus.Cleared) {
+          await clearPayments(cardPaymentProcessor, [payment]);
+        }
+        if (props.paymentStatus == PaymentStatus.Confirmed) {
+          tokenSourceAccount = cashOutAccount;
+          await clearPayments(cardPaymentProcessor, [payment]);
+          await confirmPayments(cardPaymentProcessor, [payment]);
+        }
+
+        await checkCardPaymentProcessorState(fixture, [payment]);
+
         setRefundAmount(payment, refundAmount);
         const revocationCashbackAmount = calculateRefundCashbackDifference(payment);
         const userSentAmount = refundAmount - revocationCashbackAmount;
@@ -2592,127 +2488,211 @@ describe("Contract 'CardPaymentProcessor'", async () => {
           cashOutAccountSentAmount = -(processorSentAmount + userSentAmount);
         }
 
-        const txResponse: TransactionResponse =
-          await cardPaymentProcessor.connect(executor).refundPayment(refundAmount, authorizationId);
-        await expect(
-          txResponse
-        ).to.changeTokenBalances(
+        const tx: TransactionResponse =
+          await cardPaymentProcessor.connect(executor).refundPayment(refundAmount, payment.authorizationId);
+        await expect(tx).to.changeTokenBalances(
           tokenMock,
           [cardPaymentProcessor, payment.account, cashOutAccount],
           [processorSentAmount, userSentAmount, cashOutAccountSentAmount]
         ).and.to.emit(
           cardPaymentProcessor,
-          "RefundPayment"
+          EVENT_NAME_REFUND_PAYMENT
         ).withArgs(
-          authorizationId,
+          payment.authorizationId,
           payment.account.address,
           payment.refundAmount,
           userSentAmount,
           payment.status
         );
-        await expect(
-          txResponse
-        ).to.emit(
+        await expect(tx).to.emit(
           cashbackDistributorMock,
-          "RevokeCashbackMock"
+          EVENT_NAME_REVOKE_CASHBACK_MOCK
         ).withArgs(
           cardPaymentProcessor.address,
-          payment.cashbackNonce,
+          payment.cashbackNonce || 0,
           revocationCashbackAmount
         );
 
-        await checkCardPaymentProcessorState([payment]);
+        await checkCardPaymentProcessorState(fixture, [payment]);
       }
 
       describe("Nonzero and the payment status is", async () => {
         it("Uncleared", async () => {
-          await checkRefunding(cardPaymentProcessor);
+          await checkRefunding({ refundType: RefundType.Nonzero, paymentStatus: PaymentStatus.Uncleared });
         });
 
         it("Cleared", async () => {
-          await clearPayments([payment]);
-          await checkRefunding(cardPaymentProcessor);
+          await checkRefunding({ refundType: RefundType.Nonzero, paymentStatus: PaymentStatus.Cleared });
         });
 
         it("Confirmed", async () => {
-          await clearPayments([payment]);
-          await proveTx(
-            tokenMock.connect(cashOutAccount).approve(cardPaymentProcessor.address, ethers.constants.MaxUint256)
-          );
-          await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
-          await proveTx(
-            cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
-          );
-          payment.status = PaymentStatus.Confirmed;
-          await checkRefunding(cashOutAccount);
-        });
+          await checkRefunding({ refundType: RefundType.Nonzero, paymentStatus: PaymentStatus.Confirmed });
+        })
+        ;
       });
 
       describe("Equals the payment amount and the payment status is", async () => {
-        beforeEach(() => {
-          refundAmount = payment.amount;
-        });
-
         it("Uncleared", async () => {
-          await checkRefunding(cardPaymentProcessor);
+          await checkRefunding({ refundType: RefundType.Full, paymentStatus: PaymentStatus.Uncleared });
         });
 
         it("Cleared", async () => {
-          await clearPayments([payment]);
-          await checkRefunding(cardPaymentProcessor);
+          await checkRefunding({ refundType: RefundType.Full, paymentStatus: PaymentStatus.Cleared });
         });
 
         it("Confirmed", async () => {
-          await clearPayments([payment]);
-          await proveTx(
-            tokenMock.connect(cashOutAccount).approve(cardPaymentProcessor.address, ethers.constants.MaxUint256)
-          );
-          await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
-          await proveTx(
-            cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
-          );
-          payment.status = PaymentStatus.Confirmed;
-
-          await checkRefunding(cashOutAccount);
+          await checkRefunding({ refundType: RefundType.Full, paymentStatus: PaymentStatus.Confirmed });
         });
       });
 
       describe("Zero and the payment status is", async () => {
-        beforeEach(() => {
-          refundAmount = 0;
-        });
-
         it("Uncleared", async () => {
-          await checkRefunding(cardPaymentProcessor);
+          await checkRefunding({ refundType: RefundType.Zero, paymentStatus: PaymentStatus.Cleared });
         });
 
         it("Cleared", async () => {
-          await clearPayments([payment]);
-          await checkRefunding(cardPaymentProcessor);
+          await checkRefunding({ refundType: RefundType.Zero, paymentStatus: PaymentStatus.Uncleared });
         });
 
         it("Confirmed", async () => {
-          await clearPayments([payment]);
-          await proveTx(
-            tokenMock.connect(cashOutAccount).approve(cardPaymentProcessor.address, ethers.constants.MaxUint256)
-          );
-          await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
-          await proveTx(
-            cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
-          );
-          payment.status = PaymentStatus.Confirmed;
-
-          await checkRefunding(cashOutAccount);
+          await checkRefunding({ refundType: RefundType.Zero, paymentStatus: PaymentStatus.Confirmed });
         });
+      });
+    });
+
+    describe("Is reverted if", async () => {
+      it("The contract is paused", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await pauseContract(cardPaymentProcessor);
+
+        await expect(
+          cardPaymentProcessor.connect(executor).refundPayment(
+            payment.refundAmount,
+            payment.authorizationId
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The caller does not have the executor role", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(deployer).refundPayment(
+            payment.refundAmount,
+            payment.authorizationId
+          )
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
+      });
+
+      it("The payment authorization ID is zero", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(executor).refundPayment(
+            payment.refundAmount,
+            ZERO_AUTHORIZATION_ID
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+      });
+
+      it("The payment with the provided authorization ID does not exist", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        await expect(
+          cardPaymentProcessor.connect(executor).refundPayment(
+            payment.refundAmount,
+            payment.authorizationId
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
+      });
+
+      it("The refund amount exceeds the payment amount", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
+        await makePayments(cardPaymentProcessor, [payment]);
+        setRefundAmount(payment, payment.amount + 1);
+
+        await expect(
+          cardPaymentProcessor.connect(executor).refundPayment(
+            payment.refundAmount,
+            payment.authorizationId
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_REFUND_AMOUNT_IS_INAPPROPRIATE);
+      });
+
+      it("The payment is confirmed, but the cash-out amount address is zero", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
+        await makePayments(cardPaymentProcessor, [payment]);
+        await clearPayments(cardPaymentProcessor, [payment]);
+        await confirmPayments(cardPaymentProcessor, [payment]);
+        await proveTx(cardPaymentProcessor.setCashOutAccount(ZERO_ADDRESS));
+
+        await expect(
+          cardPaymentProcessor.connect(executor).refundPayment(
+            payment.refundAmount,
+            payment.authorizationId
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO);
+      });
+
+      it("The payment status is 'Revoked'", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
+        await makePayments(cardPaymentProcessor, [payment]);
+        await proveTx(cardPaymentProcessor.connect(executor).revokePayment(
+          payment.authorizationId,
+          PAYMENT_REVOKING_CORRELATION_ID_STUB,
+          payment.parentTxHash
+        ));
+
+        await expect(
+          cardPaymentProcessor.connect(executor).refundPayment(
+            payment.refundAmount,
+            payment.authorizationId
+          )
+        ).to.be.revertedWithCustomError(
+          cardPaymentProcessor,
+          REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
+        ).withArgs(PaymentStatus.Revoked);
+      });
+
+      it("The payment status is 'Reversed'", async () => {
+        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
+        await makePayments(cardPaymentProcessor, [payment]);
+        await proveTx(cardPaymentProcessor.connect(executor).reversePayment(
+          payment.authorizationId,
+          PAYMENT_REVERSING_CORRELATION_ID_STUB,
+          payment.parentTxHash
+        ));
+
+        await expect(
+          cardPaymentProcessor.connect(executor).refundPayment(
+            payment.refundAmount,
+            payment.authorizationId,
+          )
+        ).to.be.revertedWithCustomError(
+          cardPaymentProcessor,
+          REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
+        ).withArgs(PaymentStatus.Reversed);
       });
     });
   });
 
   describe("Complex scenarios without cashback", async () => {
-    let payments: TestPayment[];
-    let authorizationIds: string[];
+    async function beforeMakingPayments(): Promise<{
+      fixture: Fixture,
+      payments: TestPayment[],
+    }> {
+      const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
+      const payments: TestPayment[] = createTestPayments().slice(0, 2);
+      await setUpContractsForPayments(fixture, payments);
 
-    async function checkRevertingOfAllPaymentProcessingFunctionsExceptMaking() {
+      return {
+        fixture,
+        payments,
+      };
+    }
+
+    async function checkRevertingOfAllPaymentProcessingFunctionsExceptMaking(
+      cardPaymentProcessor: Contract,
+      payments: TestPayment[]
+    ) {
+      const authorizationIds = payments.map(payment => payment.authorizationId);
       await expect(
         cardPaymentProcessor.connect(executor).clearPayment(authorizationIds[0])
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
@@ -2732,16 +2712,16 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await expect(
         cardPaymentProcessor.connect(executor).revokePayment(
           authorizationIds[0],
-          CORRELATION_ID,
-          PARENT_TRANSACTION_HASH
+          PAYMENT_REVOKING_CORRELATION_ID_STUB,
+          payments[0].parentTxHash
         )
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
 
       await expect(
         cardPaymentProcessor.connect(executor).reversePayment(
           authorizationIds[0],
-          CORRELATION_ID,
-          PARENT_TRANSACTION_HASH
+          PAYMENT_REVERSING_CORRELATION_ID_STUB,
+          payments[0].parentTxHash
         )
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
 
@@ -2754,50 +2734,30 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS);
     }
 
-    beforeEach(async () => {
-      payments = [
-        {
-          authorizationId: 1234,
-          account: user1,
-          amount: 2345,
-          status: PaymentStatus.Nonexistent,
-          makingPaymentCorrelationId: 3456,
-        },
-        {
-          authorizationId: 4567,
-          account: user2,
-          amount: 5678,
-          status: PaymentStatus.Nonexistent,
-          makingPaymentCorrelationId: 6789,
-        }
-      ];
-      authorizationIds = payments.map(
-        (payment: TestPayment) => createBytesString(payment.authorizationId, BYTES16_LENGTH)
-      );
-      await setUpContractsForPayments(payments);
-      await setExecutorRole(executor);
-    });
-
     it("All payment processing functions except making are reverted if a payment was revoked", async () => {
-      await makePayments(payments);
+      const { fixture, payments } = await beforeMakingPayments();
+      const { cardPaymentProcessor, tokenMock } = fixture;
+
+      await makePayments(cardPaymentProcessor, payments);
+
       await proveTx(
         cardPaymentProcessor.connect(executor).revokePayment(
-          authorizationIds[0],
-          CORRELATION_ID,
-          PARENT_TRANSACTION_HASH
+          payments[0].authorizationId,
+          PAYMENT_REVOKING_CORRELATION_ID_STUB,
+          payments[0].parentTxHash
         )
       );
       payments[0].status = PaymentStatus.Revoked;
       payments[0].revocationCounter = 1;
 
-      await checkCardPaymentProcessorState(payments);
-      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking();
+      await checkCardPaymentProcessorState(fixture, payments);
+      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking(cardPaymentProcessor, payments);
 
       await expect(
         cardPaymentProcessor.connect(payments[0].account).makePayment(
           payments[0].amount,
-          authorizationIds[0],
-          CORRELATION_ID,
+          payments[0].authorizationId,
+          payments[0].correlationId,
         )
       ).to.changeTokenBalances(
         tokenMock,
@@ -2805,10 +2765,10 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         [+payments[0].amount, -payments[0].amount]
       ).and.to.emit(
         cardPaymentProcessor,
-        "MakePayment"
+        EVENT_NAME_MAKE_PAYMENT
       ).withArgs(
-        authorizationIds[0],
-        CORRELATION_ID,
+        payments[0].authorizationId,
+        payments[0].correlationId,
         payments[0].account.address,
         payments[0].amount,
         payments[0].revocationCounter || 0,
@@ -2816,16 +2776,20 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       );
 
       payments[0].status = PaymentStatus.Uncleared;
-      await checkCardPaymentProcessorState(payments);
+      payments[0].parentTxHash = increaseBytesString(payments[0].parentTxHash, BYTES32_LENGTH);
+      await checkCardPaymentProcessorState(fixture, payments);
     });
 
     it("All payment processing functions are reverted if a payment was reversed", async () => {
-      await makePayments(payments);
+      const { fixture, payments } = await beforeMakingPayments();
+      const { cardPaymentProcessor } = fixture;
+      await makePayments(cardPaymentProcessor, payments);
+
       await proveTx(
         cardPaymentProcessor.connect(executor).reversePayment(
-          authorizationIds[0],
-          CORRELATION_ID,
-          PARENT_TRANSACTION_HASH
+          payments[0].authorizationId,
+          PAYMENT_REVERSING_CORRELATION_ID_STUB,
+          payments[0].parentTxHash
         )
       );
       payments[0].status = PaymentStatus.Reversed;
@@ -2833,74 +2797,77 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await expect(
         cardPaymentProcessor.makePayment(
           payments[0].amount,
-          authorizationIds[0],
-          createBytesString(payments[0].makingPaymentCorrelationId, BYTES16_LENGTH)
+          payments[0].authorizationId,
+          payments[0].correlationId
         )
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
 
-      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking();
-      await checkCardPaymentProcessorState(payments);
+      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking(cardPaymentProcessor, payments);
+      await checkCardPaymentProcessorState(fixture, payments);
     });
 
     it("All payment processing functions are reverted if a payment was confirmed", async () => {
-      await makePayments(payments);
-      await clearPayments(payments);
-      await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
-      await proveTx(
-        cardPaymentProcessor.connect(executor).confirmPayment(authorizationIds[0])
-      );
-      payments[0].status = PaymentStatus.Confirmed;
+      const { fixture, payments } = await beforeMakingPayments();
+      const { cardPaymentProcessor } = fixture;
+      await makePayments(cardPaymentProcessor, payments);
+      await clearPayments(cardPaymentProcessor, payments);
+
+      await confirmPayments(cardPaymentProcessor, [payments[0]]);
 
       await expect(
         cardPaymentProcessor.makePayment(
           payments[0].amount,
-          authorizationIds[0],
-          createBytesString(payments[0].makingPaymentCorrelationId, BYTES16_LENGTH)
+          payments[0].authorizationId,
+          payments[0].correlationId
         )
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
 
-      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking();
-      await checkCardPaymentProcessorState(payments);
+      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking(cardPaymentProcessor, payments);
+      await checkCardPaymentProcessorState(fixture, payments);
     });
 
     it("Making payment function is reverted if the payment has the 'Cleared' status", async () => {
-      await makePayments([payments[0]]);
-      await clearPayments([payments[0]]);
+      const { fixture, payments } = await beforeMakingPayments();
+      const { cardPaymentProcessor } = fixture;
+      await makePayments(cardPaymentProcessor, [payments[0]]);
+      await clearPayments(cardPaymentProcessor, [payments[0]]);
 
       await expect(
         cardPaymentProcessor.connect(payments[0].account).makePayment(
           payments[0].amount,
-          authorizationIds[0],
-          CORRELATION_ID
+          payments[0].authorizationId,
+          payments[0].correlationId,
         )
       ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
     });
 
     it("Making payment function is reverted if the revocation counter has reached the limit", async () => {
+      const { fixture, payments } = await beforeMakingPayments();
+      const { cardPaymentProcessor } = fixture;
       const revocationCounterMax: number = 1;
 
       await proveTx(cardPaymentProcessor.setRevocationLimit(revocationCounterMax));
       expect(await cardPaymentProcessor.revocationLimit()).to.equal(revocationCounterMax);
 
       for (let relocationCounter = 0; relocationCounter < revocationCounterMax; ++relocationCounter) {
-        await makePayments([payments[0]]);
+        await makePayments(cardPaymentProcessor, [payments[0]]);
         await proveTx(
           cardPaymentProcessor.connect(executor).revokePayment(
-            authorizationIds[0],
-            CORRELATION_ID,
-            PARENT_TRANSACTION_HASH
+            payments[0].authorizationId,
+            PAYMENT_REVOKING_CORRELATION_ID_STUB,
+            payments[0].parentTxHash
           )
         );
         payments[0].status = PaymentStatus.Revoked;
         payments[0].revocationCounter = relocationCounter + 1;
-        await checkCardPaymentProcessorState(payments);
+        await checkCardPaymentProcessorState(fixture, payments);
       }
 
       await expect(
         cardPaymentProcessor.connect(payments[0].account).makePayment(
           payments[0].amount,
-          authorizationIds[0],
-          CORRELATION_ID
+          payments[0].authorizationId,
+          payments[0].correlationId,
         )
       ).to.be.revertedWithCustomError(
         cardPaymentProcessor,
@@ -2909,167 +2876,150 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     });
 
     it("All payment processing functions execute successfully if the payment amount is zero", async () => {
+      const { fixture, payments } = await beforeMakingPayments();
+      const { cardPaymentProcessor, tokenMock } = fixture;
       payments.forEach(payment => payment.amount = 0);
 
-      await makePayments(payments);
-      await checkCardPaymentProcessorState(payments);
+      await makePayments(cardPaymentProcessor, payments);
+      await checkCardPaymentProcessorState(fixture, payments);
 
-      await proveTx(cardPaymentProcessor.connect(executor).clearPayments(authorizationIds));
-      payments.forEach(payment => payment.status = PaymentStatus.Cleared);
-      await checkCardPaymentProcessorState(payments);
+      await clearPayments(cardPaymentProcessor, payments);
+      await checkCardPaymentProcessorState(fixture, payments);
 
-      await proveTx(cardPaymentProcessor.connect(executor).unclearPayments(authorizationIds));
-      payments.forEach(payment => payment.status = PaymentStatus.Uncleared);
-      await checkCardPaymentProcessorState(payments);
+      await unclearPayments(cardPaymentProcessor, payments);
+      await checkCardPaymentProcessorState(fixture, payments);
 
       await proveTx(
         cardPaymentProcessor.connect(executor).revokePayment(
-          authorizationIds[0],
-          CORRELATION_ID,
-          PARENT_TRANSACTION_HASH
+          payments[0].authorizationId,
+          PAYMENT_REVOKING_CORRELATION_ID_STUB,
+          payments[0].parentTxHash
         )
       );
       payments[0].status = PaymentStatus.Revoked;
       payments[0].revocationCounter = 1;
-      await checkCardPaymentProcessorState(payments);
+
+      await checkCardPaymentProcessorState(fixture, payments);
 
       await proveTx(
         cardPaymentProcessor.connect(executor).reversePayment(
-          authorizationIds[1],
-          CORRELATION_ID,
-          PARENT_TRANSACTION_HASH
+          payments[1].authorizationId,
+          PAYMENT_REVERSING_CORRELATION_ID_STUB,
+          payments[1].parentTxHash
         )
       );
       payments[1].status = PaymentStatus.Reversed;
-      await checkCardPaymentProcessorState(payments);
+      await checkCardPaymentProcessorState(fixture, payments);
 
-      await makePayments([payments[0]]);
-      await clearPayments([payments[0]]);
+      await makePayments(cardPaymentProcessor, [payments[0]]);
+      await clearPayments(cardPaymentProcessor, [payments[0]]);
 
       const cashOutAccountBalanceBefore: BigNumber = await tokenMock.balanceOf(cashOutAccount.address);
-      await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
-      await proveTx(
-        cardPaymentProcessor.connect(executor).confirmPayments([authorizationIds[0]])
-      );
-      payments[0].status = PaymentStatus.Confirmed;
+      await confirmPayments(cardPaymentProcessor, [payments[0]]);
       const cashOutAccountBalanceAfter: BigNumber = await tokenMock.balanceOf(cashOutAccount.address);
-      await checkCardPaymentProcessorState(payments);
+      await checkCardPaymentProcessorState(fixture, payments);
       expect(cashOutAccountBalanceBefore).to.equal(cashOutAccountBalanceAfter);
     });
   });
 
   describe("Complex scenarios with cashback", async () => {
-    let payment: TestPayment;
-    let authorizationId: string;
-    let correlationId: string;
-
-    beforeEach(async () => {
-      payment = {
-        authorizationId: 12345,
-        account: user1,
-        amount: 23456,
-        status: PaymentStatus.Nonexistent,
-        makingPaymentCorrelationId: 34567,
-      };
-      authorizationId = createBytesString(payment.authorizationId, BYTES16_LENGTH);
-      correlationId = createBytesString(payment.makingPaymentCorrelationId, BYTES16_LENGTH);
-      await setUpContractsForPayments([payment]);
-      await setExecutorRole(executor);
-    });
 
     it("No cashback distributor contract's function are called if the cashback operations are disabled", async () => {
-      const { cashbackDistributorMock } = await deployCashbackDistributorMock();
+      const { fixture: { cardPaymentProcessor, cashbackDistributorMock }, payment } = await beforeMakingPayment();
       await expect(
         cardPaymentProcessor.connect(executor).makePaymentFrom(
           payment.account.address,
           payment.amount,
-          authorizationId,
-          correlationId
+          payment.authorizationId,
+          payment.correlationId
         )
       ).not.to.emit(
         cashbackDistributorMock,
-        "SendCashbackMock"
+        EVENT_NAME_SEND_CASHBACK_MOCK
       );
       await expect(
         cardPaymentProcessor.connect(executor).revokePayment(
-          authorizationId,
-          correlationId,
-          PARENT_TRANSACTION_HASH
+          payment.authorizationId,
+          PAYMENT_REVOKING_CORRELATION_ID_STUB,
+          payment.parentTxHash
         )
       ).not.to.emit(
         cashbackDistributorMock,
-        "RevokeCashbackMock"
+        EVENT_NAME_REVOKE_CASHBACK_MOCK
       );
       payment.revocationCounter = 1;
       await expect(
         cardPaymentProcessor.connect(executor).makePaymentFrom(
           payment.account.address,
           payment.amount,
-          authorizationId,
-          correlationId
+          payment.authorizationId,
+          payment.correlationId
         )
       ).not.to.emit(
         cashbackDistributorMock,
-        "SendCashbackMock"
+        EVENT_NAME_SEND_CASHBACK_MOCK
       );
+      payment.parentTxHash = increaseBytesString(payment.parentTxHash, BYTES32_LENGTH);
       await expect(
         cardPaymentProcessor.connect(executor).reversePayment(
-          authorizationId,
-          correlationId,
-          PARENT_TRANSACTION_HASH
+          payment.authorizationId,
+          PAYMENT_REVERSING_CORRELATION_ID_STUB,
+          payment.parentTxHash
         )
       ).not.to.emit(
         cashbackDistributorMock,
-        "RevokeCashbackMock"
+        EVENT_NAME_REVOKE_CASHBACK_MOCK
       );
     });
 
     it("Several refund operations execute as expected if cashback is enabled", async () => {
-      const { cashbackDistributorMockConfig } = await setUpAndEnableCashback();
-      payment.cashbackNonce = cashbackDistributorMockConfig.sendCashbackNonceResult;
-      setCashbackRate(payment, CASHBACK_RATE_IN_PERMIL);
-      await makePayments([payment]);
-      await checkCardPaymentProcessorState([payment]);
+      const { fixture, payment } = await beforeMakingPayment();
+      const { cardPaymentProcessor, tokenMock } = fixture;
+      await proveTx(cardPaymentProcessor.enableCashback());
+      setCashback(payment, fixture);
+      await makePayments(cardPaymentProcessor, [payment]);
 
-      let refundAmount = 123;
-      await proveTx(await cardPaymentProcessor.connect(executor).refundPayment(refundAmount, authorizationId));
-      setRefundAmount(payment, refundAmount);
-      await checkCardPaymentProcessorState([payment]);
+      await checkCardPaymentProcessorState(fixture, [payment]);
 
-      await clearPayments([payment]);
-      await checkCardPaymentProcessorState([payment]);
-
-      refundAmount = 234;
-      await proveTx(await cardPaymentProcessor.connect(executor).refundPayment(refundAmount, authorizationId));
-      setRefundAmount(payment, (payment.refundAmount || 0) + refundAmount);
-      await checkCardPaymentProcessorState([payment]);
-
-      await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
+      let refundAmount = Math.floor(payment.amount * 0.1);
       await proveTx(
-        cardPaymentProcessor.connect(executor).confirmPayment(authorizationId)
+        await cardPaymentProcessor.connect(executor).refundPayment(refundAmount, payment.authorizationId)
       );
-      payment.status = PaymentStatus.Confirmed;
-      await checkCardPaymentProcessorState([payment]);
+      setRefundAmount(payment, refundAmount);
+      await checkCardPaymentProcessorState(fixture, [payment]);
+
+      await clearPayments(cardPaymentProcessor, [payment]);
+      await checkCardPaymentProcessorState(fixture, [payment]);
+
+      refundAmount = Math.floor(payment.amount * 0.2);
+      await proveTx(
+        await cardPaymentProcessor.connect(executor).refundPayment(refundAmount, payment.authorizationId)
+      );
+      setRefundAmount(payment, (payment.refundAmount || 0) + refundAmount);
+      await checkCardPaymentProcessorState(fixture, [payment]);
+
+      await confirmPayments(cardPaymentProcessor, [payment]);
+      await checkCardPaymentProcessorState(fixture, [payment]);
       expect(
         await tokenMock.balanceOf(cashOutAccount.address)
       ).to.equal(payment.amount - (payment.refundAmount || 0));
 
+      refundAmount = Math.floor(payment.amount * 0.3);
       await proveTx(
-        tokenMock.connect(cashOutAccount).approve(cardPaymentProcessor.address, ethers.constants.MaxUint256)
+        await cardPaymentProcessor.connect(executor).refundPayment(refundAmount, payment.authorizationId)
       );
-
-      refundAmount = 345;
-      await proveTx(await cardPaymentProcessor.connect(executor).refundPayment(refundAmount, authorizationId));
       setRefundAmount(payment, (payment.refundAmount || 0) + refundAmount);
-      await checkCardPaymentProcessorState([payment]);
+      await checkCardPaymentProcessorState(fixture, [payment]);
       expect(
         await tokenMock.balanceOf(cashOutAccount.address)
       ).to.equal(payment.amount - (payment.refundAmount || 0));
 
       refundAmount = payment.amount - (payment.refundAmount || 0); // The remaining payment amount
-      await proveTx(await cardPaymentProcessor.connect(executor).refundPayment(refundAmount, authorizationId));
+      await proveTx(
+        await cardPaymentProcessor.connect(executor).refundPayment(refundAmount, payment.authorizationId)
+      );
       setRefundAmount(payment, (payment.refundAmount || 0) + refundAmount);
-      await checkCardPaymentProcessorState([payment]);
+      await checkCardPaymentProcessorState(fixture, [payment]);
       expect(
         await tokenMock.balanceOf(cashOutAccount.address)
       ).to.equal(0);

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -2601,7 +2601,10 @@ describe("Contract 'CardPaymentProcessor'", async () => {
 
       await expect(
         cardPaymentProcessor.connect(executor).confirmPayment(payment.authorizationId)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
+      ).to.be.revertedWithCustomError(
+        cardPaymentProcessor,
+        REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
+      ).withArgs(PaymentStatus.Uncleared);
     });
 
     it("Is reverted if the cash-out account is the zero address", async () => {
@@ -2733,7 +2736,10 @@ describe("Contract 'CardPaymentProcessor'", async () => {
 
       await expect(
         cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
+      ).to.be.revertedWithCustomError(
+        cardPaymentProcessor,
+        REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
+      ).withArgs(PaymentStatus.Uncleared);
     });
 
     it("Is reverted if the cash-out account is the zero address", async () => {

--- a/test/CashbackDistributor.test.ts
+++ b/test/CashbackDistributor.test.ts
@@ -1,14 +1,15 @@
-import { ethers } from "hardhat";
+import { ethers, network, upgrades } from "hardhat";
 import { expect } from "chai";
 import { BigNumber, Contract, ContractFactory } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { proveTx } from "../test-utils/eth";
 import { createBytesString, createRevertMessageDueToMissingRole } from "../test-utils/misc";
 
+const MAX_UINT256 = ethers.constants.MaxUint256;
+const ZERO_ADDRESS = ethers.constants.AddressZero;
+const ZERO_HASH = ethers.constants.HashZero;
 const BYTES32_LENGTH: number = 32;
-const CASHBACK_EXTERNAL_ID_STUB1 = createBytesString("01", BYTES32_LENGTH);
-const CASHBACK_EXTERNAL_ID_STUB2 = createBytesString("02", BYTES32_LENGTH);
-const TOKEN_ADDRESS_STUB = "0x0000000000000000000000000000000000000001";
 
 enum CashbackStatus {
   Nonexistent = 0,
@@ -44,12 +45,23 @@ interface TestCashback {
   revokedAmount?: number;
 }
 
+interface Fixture {
+  cashbackDistributor: Contract;
+  tokenMocks: Contract[];
+}
+
+interface TestContext {
+  fixture: Fixture,
+  cashbacks: TestCashback[],
+  cashbackDistributorInitialBalanceByToken: Map<Contract, number>
+}
+
 function checkNonexistentCashback(
   actualOnChainCashback: any,
   cashbackNonce: number
 ) {
   expect(actualOnChainCashback.token).to.equal(
-    ethers.constants.AddressZero,
+    ZERO_ADDRESS,
     `cashback[${cashbackNonce}].token is incorrect`
   );
   expect(actualOnChainCashback.kind).to.equal(
@@ -61,11 +73,11 @@ function checkNonexistentCashback(
     `cashback[${cashbackNonce}].status is incorrect`
   );
   expect(actualOnChainCashback.externalId).to.equal(
-    ethers.constants.HashZero,
+    ZERO_HASH,
     `cashback[${cashbackNonce}].externalId is incorrect`
   );
   expect(actualOnChainCashback.recipient).to.equal(
-    ethers.constants.AddressZero,
+    ZERO_ADDRESS,
     `cashback[${cashbackNonce}].recipient is incorrect`
   );
   expect(actualOnChainCashback.amount).to.equal(
@@ -73,7 +85,7 @@ function checkNonexistentCashback(
     `cashback[${cashbackNonce}].amount is incorrect`
   );
   expect(actualOnChainCashback.sender).to.equal(
-    ethers.constants.AddressZero,
+    ZERO_ADDRESS,
     `cashback[${cashbackNonce}].sender is incorrect`
   );
   expect(actualOnChainCashback.revokedAmount).to.equal(
@@ -124,16 +136,24 @@ function checkEquality(
   }
 }
 
-async function deployTokenMock(symbol: string = "TEST"): Promise<Contract> {
-  const tokenMockFactory: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
-  const tokenMock = await tokenMockFactory.deploy();
-  await tokenMock.deployed();
-  await proveTx(tokenMock.initialize("ERC20 Test", symbol));
-
-  return tokenMock;
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
 }
 
 describe("Contract 'CashbackDistributor'", async () => {
+  const CASHBACK_EXTERNAL_ID_STUB1 = createBytesString("01", BYTES32_LENGTH);
+  const CASHBACK_EXTERNAL_ID_STUB2 = createBytesString("02", BYTES32_LENGTH);
+  const TOKEN_ADDRESS_STUB = "0x0000000000000000000000000000000000000001";
+
+  const EVENT_NAME_ENABLE = "Enable";
+  const EVENT_NAME_DISABLE = "Disable";
+  const EVENT_NAME_REVOKE_CASHBACK = "RevokeCashback";
+  const EVENT_NAME_SEND_CASHBACK = "SendCashback";
+
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
   const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
 
@@ -143,55 +163,80 @@ describe("Contract 'CashbackDistributor'", async () => {
   const REVERT_ERROR_IF_RECIPIENT_ADDRESS_IS_ZERO = "ZeroRecipientAddress";
   const REVERT_ERROR_IF_EXTERNAL_ID_IS_ZERO = "ZeroExternalId";
 
+  const ownerRole: string = ethers.utils.id("OWNER_ROLE");
+  const blacklisterRole: string = ethers.utils.id("BLACKLISTER_ROLE");
+  const pauserRole: string = ethers.utils.id("PAUSER_ROLE");
+  const rescuerRole: string = ethers.utils.id("RESCUER_ROLE");
+  const distributorRole: string = ethers.utils.id("DISTRIBUTOR_ROLE");
+
   let cashbackDistributorFactory: ContractFactory;
-  let cashbackDistributor: Contract;
   let tokenMockFactory: ContractFactory;
 
   let deployer: SignerWithAddress;
   let distributor: SignerWithAddress;
   let user: SignerWithAddress;
 
-  let ownerRole: string;
-  let blacklisterRole: string;
-  let pauserRole: string;
-  let rescuerRole: string;
-  let distributorRole: string;
-
-  beforeEach(async () => {
-    // Token mock factory
+  before(async () => {
+    cashbackDistributorFactory = await ethers.getContractFactory("CashbackDistributor");
     tokenMockFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
 
-    // Deploy the contract under test
-    cashbackDistributorFactory = await ethers.getContractFactory("CashbackDistributor");
-    cashbackDistributor = await cashbackDistributorFactory.deploy();
-    await cashbackDistributor.deployed();
-    await proveTx(cashbackDistributor.initialize());
-
-    // Accounts
     [deployer, distributor, user] = await ethers.getSigners();
-
-    // Roles
-    ownerRole = (await cashbackDistributor.OWNER_ROLE()).toLowerCase();
-    blacklisterRole = (await cashbackDistributor.BLACKLISTER_ROLE()).toLowerCase();
-    pauserRole = (await cashbackDistributor.PAUSER_ROLE()).toLowerCase();
-    rescuerRole = (await cashbackDistributor.RESCUER_ROLE()).toLowerCase();
-    distributorRole = (await cashbackDistributor.DISTRIBUTOR_ROLE()).toLowerCase();
   });
 
-  async function setUpContractsForSendingCashbacks(cashbacks: TestCashback[]): Promise<Map<Contract, number>> {
-    const cashbackDistributorBalanceByToken: Map<Contract, number> = new Map<Contract, number>();
-    cashbacks.forEach(cashback => {
-      let totalCashbackAmount: number = cashbackDistributorBalanceByToken.get(cashback.token) || 0;
-      totalCashbackAmount += cashback.amount;
-      cashbackDistributorBalanceByToken.set(cashback.token, totalCashbackAmount);
-    });
-    for (let [token, totalCashbackAmount] of cashbackDistributorBalanceByToken.entries()) {
-      await proveTx(token.mint(cashbackDistributor.address, totalCashbackAmount));
-    }
-    return cashbackDistributorBalanceByToken;
+  async function deployTokenMock(nameSuffix: string): Promise<Contract> {
+    const name = "ERC20 Test" + nameSuffix;
+    const symbol = "TEST" + nameSuffix;
+
+    const tokenMock: Contract = await upgrades.deployProxy(tokenMockFactory, [name, symbol]);
+    await tokenMock.deployed();
+
+    return tokenMock;
   }
 
-  async function sendCashbacks(cashbacks: TestCashback[], targetStatus: CashbackStatus) {
+  async function deployCashbackDistributor(): Promise<{ cashbackDistributor: Contract }> {
+    const cashbackDistributor: Contract = await upgrades.deployProxy(cashbackDistributorFactory);
+    await cashbackDistributor.deployed();
+
+    return { cashbackDistributor };
+  }
+
+  async function deployAndConfigureAllContracts(): Promise<Fixture> {
+    const { cashbackDistributor } = await deployCashbackDistributor();
+    const tokenMock1 = await deployTokenMock("1");
+    const tokenMock2 = await deployTokenMock("2");
+
+    await proveTx(cashbackDistributor.grantRole(blacklisterRole, deployer.address));
+    await proveTx(cashbackDistributor.grantRole(distributorRole, distributor.address));
+    await proveTx(cashbackDistributor.enable());
+
+    return {
+      cashbackDistributor,
+      tokenMocks: [tokenMock1, tokenMock2],
+    };
+  }
+
+  async function setUpContractsForSendingCashbacks(
+    cashbackDistributor: Contract,
+    cashbacks: TestCashback[]
+  ): Promise<{ cashbackDistributorInitialBalanceByToken: Map<Contract, number> }> {
+    const cashbackDistributorInitialBalanceByToken: Map<Contract, number> = new Map<Contract, number>();
+    cashbacks.forEach(cashback => {
+      let totalCashbackAmount: number = cashbackDistributorInitialBalanceByToken.get(cashback.token) || 0;
+      totalCashbackAmount += cashback.amount;
+      cashbackDistributorInitialBalanceByToken.set(cashback.token, totalCashbackAmount);
+    });
+    for (let [token, totalCashbackAmount] of cashbackDistributorInitialBalanceByToken.entries()) {
+      await proveTx(token.mint(cashbackDistributor.address, totalCashbackAmount));
+    }
+    return { cashbackDistributorInitialBalanceByToken };
+  }
+
+  async function pauseContract(contract: Contract) {
+    await proveTx(contract.grantRole(pauserRole, deployer.address));
+    await proveTx(contract.pause());
+  }
+
+  async function sendCashbacks(cashbackDistributor: Contract, cashbacks: TestCashback[], targetStatus: CashbackStatus) {
     for (let cashback of cashbacks) {
       await proveTx(
         cashbackDistributor.connect(cashback.sender).sendCashback(
@@ -212,7 +257,8 @@ describe("Contract 'CashbackDistributor'", async () => {
     }
   }
 
-  async function checkCashbackStructures(cashbacks: TestCashback[]) {
+  async function checkCashbackStructures(context: TestContext) {
+    const { fixture: { cashbackDistributor }, cashbacks } = context;
     // The cashback structure with the zero nonce must be always nonexistent one.
     checkNonexistentCashback(await cashbackDistributor.getCashback(0), 0);
 
@@ -228,8 +274,10 @@ describe("Contract 'CashbackDistributor'", async () => {
     }
   }
 
-  async function checkCashbackNonceByExternalId(cashbacks: TestCashback[]) {
+  async function checkCashbackNonceByExternalId(context: TestContext) {
+    const { fixture: { cashbackDistributor }, cashbacks } = context;
     const expectedMap = new Map<string, BigNumber[]>();
+
     cashbacks.forEach(cashback => {
       const nonces: BigNumber[] = expectedMap.get(cashback.externalId) || [];
       nonces.push(BigNumber.from(cashback.nonce));
@@ -246,8 +294,10 @@ describe("Contract 'CashbackDistributor'", async () => {
     }
   }
 
-  async function checkTotalCashbackByTokenAndExternalId(cashbacks: TestCashback[]) {
+  async function checkTotalCashbackByTokenAndExternalId(context: TestContext) {
+    const { fixture: { cashbackDistributor }, cashbacks } = context;
     const expectedMap = new Map<Contract, Map<string, number>>();
+
     cashbacks.forEach(cashback => {
       const totalCashbackMap: Map<string, number> = expectedMap.get(cashback.token) || new Map<string, number>();
       let totalCashback: number = totalCashbackMap.get(cashback.externalId) || 0;
@@ -270,8 +320,10 @@ describe("Contract 'CashbackDistributor'", async () => {
     }
   }
 
-  async function checkTotalCashbackByTokenAndRecipient(cashbacks: TestCashback[]) {
+  async function checkTotalCashbackByTokenAndRecipient(context: TestContext) {
+    const { fixture: { cashbackDistributor }, cashbacks } = context;
     const expectedMap = new Map<Contract, Map<string, number>>();
+
     cashbacks.forEach(cashback => {
       const recipientAddress: string = cashback.recipient.address;
       const totalCashbackMap: Map<string, number> = expectedMap.get(cashback.token) || new Map<string, number>();
@@ -296,11 +348,10 @@ describe("Contract 'CashbackDistributor'", async () => {
     }
   }
 
-  async function checkCashbackDistributorBalanceByTokens(
-    cashbacks: TestCashback[],
-    cashbackDistributorInitialBalanceByToken: Map<Contract, number>
-  ) {
+  async function checkCashbackDistributorBalanceByTokens(context: TestContext) {
+    const { fixture: { cashbackDistributor }, cashbacks, cashbackDistributorInitialBalanceByToken } = context;
     const expectedMap = new Map<Contract, number>();
+
     cashbacks.forEach(cashback => {
       let balance: number = expectedMap.get(cashback.token)
         || (cashbackDistributorInitialBalanceByToken.get(cashback.token) || 0);
@@ -321,68 +372,103 @@ describe("Contract 'CashbackDistributor'", async () => {
     }
   }
 
-  async function checkCashbackDistributorState(
-    cashbacks: TestCashback[],
-    cashbackDistributorInitialBalanceByToken: Map<Contract, number>
-  ) {
-    await checkCashbackStructures(cashbacks);
-    await checkCashbackNonceByExternalId(cashbacks);
-    await checkTotalCashbackByTokenAndExternalId(cashbacks);
-    await checkTotalCashbackByTokenAndRecipient(cashbacks);
-    await checkCashbackDistributorBalanceByTokens(cashbacks, cashbackDistributorInitialBalanceByToken);
+  async function checkCashbackDistributorState(context: TestContext) {
+    await checkCashbackStructures(context);
+    await checkCashbackNonceByExternalId(context);
+    await checkTotalCashbackByTokenAndExternalId(context);
+    await checkTotalCashbackByTokenAndRecipient(context);
+    await checkCashbackDistributorBalanceByTokens(context);
   }
 
-  it("The initialize function can't be called more than once", async () => {
-    await expect(
-      cashbackDistributor.initialize()
-    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
-  });
+  async function prepareForSingleCashback(): Promise<{ fixture: Fixture, cashback: TestCashback }> {
+    const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
+    const cashback: TestCashback = {
+      token: tokenMockFactory.attach(TOKEN_ADDRESS_STUB),
+      kind: CashbackKind.CardPayment,
+      status: CashbackStatus.Nonexistent,
+      externalId: CASHBACK_EXTERNAL_ID_STUB1,
+      recipient: user,
+      amount: 123,
+      revokedAmount: 0,
+      sender: distributor,
+      nonce: 1,
+    };
+    cashback.token = fixture.tokenMocks[0];
 
-  it("The initial contract configuration should be as expected", async () => {
-    // The admins of roles
-    expect(await cashbackDistributor.getRoleAdmin(ownerRole)).to.equal(ownerRole);
-    expect(await cashbackDistributor.getRoleAdmin(blacklisterRole)).to.equal(ownerRole);
-    expect(await cashbackDistributor.getRoleAdmin(pauserRole)).to.equal(ownerRole);
-    expect(await cashbackDistributor.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
-    expect(await cashbackDistributor.getRoleAdmin(distributorRole)).to.equal(ownerRole);
+    return { fixture, cashback };
+  }
 
-    // The deployer should have the owner role, but not the other roles
-    expect(await cashbackDistributor.hasRole(ownerRole, deployer.address)).to.equal(true);
-    expect(await cashbackDistributor.hasRole(blacklisterRole, deployer.address)).to.equal(false);
-    expect(await cashbackDistributor.hasRole(pauserRole, deployer.address)).to.equal(false);
-    expect(await cashbackDistributor.hasRole(rescuerRole, deployer.address)).to.equal(false);
-    expect(await cashbackDistributor.hasRole(distributorRole, deployer.address)).to.equal(false);
+  async function beforeSendingCashback(): Promise<TestContext> {
+    const { fixture, cashback } = await prepareForSingleCashback();
+    const { cashbackDistributorInitialBalanceByToken } = await setUpContractsForSendingCashbacks(
+      fixture.cashbackDistributor,
+      [cashback]
+    );
 
-    // The initial contract state is unpaused
-    expect(await cashbackDistributor.paused()).to.equal(false);
+    return { fixture, cashbacks: [cashback], cashbackDistributorInitialBalanceByToken };
+  }
 
-    // Cashback related values
-    expect(await cashbackDistributor.enabled()).to.equal(false);
-    expect(await cashbackDistributor.nextNonce()).to.equal(1);
-    const cashbackDistributorInitialBalanceByToken = new Map<Contract, number>();
-    await checkCashbackDistributorState([], cashbackDistributorInitialBalanceByToken);
+  describe("Function 'initialize()'", async () => {
+    it("Configures the contract as expected", async () => {
+      const { cashbackDistributor } = await setUpFixture(deployCashbackDistributor);
+
+      // The admins of roles
+      expect(await cashbackDistributor.getRoleAdmin(ownerRole)).to.equal(ownerRole);
+      expect(await cashbackDistributor.getRoleAdmin(blacklisterRole)).to.equal(ownerRole);
+      expect(await cashbackDistributor.getRoleAdmin(pauserRole)).to.equal(ownerRole);
+      expect(await cashbackDistributor.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
+      expect(await cashbackDistributor.getRoleAdmin(distributorRole)).to.equal(ownerRole);
+
+      // The deployer should have the owner role, but not the other roles
+      expect(await cashbackDistributor.hasRole(ownerRole, deployer.address)).to.equal(true);
+      expect(await cashbackDistributor.hasRole(blacklisterRole, deployer.address)).to.equal(false);
+      expect(await cashbackDistributor.hasRole(pauserRole, deployer.address)).to.equal(false);
+      expect(await cashbackDistributor.hasRole(rescuerRole, deployer.address)).to.equal(false);
+      expect(await cashbackDistributor.hasRole(distributorRole, deployer.address)).to.equal(false);
+
+      // The initial contract state is unpaused
+      expect(await cashbackDistributor.paused()).to.equal(false);
+
+      // Cashback related values
+      expect(await cashbackDistributor.enabled()).to.equal(false);
+      expect(await cashbackDistributor.nextNonce()).to.equal(1);
+      const cashbackDistributorInitialBalanceByToken = new Map<Contract, number>();
+      const fixture: Fixture = { cashbackDistributor, tokenMocks: [] };
+      await checkCashbackDistributorState({ fixture, cashbacks: [], cashbackDistributorInitialBalanceByToken });
+    });
+
+    it("Is reverted if it is called a second time", async () => {
+      const { cashbackDistributor } = await setUpFixture(deployCashbackDistributor);
+      await expect(
+        cashbackDistributor.initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
   });
 
   describe("Function 'enable()'", async () => {
-    it("Is reverted if the caller does not have the owner role", async () => {
-      await expect(
-        cashbackDistributor.connect(user).enable()
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user.address, ownerRole));
-    });
-
     it("Executes as expected and emits the correct event", async () => {
+      const { cashbackDistributor } = await setUpFixture(deployCashbackDistributor);
+
       await expect(
         cashbackDistributor.enable()
       ).to.emit(
         cashbackDistributor,
-        "Enable"
+        EVENT_NAME_ENABLE
       ).withArgs(
         deployer.address
       );
       expect(await cashbackDistributor.enabled()).to.equal(true);
     });
 
+    it("Is reverted if the caller does not have the owner role", async () => {
+      const { cashbackDistributor } = await setUpFixture(deployCashbackDistributor);
+      await expect(
+        cashbackDistributor.connect(user).enable()
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(user.address, ownerRole));
+    });
+
     it("Is reverted if cashback operations are already enabled", async () => {
+      const { cashbackDistributor } = await setUpFixture(deployCashbackDistributor);
       await proveTx(cashbackDistributor.enable());
       await expect(
         cashbackDistributor.enable()
@@ -391,124 +477,44 @@ describe("Contract 'CashbackDistributor'", async () => {
   });
 
   describe("Function 'disable()'", async () => {
+    it("Executes as expected and emits the correct event", async () => {
+      const { cashbackDistributor } = await setUpFixture(deployCashbackDistributor);
+      await proveTx(cashbackDistributor.enable());
+      expect(await cashbackDistributor.enabled()).to.equal(true);
+
+      await expect(
+        cashbackDistributor.disable()
+      ).to.emit(
+        cashbackDistributor,
+        EVENT_NAME_DISABLE
+      ).withArgs(
+        deployer.address
+      );
+      expect(await cashbackDistributor.enabled()).to.equal(false);
+    });
+
     it("Is reverted if the caller does not have the owner role", async () => {
+      const { cashbackDistributor } = await setUpFixture(deployCashbackDistributor);
       await expect(
         cashbackDistributor.connect(user).disable()
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(user.address, ownerRole));
     });
 
     it("Is reverted if cashback operations are already disabled", async () => {
+      const { cashbackDistributor } = await setUpFixture(deployCashbackDistributor);
       await expect(
         cashbackDistributor.disable()
       ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_CASHBACK_ALREADY_DISABLED);
     });
-
-    it("Executes as expected and emits the correct event", async () => {
-      await proveTx(cashbackDistributor.enable());
-      expect(await cashbackDistributor.enabled()).to.equal(true);
-      await expect(
-        cashbackDistributor.disable()
-      ).to.emit(
-        cashbackDistributor,
-        "Disable"
-      ).withArgs(
-        deployer.address
-      );
-      expect(await cashbackDistributor.enabled()).to.equal(false);
-    });
   });
 
   describe("Function 'sendCashback()'", async () => {
-    let cashback: TestCashback;
-
-    beforeEach(async () => {
-      cashback = {
-        token: tokenMockFactory.attach(TOKEN_ADDRESS_STUB),
-        kind: CashbackKind.CardPayment,
-        status: CashbackStatus.Nonexistent,
-        externalId: CASHBACK_EXTERNAL_ID_STUB1,
-        recipient: user,
-        amount: 123,
-        sender: distributor,
-        nonce: 1,
-      };
-      await proveTx(cashbackDistributor.grantRole(distributorRole, distributor.address));
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(cashbackDistributor.grantRole(pauserRole, deployer.address));
-      await proveTx(cashbackDistributor.pause());
-      await expect(
-        cashbackDistributor.connect(cashback.sender).sendCashback(
-          cashback.token.address,
-          cashback.kind,
-          cashback.externalId,
-          cashback.recipient.address,
-          cashback.amount
-        )
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller does not have the distributor role", async () => {
-      await expect(
-        cashbackDistributor.sendCashback(
-          cashback.token.address,
-          cashback.kind,
-          cashback.externalId,
-          cashback.recipient.address,
-          cashback.amount
-        )
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, distributorRole));
-    });
-
-    it("Is reverted if the token address is zero", async () => {
-      await expect(
-        cashbackDistributor.connect(cashback.sender).sendCashback(
-          ethers.constants.AddressZero,
-          cashback.kind,
-          cashback.externalId,
-          cashback.recipient.address,
-          cashback.amount
-        )
-      ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_TOKEN_ADDRESS_IS_ZERO);
-    });
-
-    it("Is reverted if the recipient address is zero", async () => {
-      await expect(
-        cashbackDistributor.connect(cashback.sender).sendCashback(
-          cashback.token.address,
-          cashback.kind,
-          cashback.externalId,
-          ethers.constants.AddressZero,
-          cashback.amount
-        )
-      ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_RECIPIENT_ADDRESS_IS_ZERO);
-    });
-
-    it("Is reverted if the cashback external ID is zero", async () => {
-      cashback.externalId = ethers.constants.HashZero;
-      await expect(
-        cashbackDistributor.connect(cashback.sender).sendCashback(
-          cashback.token.address,
-          cashback.kind,
-          cashback.externalId,
-          cashback.recipient.address,
-          cashback.amount
-        )
-      ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_EXTERNAL_ID_IS_ZERO);
-    });
-
     describe("Executes as expected and emits the correct event if the sending succeeds and", async () => {
-      let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
-
-      beforeEach(async () => {
-        cashback.token = await deployTokenMock();
-        cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks([cashback]);
-      });
-
-      async function checkSuccessfulCashbackSending() {
-        await proveTx(cashbackDistributor.enable());
+      async function checkSuccessfulCashbackSending(context: TestContext) {
+        const { fixture, cashbacks: [cashback] } = context;
+        const { cashbackDistributor } = fixture;
         cashback.status = CashbackStatus.Success;
+
         await expect(
           cashbackDistributor.connect(cashback.sender).sendCashback(
             cashback.token.address,
@@ -523,7 +529,7 @@ describe("Contract 'CashbackDistributor'", async () => {
           [-cashback.amount, +cashback.amount, 0]
         ).and.to.emit(
           cashbackDistributor,
-          "SendCashback"
+          EVENT_NAME_SEND_CASHBACK
         ).withArgs(
           cashback.token.address,
           cashback.kind,
@@ -534,28 +540,26 @@ describe("Contract 'CashbackDistributor'", async () => {
           cashback.sender.address,
           cashback.nonce,
         );
-        await checkCashbackDistributorState([cashback], cashbackDistributorInitialBalanceByToken);
+
+        await checkCashbackDistributorState(context);
       }
 
       it("The cashback amount is nonzero", async () => {
-        await checkSuccessfulCashbackSending();
+        const context = await beforeSendingCashback();
+        await checkSuccessfulCashbackSending(context);
       });
 
       it("The cashback amount is zero", async () => {
-        cashback.amount = 0;
-        await checkSuccessfulCashbackSending();
+        const context = await beforeSendingCashback();
+        context.cashbacks[0].amount = 0;
+        await checkSuccessfulCashbackSending(context);
       });
     });
 
     describe("Executes as expected and emits the correct event if the sending fails because", async () => {
-      let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
+      async function checkUnsuccessfulCashbackSending(context: TestContext) {
+        const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
 
-      beforeEach(async () => {
-        cashback.token = await deployTokenMock();
-        cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks([cashback]);
-      });
-
-      async function checkUnsuccessfulCashbackSending() {
         await expect(
           cashbackDistributor.connect(cashback.sender).sendCashback(
             cashback.token.address,
@@ -570,7 +574,7 @@ describe("Contract 'CashbackDistributor'", async () => {
           [0, 0, 0]
         ).and.to.emit(
           cashbackDistributor,
-          "SendCashback"
+          EVENT_NAME_SEND_CASHBACK
         ).withArgs(
           cashback.token.address,
           cashback.kind,
@@ -581,89 +585,120 @@ describe("Contract 'CashbackDistributor'", async () => {
           cashback.sender.address,
           cashback.nonce,
         );
-        await checkCashbackDistributorState([cashback], cashbackDistributorInitialBalanceByToken);
+        await checkCashbackDistributorState(context);
       }
 
       it("Cashback operations are disabled", async () => {
-        cashback.status = CashbackStatus.Disabled;
-        await checkUnsuccessfulCashbackSending();
+        const context = await beforeSendingCashback();
+        await proveTx(context.fixture.cashbackDistributor.disable());
+        context.cashbacks[0].status = CashbackStatus.Disabled;
+        await checkUnsuccessfulCashbackSending(context);
       });
 
       it("The cashback distributor contract has not enough balance", async () => {
-        await proveTx(cashbackDistributor.enable());
+        const context = await beforeSendingCashback();
+        const { cashbacks: [cashback] } = context;
         cashback.amount = cashback.amount + 1;
         cashback.status = CashbackStatus.OutOfFunds;
-        await checkUnsuccessfulCashbackSending();
+        await checkUnsuccessfulCashbackSending(context);
       });
 
       it("The cashback recipient is blacklisted", async () => {
-        await proveTx(cashbackDistributor.enable());
-        await proveTx(cashbackDistributor.grantRole(blacklisterRole, deployer.address));
+        const context = await beforeSendingCashback();
+        const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
         await proveTx(cashbackDistributor.blacklist(cashback.recipient.address));
         cashback.status = CashbackStatus.Blacklisted;
-        await checkUnsuccessfulCashbackSending();
+        await checkUnsuccessfulCashbackSending(context);
+      });
+    });
+
+    describe("Is reverted if", async () => {
+      it("The contract is paused", async () => {
+        const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
+        await pauseContract(cashbackDistributor);
+        await expect(
+          cashbackDistributor.connect(cashback.sender).sendCashback(
+            cashback.token.address,
+            cashback.kind,
+            cashback.externalId,
+            cashback.recipient.address,
+            cashback.amount
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The caller does not have the distributor role", async () => {
+        const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
+        await expect(
+          cashbackDistributor.sendCashback(
+            cashback.token.address,
+            cashback.kind,
+            cashback.externalId,
+            cashback.recipient.address,
+            cashback.amount
+          )
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, distributorRole));
+      });
+
+      it("The token address is zero", async () => {
+        const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
+        await expect(
+          cashbackDistributor.connect(cashback.sender).sendCashback(
+            ZERO_ADDRESS,
+            cashback.kind,
+            cashback.externalId,
+            cashback.recipient.address,
+            cashback.amount
+          )
+        ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_TOKEN_ADDRESS_IS_ZERO);
+      });
+
+      it("The recipient address is zero", async () => {
+        const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
+        await expect(
+          cashbackDistributor.connect(cashback.sender).sendCashback(
+            cashback.token.address,
+            cashback.kind,
+            cashback.externalId,
+            ZERO_ADDRESS,
+            cashback.amount
+          )
+        ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_RECIPIENT_ADDRESS_IS_ZERO);
+      });
+
+      it("The cashback external ID is zero", async () => {
+        const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
+        cashback.externalId = ZERO_HASH;
+        await expect(
+          cashbackDistributor.connect(cashback.sender).sendCashback(
+            cashback.token.address,
+            cashback.kind,
+            cashback.externalId,
+            cashback.recipient.address,
+            cashback.amount
+          )
+        ).to.be.revertedWithCustomError(cashbackDistributor, REVERT_ERROR_IF_EXTERNAL_ID_IS_ZERO);
       });
     });
   });
 
   describe("Function 'revokeCashback()'", async () => {
-    let cashback: TestCashback;
-
-    beforeEach(async () => {
-      cashback = {
-        token: tokenMockFactory.attach(TOKEN_ADDRESS_STUB),
-        kind: CashbackKind.CardPayment,
-        status: CashbackStatus.Nonexistent,
-        externalId: CASHBACK_EXTERNAL_ID_STUB1,
-        recipient: user,
-        amount: 123,
-        sender: distributor,
-        nonce: 1,
-        revokedAmount: 12,
-      };
-      await proveTx(cashbackDistributor.grantRole(distributorRole, distributor.address));
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(cashbackDistributor.grantRole(pauserRole, deployer.address));
-      await proveTx(cashbackDistributor.pause());
-      await expect(
-        cashbackDistributor.connect(cashback.sender).revokeCashback(cashback.nonce, cashback.revokedAmount)
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller does not have the distributor role", async () => {
-      await expect(
-        cashbackDistributor.revokeCashback(cashback.nonce, cashback.revokedAmount)
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, distributorRole));
-    });
-
     describe("Executes as expected and emits the correct event if the revocation succeeds and", async () => {
-      let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
-
-      beforeEach(async () => {
-        cashback.token = await deployTokenMock();
-        cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks([cashback]);
-      });
-
-      async function checkRevokingOfSuccessfulCashback() {
-        await proveTx(cashbackDistributor.enable());
-        await sendCashbacks([cashback], CashbackStatus.Success);
-        await proveTx(cashback.token.mint(cashback.sender.address, cashback.revokedAmount));
-        await proveTx(cashback.token.connect(cashback.sender).approve(
-          cashbackDistributor.address,
-          ethers.constants.MaxUint256
-        ));
+      async function checkRevokingOfSuccessfulCashback(context: TestContext) {
+        const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
+        await sendCashbacks(cashbackDistributor, [cashback], CashbackStatus.Success);
+        await proveTx(cashback.token.mint(distributor.address, cashback.revokedAmount));
+        await proveTx(cashback.token.connect(distributor).approve(cashbackDistributor.address, MAX_UINT256));
 
         await expect(
-          cashbackDistributor.connect(cashback.sender).revokeCashback(cashback.nonce, cashback.revokedAmount)
+          cashbackDistributor.connect(distributor).revokeCashback(cashback.nonce, cashback.revokedAmount)
         ).to.changeTokenBalances(
           cashback.token,
           [cashbackDistributor, cashback.recipient, cashback.sender],
           [+(cashback.revokedAmount || 0), 0, -(cashback.revokedAmount || 0)]
         ).and.to.emit(
           cashbackDistributor,
-          "RevokeCashback"
+          EVENT_NAME_REVOKE_CASHBACK
         ).withArgs(
           cashback.token.address,
           cashback.kind,
@@ -672,45 +707,49 @@ describe("Contract 'CashbackDistributor'", async () => {
           cashback.externalId,
           cashback.recipient.address,
           cashback.revokedAmount,
-          cashback.sender.address,
+          distributor.address,
           cashback.nonce,
         );
-        await checkCashbackDistributorState([cashback], cashbackDistributorInitialBalanceByToken);
+        await checkCashbackDistributorState(context);
       }
 
       it("The revocation amount is less than the initial cashback amount", async () => {
-        await checkRevokingOfSuccessfulCashback();
+        const context = await beforeSendingCashback();
+        const { cashbacks: [cashback] } = context;
+        cashback.revokedAmount = Math.floor(cashback.amount * 0.1);
+        await checkRevokingOfSuccessfulCashback(context);
       });
 
       it("The revocation amount equals the initial cashback amount", async () => {
+        const context = await beforeSendingCashback();
+        const { cashbacks: [cashback] } = context;
         cashback.revokedAmount = cashback.amount;
-        await checkRevokingOfSuccessfulCashback();
+        await checkRevokingOfSuccessfulCashback(context);
       });
 
       it("The revocation amount is zero", async () => {
-        cashback.revokedAmount = 0;
-        await checkRevokingOfSuccessfulCashback();
+        const context = await beforeSendingCashback();
+        context.cashbacks[0].revokedAmount = 0;
+        await checkRevokingOfSuccessfulCashback(context);
       });
     });
 
     describe("Executes as expected and emits the correct event if the revocation fails because", async () => {
-      let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
+      async function checkRevokingOfUnsuccessfulCashback(
+        targetRevocationStatus: RevocationStatus,
+        context: TestContext
+      ) {
+        const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
 
-      beforeEach(async () => {
-        cashback.token = await deployTokenMock();
-        cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks([cashback]);
-      });
-
-      async function checkRevokingOfUnsuccessfulCashback(targetRevocationStatus: RevocationStatus) {
         await expect(
-          cashbackDistributor.connect(cashback.sender).revokeCashback(cashback.nonce, cashback.revokedAmount)
+          cashbackDistributor.connect(distributor).revokeCashback(cashback.nonce, cashback.revokedAmount)
         ).to.changeTokenBalances(
           cashback.token,
           [cashbackDistributor, cashback.recipient, cashback.sender],
           [0, 0, 0]
         ).and.to.emit(
           cashbackDistributor,
-          "RevokeCashback"
+          EVENT_NAME_REVOKE_CASHBACK
         ).withArgs(
           cashback.token.address,
           cashback.kind,
@@ -719,76 +758,94 @@ describe("Contract 'CashbackDistributor'", async () => {
           cashback.externalId,
           cashback.recipient.address,
           cashback.revokedAmount,
-          cashback.sender.address,
+          distributor.address,
           cashback.nonce,
         );
         cashback.revokedAmount = 0;
-        await checkCashbackDistributorState([cashback], cashbackDistributorInitialBalanceByToken);
+        await checkCashbackDistributorState(context);
       }
 
       it("The caller has not enough tokens", async () => {
-        await proveTx(cashbackDistributor.enable());
-        await sendCashbacks([cashback], CashbackStatus.Success);
-        await proveTx(cashback.token.mint(cashback.sender.address, (cashback.revokedAmount || 0) - 1));
-        await proveTx(cashback.token.connect(cashback.sender).approve(
-          cashbackDistributor.address,
-          ethers.constants.MaxUint256
-        ));
-        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.OutOfFunds);
+        const context = await beforeSendingCashback();
+        const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
+        await sendCashbacks(cashbackDistributor, [cashback], CashbackStatus.Success);
+        cashback.revokedAmount = Math.floor(cashback.amount * 0.1);
+        await proveTx(cashback.token.mint(distributor.address, (cashback.revokedAmount || 0) - 1));
+        await proveTx(cashback.token.connect(distributor).approve(cashbackDistributor.address, MAX_UINT256));
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.OutOfFunds, context);
       });
 
       it("The cashback distributor has not enough allowance from the caller", async () => {
-        await proveTx(cashbackDistributor.enable());
-        await sendCashbacks([cashback], CashbackStatus.Success);
-        await proveTx(cashback.token.mint(cashback.sender.address, cashback.revokedAmount));
-        await proveTx(cashback.token.connect(cashback.sender).approve(
+        const context = await beforeSendingCashback();
+        const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
+        await sendCashbacks(cashbackDistributor, [cashback], CashbackStatus.Success);
+        cashback.revokedAmount = Math.floor(cashback.amount * 0.1);
+        await proveTx(cashback.token.mint(distributor.address, cashback.revokedAmount));
+        await proveTx(cashback.token.connect(distributor).approve(
           cashbackDistributor.address,
           (cashback.revokedAmount || 0) - 1
         ));
-        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.OutOfAllowance);
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.OutOfAllowance, context);
       });
 
       it("Cashback operations were disabled prior cashback sending", async () => {
-        await sendCashbacks([cashback], CashbackStatus.Disabled);
-        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.Inapplicable);
+        const context = await beforeSendingCashback();
+        const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
+        await proveTx(cashbackDistributor.disable());
+        await sendCashbacks(cashbackDistributor, [cashback], CashbackStatus.Disabled);
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.Inapplicable, context);
       });
 
       it("The cashback distributor had not enough balance prior cashback sending", async () => {
-        await proveTx(cashbackDistributor.enable());
+        const context = await beforeSendingCashback();
+        const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
         cashback.amount = cashback.amount + 1;
-        await sendCashbacks([cashback], CashbackStatus.OutOfFunds);
-        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.Inapplicable);
+        await sendCashbacks(cashbackDistributor, [cashback], CashbackStatus.OutOfFunds);
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.Inapplicable, context);
       });
 
       it("The cashback recipient was blacklisted prior cashback sending", async () => {
-        await proveTx(cashbackDistributor.enable());
-        await proveTx(cashbackDistributor.grantRole(blacklisterRole, deployer.address));
+        const context = await beforeSendingCashback();
+        const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
         await proveTx(cashbackDistributor.blacklist(cashback.recipient.address));
-        await sendCashbacks([cashback], CashbackStatus.Blacklisted);
-        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.Inapplicable);
+        await sendCashbacks(cashbackDistributor, [cashback], CashbackStatus.Blacklisted);
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.Inapplicable, context);
       });
 
       it("The initial cashback amount is less than revocation amount", async () => {
-        await proveTx(cashbackDistributor.enable());
-        await sendCashbacks([cashback], CashbackStatus.Success);
-        await proveTx(cashback.token.mint(cashback.sender.address, cashback.amount + 1));
-        await proveTx(cashback.token.connect(cashback.sender).approve(
-          cashbackDistributor.address,
-          ethers.constants.MaxUint256
-        ));
+        const context = await beforeSendingCashback();
+        const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
+        await sendCashbacks(cashbackDistributor, [cashback], CashbackStatus.Success);
+        await proveTx(cashback.token.mint(distributor.address, cashback.amount + 1));
+        await proveTx(cashback.token.connect(distributor).approve(cashbackDistributor.address, MAX_UINT256));
         cashback.revokedAmount = cashback.amount + 1;
-        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.OutOfBalance);
+        await checkRevokingOfUnsuccessfulCashback(RevocationStatus.OutOfBalance, context);
+      });
+    });
+
+    describe("Is reverted if", async () => {
+      it("The contract is paused", async () => {
+        const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
+        await pauseContract(cashbackDistributor);
+        await expect(
+          cashbackDistributor.connect(distributor).revokeCashback(cashback.nonce, cashback.revokedAmount)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the caller does not have the distributor role", async () => {
+        const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
+        await expect(
+          cashbackDistributor.revokeCashback(cashback.nonce, cashback.revokedAmount)
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, distributorRole));
       });
     });
   });
 
   describe("Getter functions 'getCashbackNonces()' and 'getCashbacks()'", async () => {
-    let cashbacks: TestCashback[];
-    let cashbackNonces: BigNumber[];
-
-    beforeEach(async () => {
-      const tokenMock: Contract = await deployTokenMock();
-      cashbacks = [1, 2, 3].map(nonceValue => {
+    it("Execute as expected", async () => {
+      const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
+      const { cashbackDistributor, tokenMocks: [tokenMock] } = fixture;
+      const cashbacks: TestCashback[] = [1, 2, 3].map(nonceValue => {
         return {
           token: tokenMock,
           kind: CashbackKind.CardPayment,
@@ -800,14 +857,9 @@ describe("Contract 'CashbackDistributor'", async () => {
           nonce: nonceValue,
         };
       });
-      cashbackNonces = cashbacks.map(cashback => BigNumber.from(cashback.nonce));
-      await proveTx(cashbackDistributor.grantRole(distributorRole, distributor.address));
-    });
-
-    it("Execute as expected", async () => {
-      await proveTx(cashbackDistributor.enable());
-      await setUpContractsForSendingCashbacks(cashbacks);
-      await sendCashbacks(cashbacks, CashbackStatus.Success);
+      const cashbackNonces: BigNumber[] = cashbacks.map(cashback => BigNumber.from(cashback.nonce));
+      await setUpContractsForSendingCashbacks(cashbackDistributor, cashbacks);
+      await sendCashbacks(cashbackDistributor, cashbacks, CashbackStatus.Success);
 
       // Check existing cashbacks
       let actualCashbacks: any[] = await cashbackDistributor.getCashbacks(cashbackNonces);
@@ -850,18 +902,21 @@ describe("Contract 'CashbackDistributor'", async () => {
   });
 
   describe("Complex scenario", async () => {
-    let tokenMock1: Contract;
-    let tokenMock2: Contract;
-    let cashbacks: TestCashback[];
-    let begNonce: number;
-    let endNonce: number;
-    let cashbackDistributorInitialBalanceByToken: Map<Contract, number>;
 
-    beforeEach(async () => {
-      tokenMock1 = await deployTokenMock("TEST1");
-      tokenMock2 = await deployTokenMock("TEST2");
+    async function revokeCashback(cashbackDistributor: Contract, cashback: TestCashback) {
+      await proveTx(cashback.token.mint(distributor.address, cashback.revokedAmount || 0));
+      await proveTx(
+        cashback.token.connect(distributor).approve(cashbackDistributor.address, cashback.revokedAmount || 0)
+      );
+      await proveTx(
+        cashbackDistributor.connect(distributor).revokeCashback(cashback.nonce, cashback.revokedAmount || 0)
+      );
+    }
 
-      cashbacks = [1, 2, 3, 4, 5, 6, 7, 8].map(nonce => {
+    it("Execute as expected", async () => {
+      const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
+      const { cashbackDistributor, tokenMocks: [tokenMock1, tokenMock2] } = fixture;
+      const cashbacks: TestCashback[] = [1, 2, 3, 4, 5, 6, 7, 8].map(nonce => {
         return {
           token: [tokenMock2, tokenMock1][(nonce >> 0) & 1],
           kind: CashbackKind.CardPayment,
@@ -873,35 +928,23 @@ describe("Contract 'CashbackDistributor'", async () => {
           nonce: nonce,
         };
       });
-      begNonce = cashbacks[0].nonce;
-      endNonce = cashbacks[cashbacks.length - 1].nonce + 1;
-      await proveTx(cashbackDistributor.grantRole(distributorRole, distributor.address));
-      cashbackDistributorInitialBalanceByToken = await setUpContractsForSendingCashbacks(cashbacks);
-    });
-
-    async function revokeCashback(cashback: TestCashback) {
-      await proveTx(cashback.token.mint(cashback.sender.address, cashback.revokedAmount || 0));
-      await proveTx(
-        cashback.token.connect(cashback.sender).approve(cashbackDistributor.address, cashback.revokedAmount || 0)
+      const { cashbackDistributorInitialBalanceByToken } = await setUpContractsForSendingCashbacks(
+        cashbackDistributor,
+        cashbacks
       );
-      await proveTx(
-        cashbackDistributor.connect(cashback.sender).revokeCashback(cashback.nonce, cashback.revokedAmount || 0)
-      );
-    }
+      const context: TestContext = { fixture, cashbacks, cashbackDistributorInitialBalanceByToken };
 
-    it("Execute as expected", async () => {
-      await proveTx(cashbackDistributor.enable());
-      await sendCashbacks(cashbacks, CashbackStatus.Success);
-      await checkCashbackDistributorState(cashbacks, cashbackDistributorInitialBalanceByToken);
+      await sendCashbacks(cashbackDistributor, cashbacks, CashbackStatus.Success);
+      await checkCashbackDistributorState(context);
 
-      await revokeCashback(cashbacks[3]);
-      await checkCashbackDistributorState(cashbacks, cashbackDistributorInitialBalanceByToken);
+      await revokeCashback(cashbackDistributor, cashbacks[3]);
+      await checkCashbackDistributorState(context);
 
-      await revokeCashback(cashbacks[0]);
-      await checkCashbackDistributorState(cashbacks, cashbackDistributorInitialBalanceByToken);
+      await revokeCashback(cashbackDistributor, cashbacks[0]);
+      await checkCashbackDistributorState(context);
 
-      await revokeCashback(cashbacks[1]);
-      await checkCashbackDistributorState(cashbacks, cashbackDistributorInitialBalanceByToken);
+      await revokeCashback(cashbackDistributor, cashbacks[1]);
+      await checkCashbackDistributorState(context);
     });
   });
 });


### PR DESCRIPTION
### Abbreviations
1. CPP stands for the CardPaymentProcessor contract.
2. CD stands for the CashbackDistributor contract.

### Main changes
1.  The `correlationId` parameter has been added to the following functions and events of CPP:
    * function `updatePaymentAmount()`;
    * function `refundPayment()`;
    * event `UpdatePaymentAmount`;
    * event `RefundPayment`.

2. The new parameter is not used inside the functions and is sent directly to the events. It is needed for the backend app.

3. Tests have been updated accordingly.


### Test coverage
![image](https://user-images.githubusercontent.com/97302011/218436825-7e5d4af4-a139-4a0e-a1af-dcae5963d028.png)
