### PR TITLE
Add new batch functions and reformat tests

### DIFF
--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -200,7 +200,7 @@ contract PixCashier is
      *
      * Requirements
      *
-     * - The length of the each passed array must be equal.
+     * - The length of each passed array must be equal.
      * - The contract must not be paused.
      * - The caller must have the {CASHIER_ROLE} role.
      * - The provided `account`, `amount`, and `txId` values must not be zero.
@@ -226,8 +226,8 @@ contract PixCashier is
      *
      * - The contract must not be paused.
      * - The caller must have the {CASHIER_ROLE} role.
-     * - The `account` must must not be blacklisted.
-     * - The provided `account`, `amount`, and `txId` values must not be zero.
+     * - The `account` must not be blacklisted.
+     * - The `account`, `amount`, and `txId` values must not be zero.
      * - The cash-out operation with the provided `txId` must not be already pending.
      */
     function requestCashOutFrom(
@@ -248,9 +248,9 @@ contract PixCashier is
      *
      * - The contract must not be paused.
      * - The caller must have the {CASHIER_ROLE} role.
-     * - The each `account` in the array must must not be blacklisted.
-     * - The each provided `account`, `amount`, and `txId` values in the arrays must not be zero.
-     * - The cash-out operation with the each of the provided `txId` must not be already pending.
+     * - Each `account` in the provided array must not be blacklisted.
+     * - Each `account`, `amount`, and `txId` values in the provided arrays must not be zero.
+     * - Each cash-out operation with the provided `txId` in the array must not be already pending.
      */
     function requestCashOutFromBatch(
         address[] memory accounts,
@@ -260,9 +260,10 @@ contract PixCashier is
         if (accounts.length != amounts.length || accounts.length != txIds.length) {
             revert InvalidBatchArrays();
         }
+
         for (uint256 i = 0; i < accounts.length; i++) {
             if (accounts[i] == address(0)) {
-            revert ZeroAccount();
+                revert ZeroAccount();
             }
             if (isBlacklisted(accounts[i])) {
                 revert BlacklistedAccount(accounts[i]);

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -257,6 +257,9 @@ contract PixCashier is
         uint256[] memory amounts,
         bytes32[] memory txIds
     ) external whenNotPaused onlyRole(CASHIER_ROLE) {
+        if (accounts.length != amounts.length || accounts.length != txIds.length) {
+            revert InvalidBatchArrays();
+        }
         for (uint256 i = 0; i < accounts.length; i++) {
             if (accounts[i] == address(0)) {
             revert ZeroAccount();

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -210,7 +210,7 @@ contract PixCashier is
         uint256[] memory amounts,
         bytes32[] memory txIds
     ) external whenNotPaused onlyRole(CASHIER_ROLE) {
-        if (!(accounts.length == amounts.length && accounts.length == txIds.length)) {
+        if (accounts.length != amounts.length || accounts.length != txIds.length) {
             revert InvalidBatchArrays();
         }
 

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -61,6 +61,7 @@ contract PixCashier is
     /// @dev The minting of tokens failed when processing an `cashIn` operation.
     error TokenMintingFailure();
 
+    /// @dev The length of the one of the batch arrays is different to the others.
     error InvalidBatchArrays();
 
     /**

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -242,6 +242,33 @@ contract PixCashier is
     }
 
     /**
+     * @dev See {IPixCashier-requestCashOutFromBatch}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {CASHIER_ROLE} role.
+     * - The each `account` in the array must must not be blacklisted.
+     * - The each provided `account`, `amount`, and `txId` values in the arrays must not be zero.
+     * - The cash-out operation with the each of the provided `txId` must not be already pending.
+     */
+    function requestCashOutFromBatch(
+        address[] memory accounts,
+        uint256[] memory amounts,
+        bytes32[] memory txIds
+    ) external whenNotPaused onlyRole(CASHIER_ROLE) {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            if (accounts[i] == address(0)) {
+            revert ZeroAccount();
+            }
+            if (isBlacklisted(accounts[i])) {
+                revert BlacklistedAccount(accounts[i]);
+            }
+            _requestCashOut(_msgSender(), accounts[i], amounts[i], txIds[i]);
+        }
+    }
+
+    /**
      * @dev See {IPixCashier-confirmCashOut}.
      *
      * Requirements:

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -234,10 +234,6 @@ contract PixCashier is
         address account,
         uint256 amount,
         bytes32 txId
-    ) external whenNotPaused onlyRole(CASHIER_ROLE) notBlacklisted(account) {
-        if (account == address(0)) {
-            revert ZeroAccount();
-        }
     ) external whenNotPaused onlyRole(CASHIER_ROLE) {
         _requestCashOut(_msgSender(), account, amount, txId);
     }
@@ -263,12 +259,6 @@ contract PixCashier is
         }
 
         for (uint256 i = 0; i < accounts.length; i++) {
-            if (accounts[i] == address(0)) {
-                revert ZeroAccount();
-            }
-            if (isBlacklisted(accounts[i])) {
-                revert BlacklistedAccount(accounts[i]);
-            }
             _requestCashOut(_msgSender(), accounts[i], amounts[i], txIds[i]);
         }
     }
@@ -381,6 +371,12 @@ contract PixCashier is
         }
         if (txId == 0) {
             revert ZeroTxId();
+        }
+        if (account == address(0)) {
+            revert ZeroAccount();
+        }
+        if (isBlacklisted(account)) {
+            revert BlacklistedAccount(account);
         }
 
         CashOut storage operation = _cashOuts[txId];

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -336,7 +336,7 @@ contract PixCashier is
     }
 
     /**
-     * See {PixCashier-cashIn}.
+     * @dev See {PixCashier-cashIn}.
      */
     function _cashIn(
         address account,
@@ -364,7 +364,7 @@ contract PixCashier is
     }
 
     /**
-     * See {PixCashier-requestCashOut}.
+     * @dev See {PixCashier-requestCashOut}.
      */
     function _requestCashOut(
         address sender,
@@ -415,7 +415,7 @@ contract PixCashier is
     }
 
     /**
-     * See {PixCashier-confirmCashOut and reverseCashOut}.
+     * @dev See {PixCashier-confirmCashOut} and {PixCashier-reverseCashOut}.
      */
     function _processCashOut(bytes32 txId, CashOutStatus targetStatus) internal {
         if (txId == 0) {

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -238,6 +238,7 @@ contract PixCashier is
         if (account == address(0)) {
             revert ZeroAccount();
         }
+    ) external whenNotPaused onlyRole(CASHIER_ROLE) {
         _requestCashOut(_msgSender(), account, amount, txId);
     }
 
@@ -357,6 +358,9 @@ contract PixCashier is
         }
         if (txId == 0) {
             revert ZeroTxId();
+        }
+        if (isBlacklisted(account)) {
+            revert BlacklistedAccount(account);
         }
 
         emit CashIn(account, amount, txId);

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -286,7 +286,7 @@ contract PixCashier is
     }
 
     /**
-     * @dev See {IPixCashier-confirmCashOuts}.
+     * @dev See {IPixCashier-confirmCashOutBatch}.
      *
      * Requirements:
      *
@@ -296,7 +296,7 @@ contract PixCashier is
      * - All the values in the input `txIds` array must not be zero.
      * - All the cash-out operations corresponded the values in the input `txIds` array must have the pending status.
      */
-    function confirmCashOuts(bytes32[] memory txIds) external whenNotPaused onlyRole(CASHIER_ROLE) {
+    function confirmCashOutBatch(bytes32[] memory txIds) external whenNotPaused onlyRole(CASHIER_ROLE) {
         uint256 len = txIds.length;
         if (len == 0) {
             revert EmptyTransactionIdsArray();
@@ -322,7 +322,7 @@ contract PixCashier is
     }
 
     /**
-     * @dev See {IPixCashier-reverseCashOuts}.
+     * @dev See {IPixCashier-reverseCashOutBatch}.
      *
      * Requirements:
      *
@@ -332,7 +332,7 @@ contract PixCashier is
      * - All the values in the input `txIds` array must not be zero.
      * - All the cash-out operations corresponded the values in the input `txIds` array must have the pending status.
      */
-    function reverseCashOuts(bytes32[] memory txIds) external whenNotPaused onlyRole(CASHIER_ROLE) {
+    function reverseCashOutBatch(bytes32[] memory txIds) external whenNotPaused onlyRole(CASHIER_ROLE) {
         uint256 len = txIds.length;
         if (len == 0) {
             revert EmptyTransactionIdsArray();

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -372,14 +372,14 @@ contract PixCashier is
         uint256 amount,
         bytes32 txId
     ) internal {
+        if (account == address(0)) {
+            revert ZeroAccount();
+        }
         if (amount == 0) {
             revert ZeroAmount();
         }
         if (txId == 0) {
             revert ZeroTxId();
-        }
-        if (account == address(0)) {
-            revert ZeroAccount();
         }
         if (isBlacklisted(account)) {
             revert BlacklistedAccount(account);

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -335,6 +335,9 @@ contract PixCashier is
         }
     }
 
+    /**
+     * See {PixCashier-cashIn}.
+     */
     function _cashIn(
         address account,
         uint256 amount,
@@ -360,6 +363,9 @@ contract PixCashier is
         }
     }
 
+    /**
+     * See {PixCashier-requestCashOut}.
+     */
     function _requestCashOut(
         address sender,
         address account,
@@ -408,6 +414,9 @@ contract PixCashier is
         );
     }
 
+    /**
+     * See {PixCashier-confirmCashOut and reverseCashOut}.
+     */
     function _processCashOut(bytes32 txId, CashOutStatus targetStatus) internal {
         if (txId == 0) {
             revert ZeroTxId();

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -216,7 +216,7 @@ interface IPixCashier is IPixCashierTypes {
      *
      * @param txIds The off-chain transaction identifiers of the operations.
      */
-    function confirmCashOuts(bytes32[] memory txIds) external;
+    function confirmCashOutBatch(bytes32[] memory txIds) external;
 
     /**
      * @dev Reverts a single cash-out operation.
@@ -242,5 +242,5 @@ interface IPixCashier is IPixCashierTypes {
      *
      * @param txIds The off-chain transaction identifiers of the operations.
      */
-    function reverseCashOuts(bytes32[] memory txIds) external;
+    function reverseCashOutBatch(bytes32[] memory txIds) external;
 }

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -137,6 +137,24 @@ interface IPixCashier is IPixCashierTypes {
     ) external;
 
     /**
+     * @dev Executes a batch of cash-in operations.
+     *
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to execute cash-in operations.
+     *
+     * Emits {CashIn} events.
+     *
+     * @param accounts The array of the addresses of the tokens recipient.
+     * @param amounts The array of the token amounts to be received.
+     * @param txIds The array of the off-chain transaction identifiers of the operation.
+     */
+    function cashInBatch(
+        address[] memory accounts,
+        uint256[] memory amounts,
+        bytes32[] memory txIds
+    ) external;
+
+    /**
      * @dev Initiates a cash-out operation from some other account.
      *
      * Transfers tokens from the account to the contract.

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -174,6 +174,25 @@ interface IPixCashier is IPixCashierTypes {
     ) external;
 
     /**
+     * @dev Initiates a batch of cash-out operations from some other accounts.
+     *
+     * Transfers tokens from the accounts to the contract.
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to process cash-out operations.
+     *
+     * Emits {CashOut} events.
+     *
+     * @param accounts The array of accounts on that behalf the operation is made.
+     * @param amounts The array of amounts of tokens to be cash-outed.
+     * @param txIds The array of off-chain transaction identifiers of the operation.
+     */
+    function requestCashOutFromBatch(
+        address[] memory accounts,
+        uint256[] memory amounts,
+        bytes32[] memory txIds
+    ) external;
+
+    /**
      * @dev Confirms a single cash-out operation.
      *
      * Burns tokens previously transferred to the contract.

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -416,7 +416,7 @@ describe("Contract 'PixCashier'", async () => {
       const users = [user.address, secondUser.address, thirdUser.address];
       const moreUsers = [user.address, secondUser.address, thirdUser.address, user.address];
       const moreAmounts = [100, 200, 300, 400];
-      const moreTransactins = [TRANSACTION_ID1, TRANSACTION_ID2, TRANSACTION_ID3, TRANSACTION_ID1];
+      const moreTransactions = [TRANSACTION_ID1, TRANSACTION_ID2, TRANSACTION_ID3, TRANSACTION_ID1];
 
       await expect(
         pixCashier.connect(cashier).cashInBatch(moreUsers, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY)
@@ -427,7 +427,7 @@ describe("Contract 'PixCashier'", async () => {
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_BATCH_TRANSACTION_DIFFERENT);
 
       await expect(
-        pixCashier.connect(cashier).cashInBatch(users, TOKEN_AMOUNTS, moreTransactins)
+        pixCashier.connect(cashier).cashInBatch(users, TOKEN_AMOUNTS, moreTransactions)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_BATCH_TRANSACTION_DIFFERENT);
     })
 
@@ -638,7 +638,7 @@ describe("Contract 'PixCashier'", async () => {
       const users = [user.address, secondUser.address, thirdUser.address];
       const moreUsers = [user.address, secondUser.address, thirdUser.address, user.address];
       const moreAmounts = [100, 200, 300, 400];
-      const moreTransactins = [TRANSACTION_ID1, TRANSACTION_ID2, TRANSACTION_ID3, TRANSACTION_ID1];
+      const moreTransactions = [TRANSACTION_ID1, TRANSACTION_ID2, TRANSACTION_ID3, TRANSACTION_ID1];
 
       await expect(
         pixCashier.connect(cashier).requestCashOutFromBatch(moreUsers, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY)
@@ -649,7 +649,7 @@ describe("Contract 'PixCashier'", async () => {
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_BATCH_TRANSACTION_DIFFERENT);
 
       await expect(
-        pixCashier.connect(cashier).requestCashOutFromBatch(users, TOKEN_AMOUNTS, moreTransactins)
+        pixCashier.connect(cashier).requestCashOutFromBatch(users, TOKEN_AMOUNTS, moreTransactions)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_BATCH_TRANSACTION_DIFFERENT);
     })
 

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -309,6 +309,14 @@ describe("Contract 'PixCashier'", async () => {
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
     });
 
+    it("Is reverted if the account is blacklisted", async () => {
+      await proveTx(pixCashier.grantRole(blacklisterRole, deployer.address));
+      await proveTx(pixCashier.blacklist(user.address));
+      await expect(
+        pixCashier.connect(cashier).cashIn(user.address, tokenAmount, TRANSACTION_ID1)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
     it("Is reverted if the account address is zero", async () => {
       await expect(
         pixCashier.connect(cashier).cashIn(ethers.constants.AddressZero, tokenAmount, TRANSACTION_ID1)
@@ -393,6 +401,15 @@ describe("Contract 'PixCashier'", async () => {
       await expect(
         pixCashier.connect(cashier).cashInBatch(zeroAccountArray, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_ZERO);
+    });
+
+    it("Is reverted if one of the accounts is blacklisted", async () => {
+      await proveTx(pixCashier.grantRole(blacklisterRole, deployer.address));
+      const users = [user.address, secondUser.address, thirdUser.address];
+      await proveTx(pixCashier.blacklist(secondUser.address));
+      await expect(
+        pixCashier.connect(cashier).cashInBatch(users, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
     });
 
     it("Is reverted if one of the token amounts is zero", async () => {

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -769,7 +769,7 @@ describe("Contract 'PixCashier'", async () => {
 
   });
 
-  describe("Function 'confirmCashOuts()'", async () => {
+  describe("Function 'confirmCashOutBatch()'", async () => {
     let cashOuts: TestCashOut[];
     let txIds: string[];
 
@@ -798,7 +798,7 @@ describe("Contract 'PixCashier'", async () => {
       await checkPixCashierState(cashOuts);
       const totalTokens = countNumberArrayTotal(cashOuts.map(cashOut => cashOut.amount));
       await expect(
-        pixCashier.connect(cashier).confirmCashOuts(txIds)
+        pixCashier.connect(cashier).confirmCashOutBatch(txIds)
       ).to.changeTokenBalances(
         tokenMock,
         [pixCashier, ...cashOuts.map(cashOut => cashOut.account)],
@@ -828,19 +828,19 @@ describe("Contract 'PixCashier'", async () => {
       await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
       await proveTx(pixCashier.pause());
       await expect(
-        pixCashier.connect(cashier).confirmCashOuts(txIds)
+        pixCashier.connect(cashier).confirmCashOutBatch(txIds)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the cashier role", async () => {
       await expect(
-        pixCashier.connect(deployer).confirmCashOuts(txIds)
+        pixCashier.connect(deployer).confirmCashOutBatch(txIds)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
     });
 
     it("Is reverted if the off-chain transaction IDs array is empty", async () => {
       await expect(
-        pixCashier.connect(cashier).confirmCashOuts([])
+        pixCashier.connect(cashier).confirmCashOutBatch([])
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_EMPTY_TRANSACTION_IDS_ARRAY);
     });
 
@@ -848,7 +848,7 @@ describe("Contract 'PixCashier'", async () => {
       await requestCashOuts(cashOuts);
       txIds[txIds.length - 1] = ethers.constants.HashZero;
       await expect(
-        pixCashier.connect(cashier).confirmCashOuts(txIds)
+        pixCashier.connect(cashier).confirmCashOutBatch(txIds)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
     });
 
@@ -856,7 +856,7 @@ describe("Contract 'PixCashier'", async () => {
       await requestCashOuts(cashOuts);
       txIds[txIds.length - 1] = TRANSACTION_ID3;
       await expect(
-        pixCashier.connect(cashier).confirmCashOuts(txIds)
+        pixCashier.connect(cashier).confirmCashOutBatch(txIds)
       ).to.be.revertedWithCustomError(
         pixCashier,
         REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
@@ -932,7 +932,7 @@ describe("Contract 'PixCashier'", async () => {
 
   });
 
-  describe("Function 'reverseCashOuts()'", async () => {
+  describe("Function 'reverseCashOutBatch()'", async () => {
     let cashOuts: TestCashOut[];
     let txIds: string[];
 
@@ -961,7 +961,7 @@ describe("Contract 'PixCashier'", async () => {
       await checkPixCashierState(cashOuts);
       const totalTokens = countNumberArrayTotal(cashOuts.map(cashOut => cashOut.amount));
       await expect(
-        pixCashier.connect(cashier).reverseCashOuts(txIds)
+        pixCashier.connect(cashier).reverseCashOutBatch(txIds)
       ).to.changeTokenBalances(
         tokenMock,
         [pixCashier, cashier, ...cashOuts.map(cashOut => cashOut.account)],
@@ -991,19 +991,19 @@ describe("Contract 'PixCashier'", async () => {
       await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
       await proveTx(pixCashier.pause());
       await expect(
-        pixCashier.connect(cashier).reverseCashOuts(txIds)
+        pixCashier.connect(cashier).reverseCashOutBatch(txIds)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the cashier role", async () => {
       await expect(
-        pixCashier.connect(deployer).reverseCashOuts(txIds)
+        pixCashier.connect(deployer).reverseCashOutBatch(txIds)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
     });
 
     it("Is reverted if the off-chain transaction IDs array is empty", async () => {
       await expect(
-        pixCashier.connect(cashier).reverseCashOuts([])
+        pixCashier.connect(cashier).reverseCashOutBatch([])
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_EMPTY_TRANSACTION_IDS_ARRAY);
     });
 
@@ -1011,7 +1011,7 @@ describe("Contract 'PixCashier'", async () => {
       await requestCashOuts(cashOuts);
       txIds[txIds.length - 1] = ethers.constants.HashZero;
       await expect(
-        pixCashier.connect(cashier).reverseCashOuts(txIds)
+        pixCashier.connect(cashier).reverseCashOutBatch(txIds)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
     });
 
@@ -1019,7 +1019,7 @@ describe("Contract 'PixCashier'", async () => {
       await requestCashOuts(cashOuts);
       txIds[txIds.length - 1] = TRANSACTION_ID3;
       await expect(
-        pixCashier.connect(cashier).reverseCashOuts(txIds)
+        pixCashier.connect(cashier).reverseCashOutBatch(txIds)
       ).to.be.revertedWithCustomError(
         pixCashier,
         REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
@@ -1114,7 +1114,7 @@ describe("Contract 'PixCashier'", async () => {
         REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
       ).withArgs(cashOut.txId, CashOutStatus.Reversed);
       await expect(
-        pixCashier.connect(cashier).reverseCashOuts([cashOut.txId])
+        pixCashier.connect(cashier).reverseCashOutBatch([cashOut.txId])
       ).to.be.revertedWithCustomError(
         pixCashier,
         REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
@@ -1128,7 +1128,7 @@ describe("Contract 'PixCashier'", async () => {
         REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
       ).withArgs(cashOut.txId, CashOutStatus.Reversed);
       await expect(
-        pixCashier.connect(cashier).confirmCashOuts([cashOut.txId])
+        pixCashier.connect(cashier).confirmCashOutBatch([cashOut.txId])
       ).to.be.revertedWithCustomError(
         pixCashier,
         REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
@@ -1157,7 +1157,7 @@ describe("Contract 'PixCashier'", async () => {
         REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
       ).withArgs(cashOut.txId, CashOutStatus.Confirmed);
       await expect(
-        pixCashier.connect(cashier).reverseCashOuts([cashOut.txId])
+        pixCashier.connect(cashier).reverseCashOutBatch([cashOut.txId])
       ).to.be.revertedWithCustomError(
         pixCashier,
         REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
@@ -1171,7 +1171,7 @@ describe("Contract 'PixCashier'", async () => {
         REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
       ).withArgs(cashOut.txId, CashOutStatus.Confirmed);
       await expect(
-        pixCashier.connect(cashier).confirmCashOuts([cashOut.txId])
+        pixCashier.connect(cashier).confirmCashOutBatch([cashOut.txId])
       ).to.be.revertedWithCustomError(
         pixCashier,
         REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -341,7 +341,6 @@ describe("Contract 'PixCashier'", async () => {
     });
 
     it("Mints correct amount of tokens and emits the correct event", async () => {
-      const amountSum = 600;
       const users = [user.address, secondUser.address, thirdUser.address];
       await expect(
         pixCashier.connect(cashier).cashInBatch(users, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY)

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -230,20 +230,6 @@ describe("Contract 'PixCashier'", async () => {
     }
   }
 
-  it("The initialize function can't be called more than once", async () => {
-    await expect(
-      pixCashier.initialize(tokenMock.address)
-    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
-  });
-
-  it("The initialize function is reverted if the passed token address is zero", async () => {
-    const anotherPixCashier: Contract = await PixCashier.deploy();
-    await anotherPixCashier.deployed();
-    await expect(
-      anotherPixCashier.initialize(ethers.constants.AddressZero)
-    ).to.be.revertedWithCustomError(PixCashier, REVERT_ERROR_IF_TOKEN_ADDRESS_IZ_ZERO);
-  });
-
   it("The initial contract configuration should be as expected", async () => {
     // The underlying contract address
     expect(await pixCashier.underlyingToken()).to.equal(tokenMock.address);
@@ -271,11 +257,42 @@ describe("Contract 'PixCashier'", async () => {
     expect(await pixCashier.getPendingCashOutTxIds(0, 1)).to.be.empty;
   });
 
+  it("The initialize function can't be called more than once", async () => {
+    await expect(
+      pixCashier.initialize(tokenMock.address)
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initialize function is reverted if the passed token address is zero", async () => {
+    const anotherPixCashier: Contract = await PixCashier.deploy();
+    await anotherPixCashier.deployed();
+    await expect(
+      anotherPixCashier.initialize(ethers.constants.AddressZero)
+    ).to.be.revertedWithCustomError(PixCashier, REVERT_ERROR_IF_TOKEN_ADDRESS_IZ_ZERO);
+  });
+
   describe("Function 'cashIn()'", async () => {
     const tokenAmount: number = 100;
 
     beforeEach(async () => {
       await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
+    });
+
+    it("Mints correct amount of tokens and emits the correct event", async () => {
+      await expect(
+        pixCashier.connect(cashier).cashIn(user.address, tokenAmount, TRANSACTION_ID1)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [user, pixCashier],
+        [+tokenAmount, 0]
+      ).and.to.emit(
+        pixCashier,
+        "CashIn"
+      ).withArgs(
+        user.address,
+        tokenAmount,
+        TRANSACTION_ID1
+      );
     });
 
     it("Is reverted if the contract is paused", async () => {
@@ -316,28 +333,44 @@ describe("Contract 'PixCashier'", async () => {
         pixCashier.connect(cashier).cashIn(user.address, tokenAmount, TRANSACTION_ID1)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TOKEN_MINTING_FAILURE);
     });
-
-    it("Mints correct amount of tokens and emits the correct event", async () => {
-      await expect(
-        pixCashier.connect(cashier).cashIn(user.address, tokenAmount, TRANSACTION_ID1)
-      ).to.changeTokenBalances(
-        tokenMock,
-        [user, pixCashier],
-        [+tokenAmount, 0]
-      ).and.to.emit(
-        pixCashier,
-        "CashIn"
-      ).withArgs(
-        user.address,
-        tokenAmount,
-        TRANSACTION_ID1
-      );
-    });
   });
 
   describe("Function 'cashInBatch()'", async () => {
     beforeEach(async () => {
       await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
+    });
+
+    it("Mints correct amount of tokens and emits the correct event", async () => {
+      const amountSum = 600;
+      const users = [user.address, secondUser.address, thirdUser.address];
+      await expect(
+        pixCashier.connect(cashier).cashInBatch(users, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [user, secondUser, thirdUser, pixCashier],
+        [+100, +200, +300, 0]
+      ).and.to.emit(
+        pixCashier,
+        "CashIn"
+      ).withArgs(
+        user.address,
+        100,
+        TRANSACTION_ID1
+      ).and.to.emit(
+        pixCashier,
+        "CashIn"
+      ).withArgs(
+        secondUser.address,
+        200,
+        TRANSACTION_ID2
+      ).and.to.emit(
+        pixCashier,
+        "CashIn"
+      ).withArgs(
+        thirdUser.address,
+        300,
+        TRANSACTION_ID3
+      );
     });
 
     it("Is reverted if the contract is paused", async () => {
@@ -405,39 +438,6 @@ describe("Contract 'PixCashier'", async () => {
         pixCashier.connect(cashier).cashInBatch(users, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TOKEN_MINTING_FAILURE);
     });
-
-    it("Mints correct amount of tokens and emits the correct event", async () => {
-      const amountSum = 600;
-      const users = [user.address, secondUser.address, thirdUser.address];
-      await expect(
-        pixCashier.connect(cashier).cashInBatch(users, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY)
-      ).to.changeTokenBalances(
-        tokenMock,
-        [user, secondUser, thirdUser, pixCashier],
-        [+100, +200, +300, 0]
-      ).and.to.emit(
-        pixCashier,
-        "CashIn"
-      ).withArgs(
-        user.address,
-        100,
-        TRANSACTION_ID1
-      ).and.to.emit(
-        pixCashier,
-        "CashIn"
-      ).withArgs(
-        secondUser.address,
-        200,
-        TRANSACTION_ID2
-      ).and.to.emit(
-        pixCashier,
-        "CashIn"
-      ).withArgs(
-        thirdUser.address,
-        300,
-        TRANSACTION_ID3
-      );
-    });
   });
 
   describe("Function 'requestCashOutFrom()'", async () => {
@@ -452,6 +452,29 @@ describe("Contract 'PixCashier'", async () => {
       };
       await proveTx(tokenMock.connect(cashOut.account).approve(pixCashier.address, ethers.constants.MaxUint256));
       await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
+    });
+
+    it("Transfers tokens as expected, emits the correct event, changes cash-out balances accordingly", async () => {
+      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
+      await checkPixCashierState([cashOut]);
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [cashOut.account, pixCashier, cashier],
+        [-cashOut.amount, +cashOut.amount, 0]
+      ).and.to.emit(
+        pixCashier,
+        "RequestCashOut"
+      ).withArgs(
+        cashOut.account.address,
+        cashOut.amount,
+        cashOut.amount,
+        cashOut.txId,
+        cashier.address
+      );
+      cashOut.status = CashOutStatus.Pending;
+      await checkPixCashierState([cashOut]);
     });
 
     it("Is reverted if the contract is paused", async () => {
@@ -515,16 +538,54 @@ describe("Contract 'PixCashier'", async () => {
         pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
+  });
+
+  describe("Function 'requestCashOutFromBatch()'", async () => {
+    let cashOut: TestCashOut;
+    let secondCashOut: TestCashOut;
+    let thirdCashOut: TestCashOut;
+    let accounts: string[];
+    let amounts: number[];
+
+    beforeEach(async () => {
+      cashOut = {
+        account: user,
+        amount: 200,
+        txId: TRANSACTION_ID1,
+        status: CashOutStatus.Nonexistent,
+      };
+      secondCashOut = {
+        account: secondUser,
+        amount: 300,
+        txId: TRANSACTION_ID2,
+        status: CashOutStatus.Nonexistent,
+      };
+      thirdCashOut = {
+        account: thirdUser,
+        amount: 400,
+        txId: TRANSACTION_ID3,
+        status: CashOutStatus.Nonexistent,
+      };
+      accounts = [cashOut.account.address, secondCashOut.account.address, thirdCashOut.account.address];
+      amounts = [cashOut.amount, secondCashOut.amount, thirdCashOut.amount];
+      await proveTx(tokenMock.connect(cashOut.account).approve(pixCashier.address, ethers.constants.MaxUint256));
+      await proveTx(tokenMock.connect(secondCashOut.account).approve(pixCashier.address, ethers.constants.MaxUint256));
+      await proveTx(tokenMock.connect(thirdCashOut.account).approve(pixCashier.address, ethers.constants.MaxUint256));
+      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
+      await proveTx(tokenMock.mint(secondCashOut.account.address, secondCashOut.amount));
+      await proveTx(tokenMock.mint(thirdCashOut.account.address, thirdCashOut.amount));
+      await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
+    });
 
     it("Transfers tokens as expected, emits the correct event, changes cash-out balances accordingly", async () => {
-      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
-      await checkPixCashierState([cashOut]);
+      const amountSum = cashOut.amount + secondCashOut.amount +thirdCashOut.amount;
+      await checkPixCashierState([cashOut, secondCashOut, thirdCashOut]);
       await expect(
-        pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId)
+        pixCashier.connect(cashier).requestCashOutFromBatch(accounts, amounts, TRANSACTIONS_ARRAY)
       ).to.changeTokenBalances(
         tokenMock,
-        [cashOut.account, pixCashier, cashier],
-        [-cashOut.amount, +cashOut.amount, 0]
+        [cashOut.account, secondCashOut.account, thirdCashOut.account, pixCashier, cashier],
+        [-cashOut.amount, -secondCashOut.amount, -thirdCashOut.amount, +amountSum, 0]
       ).and.to.emit(
         pixCashier,
         "RequestCashOut"
@@ -534,9 +595,90 @@ describe("Contract 'PixCashier'", async () => {
         cashOut.amount,
         cashOut.txId,
         cashier.address
+      ).and.to.emit(
+        pixCashier,
+        "RequestCashOut"
+      ).withArgs(
+        secondCashOut.account.address,
+        secondCashOut.amount,
+        secondCashOut.amount,
+        secondCashOut.txId,
+        cashier.address
+      ).and.to.emit(
+        pixCashier,
+        "RequestCashOut"
+      ).withArgs(
+        thirdCashOut.account.address,
+        thirdCashOut.amount,
+        thirdCashOut.amount,
+        thirdCashOut.txId,
+        cashier.address
       );
       cashOut.status = CashOutStatus.Pending;
-      await checkPixCashierState([cashOut]);
+      secondCashOut.status = CashOutStatus.Pending;
+      thirdCashOut.status = CashOutStatus.Pending;
+      await checkPixCashierState([cashOut, secondCashOut, thirdCashOut]);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFromBatch(accounts, amounts, TRANSACTIONS_ARRAY)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the cashier role", async () => {
+      await expect(
+        pixCashier.connect(deployer).requestCashOutFromBatch(accounts, amounts, TRANSACTIONS_ARRAY)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
+    });
+
+    it("Is reverted if the account is blacklisted", async () => {
+      await proveTx(pixCashier.grantRole(blacklisterRole, deployer.address));
+      await proveTx(pixCashier.blacklist(secondCashOut.account.address));
+      const accounts = [cashOut.account.address, secondCashOut.account.address, thirdCashOut.account.address];
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFromBatch(accounts, amounts, TRANSACTIONS_ARRAY)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Is reverted if the account address is zero", async () => {
+      const accounts = [cashOut.account.address, ethers.constants.AddressZero, thirdCashOut.account.address];
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFromBatch(accounts, amounts, TRANSACTIONS_ARRAY)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_ZERO);
+    });
+
+    it("Is reverted if the token amount is zero", async () => {
+      const amounts = [cashOut.amount, secondCashOut.amount, 0];
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFromBatch(accounts, amounts, TRANSACTIONS_ARRAY)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_AMOUNT_IS_ZERO);
+    });
+
+    it("Is reverted if the off-chain transaction ID is zero", async () => {
+      const transactions = [TRANSACTION_ID1, ethers.constants.HashZero, TRANSACTION_ID3]
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFromBatch(accounts, amounts, transactions)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
+    });
+
+    it("Is reverted if the cash-out with the provided txId is already pending", async () => {
+      await pixCashier.connect(cashier).requestCashOutFromBatch(accounts, amounts, TRANSACTIONS_ARRAY);
+      expect(
+        pixCashier.connect(cashier).requestCashOutFromBatch(accounts, amounts, TRANSACTIONS_ARRAY)
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Pending);
+    });
+
+    it("Is reverted if the user has not enough tokens", async () => {
+      const amounts = [cashOut.amount, secondCashOut.amount, thirdCashOut.amount+1];
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFromBatch(accounts, amounts, TRANSACTIONS_ARRAY)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
   });
 
@@ -552,6 +694,29 @@ describe("Contract 'PixCashier'", async () => {
       };
       await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
       await setUpContractsForCashOuts([cashOut]);
+    });
+
+    it("Burns tokens as expected, emits the correct event, changes the contract state accordingly", async () => {
+      await requestCashOuts([cashOut]);
+      cashOut.status = CashOutStatus.Pending;
+      await checkPixCashierState([cashOut]);
+      await expect(
+        pixCashier.connect(cashier).confirmCashOut(cashOut.txId)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [pixCashier, cashOut.account],
+        [-cashOut.amount, 0]
+      ).and.to.emit(
+        pixCashier,
+        "ConfirmCashOut"
+      ).withArgs(
+        cashOut.account.address,
+        cashOut.amount,
+        0,
+        cashOut.txId
+      );
+      cashOut.status = CashOutStatus.Confirmed;
+      await checkPixCashierState([cashOut]);
     });
 
     it("Is reverted if the contract is paused", async () => {
@@ -583,28 +748,6 @@ describe("Contract 'PixCashier'", async () => {
       ).withArgs(cashOut.txId, CashOutStatus.Nonexistent);
     });
 
-    it("Burns tokens as expected, emits the correct event, changes the contract state accordingly", async () => {
-      await requestCashOuts([cashOut]);
-      cashOut.status = CashOutStatus.Pending;
-      await checkPixCashierState([cashOut]);
-      await expect(
-        pixCashier.connect(cashier).confirmCashOut(cashOut.txId)
-      ).to.changeTokenBalances(
-        tokenMock,
-        [pixCashier, cashOut.account],
-        [-cashOut.amount, 0]
-      ).and.to.emit(
-        pixCashier,
-        "ConfirmCashOut"
-      ).withArgs(
-        cashOut.account.address,
-        cashOut.amount,
-        0,
-        cashOut.txId
-      );
-      cashOut.status = CashOutStatus.Confirmed;
-      await checkPixCashierState([cashOut]);
-    });
   });
 
   describe("Function 'confirmCashOuts()'", async () => {
@@ -629,26 +772,6 @@ describe("Contract 'PixCashier'", async () => {
       txIds = cashOuts.map(cashOut => cashOut.txId);
       await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
       await setUpContractsForCashOuts(cashOuts);
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
-      await proveTx(pixCashier.pause());
-      await expect(
-        pixCashier.connect(cashier).confirmCashOuts(txIds)
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller does not have the cashier role", async () => {
-      await expect(
-        pixCashier.connect(deployer).confirmCashOuts(txIds)
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
-    });
-
-    it("Is reverted if the off-chain transaction IDs array is empty", async () => {
-      await expect(
-        pixCashier.connect(cashier).confirmCashOuts([])
-      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_EMPTY_TRANSACTION_IDS_ARRAY);
     });
 
     it("Burns tokens as expected, emits the correct event, changes the contract state accordingly", async () => {
@@ -680,6 +803,26 @@ describe("Contract 'PixCashier'", async () => {
       );
       cashOuts.forEach(cashOut => cashOut.status = CashOutStatus.Confirmed);
       await checkPixCashierState(cashOuts);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(
+        pixCashier.connect(cashier).confirmCashOuts(txIds)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the cashier role", async () => {
+      await expect(
+        pixCashier.connect(deployer).confirmCashOuts(txIds)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
+    });
+
+    it("Is reverted if the off-chain transaction IDs array is empty", async () => {
+      await expect(
+        pixCashier.connect(cashier).confirmCashOuts([])
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_EMPTY_TRANSACTION_IDS_ARRAY);
     });
 
     it("Is reverted if one of the off-chain transaction IDs is zero", async () => {
@@ -716,6 +859,29 @@ describe("Contract 'PixCashier'", async () => {
       await setUpContractsForCashOuts([cashOut]);
     });
 
+    it("Transfers tokens as expected, emits the correct event, changes the contract state accordingly", async () => {
+      await requestCashOuts([cashOut]);
+      cashOut.status = CashOutStatus.Pending;
+      await checkPixCashierState([cashOut]);
+      await expect(
+        pixCashier.connect(cashier).reverseCashOut(cashOut.txId)
+      ).to.changeTokenBalances(
+        tokenMock,
+        [cashOut.account, pixCashier, cashier],
+        [+cashOut.amount, -cashOut.amount, 0]
+      ).and.to.emit(
+        pixCashier,
+        "ReverseCashOut"
+      ).withArgs(
+        cashOut.account.address,
+        cashOut.amount,
+        0,
+        cashOut.txId
+      );
+      cashOut.status = CashOutStatus.Reversed;
+      await checkPixCashierState([cashOut]);
+    });
+
     it("Is reverted if the contract is paused", async () => {
       await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
       await proveTx(pixCashier.pause());
@@ -745,28 +911,6 @@ describe("Contract 'PixCashier'", async () => {
       ).withArgs(cashOut.txId, CashOutStatus.Nonexistent);
     });
 
-    it("Transfers tokens as expected, emits the correct event, changes the contract state accordingly", async () => {
-      await requestCashOuts([cashOut]);
-      cashOut.status = CashOutStatus.Pending;
-      await checkPixCashierState([cashOut]);
-      await expect(
-        pixCashier.connect(cashier).reverseCashOut(cashOut.txId)
-      ).to.changeTokenBalances(
-        tokenMock,
-        [cashOut.account, pixCashier, cashier],
-        [+cashOut.amount, -cashOut.amount, 0]
-      ).and.to.emit(
-        pixCashier,
-        "ReverseCashOut"
-      ).withArgs(
-        cashOut.account.address,
-        cashOut.amount,
-        0,
-        cashOut.txId
-      );
-      cashOut.status = CashOutStatus.Reversed;
-      await checkPixCashierState([cashOut]);
-    });
   });
 
   describe("Function 'reverseCashOuts()'", async () => {
@@ -791,26 +935,6 @@ describe("Contract 'PixCashier'", async () => {
       txIds = cashOuts.map(cashOut => cashOut.txId);
       await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
       await setUpContractsForCashOuts(cashOuts);
-    });
-
-    it("Is reverted if the contract is paused", async () => {
-      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
-      await proveTx(pixCashier.pause());
-      await expect(
-        pixCashier.connect(cashier).reverseCashOuts(txIds)
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
-    });
-
-    it("Is reverted if the caller does not have the cashier role", async () => {
-      await expect(
-        pixCashier.connect(deployer).reverseCashOuts(txIds)
-      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
-    });
-
-    it("Is reverted if the off-chain transaction IDs array is empty", async () => {
-      await expect(
-        pixCashier.connect(cashier).reverseCashOuts([])
-      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_EMPTY_TRANSACTION_IDS_ARRAY);
     });
 
     it("Transfers tokens as expected, emits the correct event, changes the contract state accordingly", async () => {
@@ -842,6 +966,26 @@ describe("Contract 'PixCashier'", async () => {
       );
       cashOuts.forEach(cashOut => cashOut.status = CashOutStatus.Reversed);
       await checkPixCashierState(cashOuts);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(
+        pixCashier.connect(cashier).reverseCashOuts(txIds)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the cashier role", async () => {
+      await expect(
+        pixCashier.connect(deployer).reverseCashOuts(txIds)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
+    });
+
+    it("Is reverted if the off-chain transaction IDs array is empty", async () => {
+      await expect(
+        pixCashier.connect(cashier).reverseCashOuts([])
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_EMPTY_TRANSACTION_IDS_ARRAY);
     });
 
     it("Is reverted if one of the off-chain transaction IDs is zero", async () => {

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -634,6 +634,25 @@ describe("Contract 'PixCashier'", async () => {
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
     });
 
+    it("Is reverted if the length of any passed arrays is different to others", async () => {
+      const users = [user.address, secondUser.address, thirdUser.address];
+      const moreUsers = [user.address, secondUser.address, thirdUser.address, user.address];
+      const moreAmounts = [100, 200, 300, 400];
+      const moreTransactins = [TRANSACTION_ID1, TRANSACTION_ID2, TRANSACTION_ID3, TRANSACTION_ID1];
+
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFromBatch(moreUsers, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_BATCH_TRANSACTION_DIFFERENT);
+
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFromBatch(users, moreAmounts, TRANSACTIONS_ARRAY)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_BATCH_TRANSACTION_DIFFERENT);
+
+      await expect(
+        pixCashier.connect(cashier).requestCashOutFromBatch(users, TOKEN_AMOUNTS, moreTransactins)
+      ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_BATCH_TRANSACTION_DIFFERENT);
+    })
+
     it("Is reverted if the account is blacklisted", async () => {
       await proveTx(pixCashier.grantRole(blacklisterRole, deployer.address));
       await proveTx(pixCashier.blacklist(secondCashOut.account.address));


### PR DESCRIPTION
Code changes:

1. Two new functions were added: `cashInBatch` and `requestCashOutBatch`. These function allow cashier to perform multiple cash-in operations or requests by calling only one function.

2. Old functions used to perform multiple actions were renamed similarly to new functions.

3. Tests were reorganized, so the positive cases are tested before the negative.

4. NatSpec references were added to all internal functions.

All new functionality was covered with tests and successfully tested:
![Screenshot_1](https://user-images.githubusercontent.com/113507287/231481288-228d6c15-884a-4b18-8c4e-352b08bf8715.png)