### PR TITLE
Add the extra payment amount feature to CPP

### DIFF
--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -122,7 +122,7 @@ contract CardPaymentProcessor is
     error InappropriateRefundAmount();
 
     /// @dev The new amount of the payment does not meet the requirements.
-    error InappropriateNewBasPaymentAmount();
+    error InappropriateNewBasePaymentAmount();
 
     /// @dev The new extra amount of the payment does not meet the requirements.
     error InappropriateNewExtraPaymentAmount();
@@ -807,7 +807,7 @@ contract CardPaymentProcessor is
             revert InappropriatePaymentStatus(status);
         }
         if (refundAmount > newBaseAmount) {
-            revert InappropriateNewBasPaymentAmount();
+            revert InappropriateNewBasePaymentAmount();
         }
 
         uint256 newCompensationAmount = refundAmount +

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -191,6 +191,18 @@ contract CardPaymentProcessor is
     }
 
     /**
+     * @dev A version of the function without the `extraAmount` parameter for backward compatibility.
+     */
+    function makePayment(
+        uint256 amount,
+        bytes16 authorizationId,
+        bytes16 correlationId
+    ) external whenNotPaused notBlacklisted(_msgSender()) {
+        address sender = _msgSender();
+        makePaymentInternal(sender, sender, amount, 0, authorizationId, correlationId);
+    }
+
+    /**
      * @dev See {ICardPaymentProcessor-makePaymentFor}.
      *
      * Requirements:
@@ -216,6 +228,21 @@ contract CardPaymentProcessor is
     }
 
     /**
+     * @dev A version of the function without the `extraAmount` parameter for backward compatibility.
+     */
+    function makePaymentFrom(
+        address account,
+        uint256 amount,
+        bytes16 authorizationId,
+        bytes16 correlationId
+    ) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
+        if (account == address(0)) {
+            revert ZeroAccount();
+        }
+        makePaymentInternal(_msgSender(), account, amount, 0, authorizationId, correlationId);
+    }
+
+    /**
      * @dev See {ICardPaymentProcessor-updatePaymentAmount}.
      *
      * Requirements:
@@ -236,6 +263,17 @@ contract CardPaymentProcessor is
         bytes16 correlationId
     ) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
         updatePaymentAmountInternal(newBaseAmount, newExtraAmount, authorizationId, correlationId);
+    }
+
+    /**
+     * @dev A version of the function without the `newExtraAmount` parameter for backward compatibility.
+     */
+    function updatePaymentAmount(
+        uint256 newAmount,
+        bytes16 authorizationId,
+        bytes16 correlationId
+    ) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
+        updatePaymentAmountInternal(newAmount, _payments[authorizationId].extraAmount, authorizationId, correlationId);
     }
 
     /**
@@ -441,6 +479,17 @@ contract CardPaymentProcessor is
         bytes16 correlationId
     ) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
         refundPaymentInternal(refundAmount, newExtraAmount, authorizationId, correlationId);
+    }
+
+    /**
+     * @dev A version of the function without the `newExtraAmount` parameter for backward compatibility.
+     */
+    function refundPayment(
+        uint256 refundAmount,
+        bytes16 authorizationId,
+        bytes16 correlationId
+    ) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
+        refundPaymentInternal(refundAmount, _payments[authorizationId].extraAmount, authorizationId, correlationId);
     }
 
     /**

--- a/test-utils/checkers.ts
+++ b/test-utils/checkers.ts
@@ -1,0 +1,17 @@
+import { expect } from "chai";
+
+function checkEventField(fieldName: string, expectedValue: any): (value: any) => boolean {
+  const f = function (value: any): boolean {
+    expect(value).to.equal(
+      expectedValue,
+      `The "${fieldName}" field of the event is wrong`
+    );
+    return true;
+  };
+  Object.defineProperty(f, "name", { value: `checkEventField_${fieldName}`, writable: false });
+  return f;
+}
+
+export {
+  checkEventField,
+};

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1620,7 +1620,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   const REVERT_ERROR_IF_CASHBACK_ALREADY_DISABLED = "CashbackAlreadyDisabled";
   const REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO = "ZeroCashOutAccount";
   const REVERT_ERROR_IF_REFUND_AMOUNT_IS_INAPPROPRIATE = "InappropriateRefundAmount";
-  const REVERT_ERROR_IF_NEW_BASE_PAYMENT_AMOUNT_IS_INAPPROPRIATE = "InappropriateNewBasPaymentAmount";
+  const REVERT_ERROR_IF_NEW_BASE_PAYMENT_AMOUNT_IS_INAPPROPRIATE = "InappropriateNewBasePaymentAmount";
   const REVERT_ERROR_IF_NEW_EXTRA_PAYMENT_AMOUNT_IS_INAPPROPRIATE = "InappropriateNewExtraPaymentAmount";
 
   const ownerRole: string = ethers.utils.id("OWNER_ROLE");

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -4,8 +4,9 @@ import { BigNumber, Contract, ContractFactory } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { proveTx } from "../test-utils/eth";
-import { countNumberArrayTotal, createBytesString, createRevertMessageDueToMissingRole } from "../test-utils/misc";
-import { TransactionResponse } from "@ethersproject/abstract-provider";
+import { createBytesString, createRevertMessageDueToMissingRole } from "../test-utils/misc";
+import { TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
+import { checkEventField } from "../test-utils/checkers";
 
 const MAX_UINT256 = ethers.constants.MaxUint256;
 const MAX_INT256 = ethers.constants.MaxInt256;
@@ -13,6 +14,37 @@ const ZERO_ADDRESS = ethers.constants.AddressZero;
 const ZERO_TRANSACTION_HASH: string = ethers.constants.HashZero;
 const BYTES16_LENGTH: number = 16;
 const BYTES32_LENGTH: number = 32;
+const INITIAL_USER_BALANCE = 1000000;
+
+const FUNCTION_MAKE_PAYMENT = "makePayment(uint256,uint256,bytes16,bytes16)";
+const FUNCTION_MAKE_PAYMENT_FROM = "makePaymentFrom(address,uint256,uint256,bytes16,bytes16)";
+const FUNCTION_UPDATE_PAYMENT_AMOUNT = "updatePaymentAmount(uint256,uint256,bytes16,bytes16)";
+const FUNCTION_REFUND_PAYMENT = "refundPayment(uint256,uint256,bytes16,bytes16)";
+
+const EVENT_NAME_CONFIRM_PAYMENT = "ConfirmPayment";
+const EVENT_NAME_CLEAR_PAYMENT = "ClearPayment";
+const EVENT_NAME_ENABLE_CASHBACK = "EnableCashback";
+const EVENT_NAME_DISABLE_CASHBACK = "DisableCashback";
+const EVENT_NAME_INCREASE_CASHBACK_FAILURE = "IncreaseCashbackFailure";
+const EVENT_NAME_INCREASE_CASHBACK_MOCK = "IncreaseCashbackMock";
+const EVENT_NAME_INCREASE_CASHBACK_SUCCESS = "IncreaseCashbackSuccess";
+const EVENT_NAME_MAKE_PAYMENT = "MakePayment";
+const EVENT_NAME_PAYMENT_EXTRA_AMOUNT_CHANGED = "PaymentExtraAmountChanged";
+const EVENT_NAME_REFUND_PAYMENT = "RefundPayment";
+const EVENT_NAME_REVERSE_PAYMENT = "ReversePayment";
+const EVENT_NAME_REVOKE_CASHBACK_FAILURE = "RevokeCashbackFailure";
+const EVENT_NAME_REVOKE_CASHBACK_MOCK = "RevokeCashbackMock";
+const EVENT_NAME_REVOKE_CASHBACK_SUCCESS = "RevokeCashbackSuccess";
+const EVENT_NAME_REVOKE_PAYMENT = "RevokePayment";
+const EVENT_NAME_SEND_CASHBACK_FAILURE = "SendCashbackFailure";
+const EVENT_NAME_SEND_CASHBACK_MOCK = "SendCashbackMock";
+const EVENT_NAME_SEND_CASHBACK_SUCCESS = "SendCashbackSuccess";
+const EVENT_NAME_SET_CASH_OUT_ACCOUNT = "SetCashOutAccount";
+const EVENT_NAME_SET_CASHBACK_DISTRIBUTOR = "SetCashbackDistributor";
+const EVENT_NAME_SET_CASHBACK_RATE = "SetCashbackRate";
+const EVENT_NAME_SET_REVOCATION_LIMIT = "SetRevocationLimit";
+const EVENT_NAME_UNCLEAR_PAYMENT = "UnclearPayment";
+const EVENT_NAME_UPDATE_PAYMENT_AMOUNT = "UpdatePaymentAmount";
 
 enum PaymentStatus {
   Nonexistent = 0,
@@ -29,18 +61,26 @@ enum CashbackKind {
 }
 
 interface TestPayment {
-  authorizationId: string;
   account: SignerWithAddress;
-  amount: number;
-  status: PaymentStatus;
-  revocationCounter?: number;
+  baseAmount: number;
+  extraAmount: number;
+  authorizationId: string;
   correlationId: string;
   parentTxHash: string;
-  compensationAmount?: number;
-  cashbackNonce?: number;
-  cashbackRateInPermil?: number;
-  refundAmount?: number;
-  unrevokedCashback?: number;
+}
+
+interface PaymentModel {
+  authorizationId: string;
+  account: SignerWithAddress;
+  baseAmount: number;
+  extraAmount: number;
+  status: PaymentStatus;
+  compensationAmount: number;
+  refundAmount: number;
+  cashbackRate: number;
+  cashbackEnabled: boolean;
+  revocationParentTxHashes: string[];
+  reversalParentTxHashes: string[];
 }
 
 interface CashbackDistributorMockConfig {
@@ -52,6 +92,56 @@ interface CashbackDistributorMockConfig {
   increaseCashbackAmountResult: number;
 }
 
+interface CashbackModel {
+  lastCashbackNonce: number;
+}
+
+enum OperationKind {
+  Undefined = 0,
+  Making = 1,
+  Updating = 2,
+  Clearing = 3,
+  Unclearing = 4,
+  Revoking = 5,
+  Reversing = 6,
+  Confirming = 7,
+  Refunding = 8,
+}
+
+interface PaymentOperation {
+  kind: OperationKind;
+  sender?: SignerWithAddress;
+  account: SignerWithAddress;
+  newBaseAmount: number;
+  newExtraAmount: number;
+  refundAmount: number;
+  oldBaseAmount: number;
+  oldExtraAmount: number;
+  totalAmount: number;
+  authorizationId: string;
+  correlationId: string;
+  parentTransactionHash: string;
+  revocationCounter: number;
+  cashbackEnabled: boolean;
+  cashbackSendingSucceeded: boolean;
+  cashbackRevocationRequested: boolean;
+  cashbackRevocationSuccess: boolean;
+  cashbackIncreaseRequested: boolean;
+  cashbackIncreaseSuccess: boolean;
+  cashbackRequestedChange: number;
+  cashbackActualChange: number;
+  cashbackRate: number;
+  cashbackNonce: number;
+  senderBalanceChange: number;
+  cardPaymentProcessorBalanceChange: number;
+  userBalanceChange: number;
+  cashOutAccountBalanceChange: number;
+  compensationAmountChange: number;
+  clearedBalance: number;
+  unclearedBalance: number;
+  paymentStatus: PaymentStatus;
+}
+
 interface Fixture {
   cardPaymentProcessor: Contract;
   tokenMock: Contract;
@@ -59,64 +149,1414 @@ interface Fixture {
   cashbackDistributorMockConfig: CashbackDistributorMockConfig;
 }
 
-function checkNonexistentPayment(
-  actualOnChainPayment: any,
-  paymentIndex: number
-) {
-  expect(actualOnChainPayment.account).to.equal(
-    ZERO_ADDRESS,
-    `payment[${paymentIndex}].account is incorrect`
-  );
-  expect(actualOnChainPayment.amount).to.equal(
-    0,
-    `payment[${paymentIndex}].amount is incorrect`
-  );
-  expect(actualOnChainPayment.status).to.equal(
-    0,
-    `payment[${paymentIndex}].status is incorrect`
-  );
-  expect(actualOnChainPayment.revocationCounter).to.equal(0);
-  expect(actualOnChainPayment.compensationAmount).to.equal(0);
-  expect(actualOnChainPayment.refundAmount).to.equal(0);
-  expect(actualOnChainPayment.cashbackRate).to.equal(0);
+class CashbackDistributorMockShell {
+  readonly contract: Contract;
+  readonly config: CashbackDistributorMockConfig;
+
+  constructor(props: {
+    cashbackDistributorMockConfig: CashbackDistributorMockConfig,
+    cashbackDistributorMockContract: Contract
+  }) {
+    this.contract = props.cashbackDistributorMockContract;
+    this.config = props.cashbackDistributorMockConfig;
+  }
+
+  async setSendCashbackSuccessResult(newSendCashbackSuccessResult: boolean) {
+    await proveTx(this.contract.setSendCashbackSuccessResult(newSendCashbackSuccessResult));
+    this.config.sendCashbackSuccessResult = newSendCashbackSuccessResult;
+  }
+
+  async setSendCashbackAmountResult(newSendCashbackAmountResult: number) {
+    await proveTx(this.contract.setSendCashbackAmountResult(newSendCashbackAmountResult));
+    this.config.sendCashbackAmountResult = newSendCashbackAmountResult;
+  }
+
+  async setRevokeCashbackSuccessResult(newRevokeCashbackSuccessResult: boolean) {
+    await proveTx(this.contract.setRevokeCashbackSuccessResult(newRevokeCashbackSuccessResult));
+    this.config.revokeCashbackSuccessResult = newRevokeCashbackSuccessResult;
+  }
+
+  async setIncreaseCashbackSuccessResult(newIncreaseCashbackSuccessResult: boolean) {
+    await proveTx(this.contract.setIncreaseCashbackSuccessResult(newIncreaseCashbackSuccessResult));
+    this.config.increaseCashbackSuccessResult = newIncreaseCashbackSuccessResult;
+  }
+
+  async setIncreaseCashbackAmountResult(newIncreaseCashbackAmountResult: number) {
+    await proveTx(this.contract.setIncreaseCashbackAmountResult(newIncreaseCashbackAmountResult));
+    this.config.increaseCashbackAmountResult = newIncreaseCashbackAmountResult;
+  }
 }
 
-function checkEquality(
-  actualOnChainPayment: any,
-  expectedPayment: TestPayment,
-  paymentIndex: number
-) {
-  if (expectedPayment.status == PaymentStatus.Nonexistent) {
-    checkNonexistentPayment(actualOnChainPayment, paymentIndex);
-  } else {
+class CardPaymentProcessorModel {
+  #cashbackDistributorMockConfig: CashbackDistributorMockConfig;
+  #cashbackEnabled: boolean = false;
+  #cashbackRateInPermil: number;
+  #paymentPerAuthorizationId: Map<string, PaymentModel> = new Map<string, PaymentModel>();
+  #unclearedBalancePerAccount: Map<string, number> = new Map<string, number>();
+  #clearedBalancePerAccount: Map<string, number> = new Map<string, number>();
+  #totalUnclearedBalance: number = 0;
+  #totalClearedBalance: number = 0;
+  #totalBalance: number = 0;
+  #cashbackPerAuthorizationId: Map<string, CashbackModel> = new Map<string, CashbackModel>();
+  #paymentMakingOperations: PaymentOperation[] = [];
+  #paymentOperations: PaymentOperation[] = [];
+
+  constructor(props: {
+    cashbackDistributorMockConfig: CashbackDistributorMockConfig;
+    cashbackRateInPermil: number,
+  }) {
+    this.#cashbackDistributorMockConfig = props.cashbackDistributorMockConfig;
+    this.#cashbackRateInPermil = props.cashbackRateInPermil;
+  }
+
+  makePayment(payment: TestPayment, sender: SignerWithAddress = payment.account): number {
+    const paymentModel = this.#createPayment(payment);
+    const operation: PaymentOperation = this.#createPaymentOperation(paymentModel, OperationKind.Making);
+    operation.sender = sender;
+    operation.oldBaseAmount = 0;
+    operation.oldExtraAmount = 0;
+    operation.correlationId = payment.correlationId;
+    this.#definePaymentMakingOperation(operation);
+    return this.#registerPaymentMakingOperation(operation, paymentModel);
+  }
+
+  updatePaymentAmount(
+    newBaseAmount: number,
+    newExtraAmount: number,
+    authorizationId: string,
+    correlationId: string
+  ): number {
+    const payment: PaymentModel = this.getPaymentByAuthorizationId(authorizationId);
+    const operation: PaymentOperation = this.#createPaymentOperation(payment, OperationKind.Updating);
+    operation.newBaseAmount = newBaseAmount;
+    operation.newExtraAmount = newExtraAmount;
+    operation.correlationId = correlationId;
+    this.#checkPaymentUpdating(operation, payment);
+    this.#definePaymentUpdatingOperation(operation, payment);
+    return this.#registerPaymentUpdatingOperation(operation, payment);
+  }
+
+  clearPayment(authorizationId: string): number {
+    const payment: PaymentModel = this.getPaymentByAuthorizationId(authorizationId);
+    const operation: PaymentOperation = this.#createPaymentOperation(payment, OperationKind.Clearing);
+    this.#checkPaymentClearing(payment);
+    return this.#registerPaymentClearingOperation(operation, payment);
+  }
+
+  unclearPayment(authorizationId: string): number {
+    const payment: PaymentModel = this.getPaymentByAuthorizationId(authorizationId);
+    const operation: PaymentOperation = this.#createPaymentOperation(payment, OperationKind.Unclearing);
+    this.#checkPaymentUnclearing(payment);
+    return this.#registerPaymentUnclearingOperation(operation, payment);
+  }
+
+  revokePayment(authorizationId: string, correlationId: string, parentTxHash: string): number {
+    const payment: PaymentModel = this.getPaymentByAuthorizationId(authorizationId);
+    const operation: PaymentOperation = this.#createPaymentOperation(payment, OperationKind.Revoking);
+    operation.correlationId = correlationId;
+    operation.parentTransactionHash = parentTxHash;
+    operation.revocationCounter += 1;
+    this.#checkPaymentCanceling(payment);
+    this.#definePaymentCancelingOperation(operation, payment);
+    this.#updateModelDueToPaymentCancelingOperation(operation, payment);
+    return this.#registerPaymentRevokingOperation(operation, payment);
+  }
+
+  reversePayment(authorizationId: string, correlationId: string, parentTxHash: string): number {
+    const payment: PaymentModel = this.getPaymentByAuthorizationId(authorizationId);
+    const operation: PaymentOperation = this.#createPaymentOperation(payment, OperationKind.Reversing);
+    operation.correlationId = correlationId;
+    operation.parentTransactionHash = parentTxHash;
+    this.#checkPaymentCanceling(payment);
+    this.#definePaymentCancelingOperation(operation, payment);
+    this.#updateModelDueToPaymentCancelingOperation(operation, payment);
+    return this.#registerPaymentReversingOperation(operation, payment);
+  }
+
+  confirmPayment(authorizationId: string): number {
+    const payment: PaymentModel = this.getPaymentByAuthorizationId(authorizationId);
+    const operation: PaymentOperation = this.#createPaymentOperation(payment, OperationKind.Confirming);
+    operation.cardPaymentProcessorBalanceChange = -operation.totalAmount;
+    operation.cashOutAccountBalanceChange = operation.totalAmount;
+    this.#checkPaymentConfirming(payment);
+    return this.#registerPaymentConfirmingOperation(operation, payment);
+  }
+
+  refundPayment(
+    refundAmount: number,
+    newExtraAmount: number,
+    authorizationId: string,
+    correlationId: string
+  ): number {
+    const payment: PaymentModel = this.getPaymentByAuthorizationId(authorizationId);
+    const operation: PaymentOperation = this.#createPaymentOperation(payment, OperationKind.Refunding);
+    operation.correlationId = correlationId;
+    operation.refundAmount = refundAmount;
+    operation.newExtraAmount = newExtraAmount;
+    this.#checkPaymentRefunding(operation, payment);
+    this.#definePaymentRefundingOperation(operation, payment);
+    return this.#registerPaymentRefundingOperation(operation, payment);
+  }
+
+  enableCashback() {
+    this.#cashbackEnabled = true;
+  }
+
+  disableCashback() {
+    this.#cashbackEnabled = false;
+  }
+
+  getPaymentModelsInMakingOrder(): PaymentModel[] {
+    const paymentNumber = this.#paymentMakingOperations.length;
+    const paymentModels: PaymentModel[] = [];
+    for (let i = 0; i < paymentNumber; ++i) {
+      const paymentModel: PaymentModel = this.#getPaymentByMakingOperationIndex(i);
+      paymentModels.push(paymentModel);
+    }
+    return paymentModels;
+  }
+
+  getAuthorizationIds(): Set<string> {
+    return new Set(this.#paymentPerAuthorizationId.keys());
+  }
+
+  getPaymentByAuthorizationId(authorizationId: string): PaymentModel {
+    const payment = this.#paymentPerAuthorizationId.get(authorizationId);
+    if (!payment) {
+      throw Error(`A payment is not in the model. authorizationId = ${authorizationId}`);
+    }
+    return payment;
+  }
+
+  getCashbackByAuthorizationId(authorizationId: string): CashbackModel | undefined {
+    return this.#cashbackPerAuthorizationId.get(authorizationId);
+  }
+
+  getAccountAddresses(): Set<string> {
+    return new Set(
+      this.#paymentMakingOperations.map(operation => operation.account.address)
+    );
+  }
+
+  getAccountUnclearedBalance(account: string): number {
+    return (this.#unclearedBalancePerAccount.get(account) ?? 0);
+  }
+
+  getAccountClearedBalance(account: string): number {
+    return (this.#clearedBalancePerAccount.get(account) ?? 0);
+  }
+
+  get totalUnclearedBalance(): number {
+    return this.#totalUnclearedBalance;
+  }
+
+  get totalClearedBalance(): number {
+    return this.#totalClearedBalance;
+  }
+
+  get totalBalance(): number {
+    return this.#totalBalance;
+  }
+
+  getPaymentOperation(operationIndex: number): PaymentOperation {
+    return this.#getOperationByIndex(this.#paymentOperations, operationIndex, "");
+  }
+
+  #createPayment(payment: TestPayment): PaymentModel {
+    const currentPayment = this.#paymentPerAuthorizationId.get(payment.authorizationId);
+    if (!!currentPayment && currentPayment.status != PaymentStatus.Revoked) {
+      throw new Error(
+        `A payment with the provided authorization ID already exists in the model and its status is not "Revoked".` +
+        `authorizationId=${payment.authorizationId}`
+      );
+    }
+    return {
+      authorizationId: payment.authorizationId,
+      account: payment.account,
+      baseAmount: payment.baseAmount,
+      extraAmount: payment.extraAmount,
+      status: PaymentStatus.Uncleared,
+      compensationAmount: 0,
+      refundAmount: 0,
+      cashbackRate: (this.#cashbackEnabled && this.#cashbackDistributorMockConfig.sendCashbackSuccessResult)
+        ? this.#cashbackRateInPermil
+        : 0,
+      cashbackEnabled: this.#cashbackEnabled,
+      revocationParentTxHashes: (!currentPayment) ? [] : [...currentPayment.revocationParentTxHashes],
+      reversalParentTxHashes: [],
+    };
+  }
+
+  #createPaymentOperation(payment: PaymentModel, kind: OperationKind): PaymentOperation {
+    const cashback = this.getCashbackByAuthorizationId(payment.authorizationId);
+    return {
+      kind,
+      sender: undefined,
+      account: payment.account,
+      newBaseAmount: payment.baseAmount,
+      newExtraAmount: payment.extraAmount,
+      refundAmount: 0,
+      oldBaseAmount: payment.baseAmount,
+      oldExtraAmount: payment.extraAmount,
+      totalAmount: payment.baseAmount + payment.extraAmount - payment.refundAmount,
+      authorizationId: payment.authorizationId,
+      correlationId: "<no_data>",
+      parentTransactionHash: "<no_data>",
+      revocationCounter: payment.revocationParentTxHashes.length,
+      cashbackEnabled: payment.cashbackEnabled,
+      cashbackSendingSucceeded: false,
+      cashbackRevocationRequested: false,
+      cashbackRevocationSuccess: false,
+      cashbackIncreaseRequested: false,
+      cashbackIncreaseSuccess: false,
+      cashbackRequestedChange: 0,
+      cashbackActualChange: 0,
+      cashbackRate: payment.cashbackRate,
+      cashbackNonce: cashback?.lastCashbackNonce ?? 0,
+      senderBalanceChange: 0,
+      cardPaymentProcessorBalanceChange: 0,
+      userBalanceChange: 0,
+      cashOutAccountBalanceChange: 0,
+      compensationAmountChange: 0,
+      clearedBalance: this.#clearedBalancePerAccount.get(payment.account.address) ?? 0,
+      unclearedBalance: this.#unclearedBalancePerAccount.get(payment.account.address) ?? 0,
+      paymentStatus: payment.status
+    };
+  }
+
+  #definePaymentMakingOperation(operation: PaymentOperation) {
+    if (operation.cashbackEnabled) {
+      operation.cashbackRequestedChange = this.#calculateCashback(operation.newBaseAmount);
+      operation.cashbackSendingSucceeded = this.#cashbackDistributorMockConfig.sendCashbackSuccessResult;
+      operation.cashbackNonce = this.#cashbackDistributorMockConfig.sendCashbackNonceResult;
+      this.#cashbackPerAuthorizationId.set(
+        operation.authorizationId,
+        { lastCashbackNonce: operation.cashbackNonce }
+      );
+      if (operation.cashbackSendingSucceeded) {
+        operation.cashbackRate = this.#cashbackRateInPermil;
+        if (this.#cashbackDistributorMockConfig.sendCashbackAmountResult < 0) {
+          operation.cashbackActualChange = operation.cashbackRequestedChange;
+        } else {
+          operation.cashbackActualChange = this.#cashbackDistributorMockConfig.sendCashbackAmountResult;
+        }
+      }
+    }
+    operation.totalAmount = operation.newBaseAmount + operation.newExtraAmount;
+    operation.cardPaymentProcessorBalanceChange = operation.newBaseAmount + operation.newExtraAmount;
+    operation.userBalanceChange = -operation.cardPaymentProcessorBalanceChange + operation.cashbackActualChange;
+    if (operation.sender == operation.account) {
+      operation.senderBalanceChange = operation.userBalanceChange;
+    }
+  }
+
+  #registerPaymentMakingOperation(operation: PaymentOperation, payment: PaymentModel): number {
+    payment.compensationAmount = operation.cashbackActualChange;
+    let balance = this.#unclearedBalancePerAccount.get(operation.account.address) ?? 0;
+    balance += operation.totalAmount;
+    this.#unclearedBalancePerAccount.set(operation.account.address, balance);
+    this.#totalUnclearedBalance += operation.totalAmount;
+    this.#totalBalance += operation.totalAmount;
+    this.#paymentPerAuthorizationId.set(payment.authorizationId, payment);
+    this.#paymentOperations.push(operation);
+    return this.#paymentMakingOperations.push(operation) - 1;
+  }
+
+  #calculateCashback(amount: number, cashbackRateInPermil: number = this.#cashbackRateInPermil) {
+    return Math.floor(amount * cashbackRateInPermil / 1000);
+  }
+
+  #getPaymentByMakingOperationIndex(paymentMakingOperationIndex: number): PaymentModel {
+    const paymentOperation: PaymentOperation = this.#paymentMakingOperations[paymentMakingOperationIndex];
+    const authorizationId = paymentOperation.authorizationId;
+    return this.getPaymentByAuthorizationId(authorizationId);
+  }
+
+  #changeBalanceMap(balanceMap: Map<string, number>, mapKey: string, balanceChange: number) {
+    let balance = balanceMap.get(mapKey) || 0;
+    balance += balanceChange;
+    balanceMap.set(mapKey, balance);
+  }
+
+  #checkPaymentUpdating(operation: PaymentOperation, payment: PaymentModel) {
+    if (payment.status !== PaymentStatus.Uncleared) {
+      throw new Error(
+        `The payment has inappropriate status: ${payment.status}`
+      );
+    }
+    if (payment.refundAmount > operation.newBaseAmount) {
+      throw new Error(
+        `The new base amount is wrong for the payment with authorizationId=${payment.authorizationId}.` +
+        `The requested new base amount: ${operation.newBaseAmount}. ` +
+        `The payment initial base amount: ${payment.baseAmount}. ` +
+        `The current payment refund amount: ${payment.refundAmount}`
+      );
+    }
+  }
+
+  #definePaymentUpdatingOperation(operation: PaymentOperation, payment: PaymentModel) {
+    const amountDiff =
+      operation.newBaseAmount + operation.newExtraAmount - operation.oldBaseAmount - operation.oldExtraAmount;
+    if (!payment.cashbackEnabled) {
+      operation.userBalanceChange = -amountDiff;
+      operation.cardPaymentProcessorBalanceChange = amountDiff;
+    } else {
+      const cashbackModel = this.getCashbackByAuthorizationId(operation.authorizationId);
+      operation.cashbackNonce = cashbackModel?.lastCashbackNonce ?? 0;
+      const oldCashback = this.#calculateCashback(
+        operation.oldBaseAmount - payment.refundAmount,
+        payment.cashbackRate
+      );
+      const newCashback = this.#calculateCashback(
+        operation.newBaseAmount - payment.refundAmount,
+        payment.cashbackRate
+      );
+      operation.cashbackRequestedChange = newCashback - oldCashback;
+      if (newCashback >= oldCashback) {
+        operation.cashbackIncreaseRequested = true;
+        if (this.#cashbackDistributorMockConfig.increaseCashbackSuccessResult) {
+          operation.cashbackIncreaseSuccess = true;
+          if (this.#cashbackDistributorMockConfig.increaseCashbackAmountResult < 0) {
+            operation.cashbackActualChange = operation.cashbackRequestedChange;
+          } else {
+            operation.cashbackActualChange = this.#cashbackDistributorMockConfig.increaseCashbackAmountResult;
+          }
+        }
+        operation.userBalanceChange = -amountDiff + operation.cashbackActualChange;
+        operation.cardPaymentProcessorBalanceChange = amountDiff;
+        operation.compensationAmountChange = operation.cashbackActualChange;
+      } else {
+        operation.cashbackRevocationRequested = true;
+        if (this.#cashbackDistributorMockConfig.revokeCashbackSuccessResult) {
+          operation.cashbackRevocationSuccess = true;
+          operation.cashbackActualChange = operation.cashbackRequestedChange;
+        }
+        operation.userBalanceChange = -amountDiff + operation.cashbackRequestedChange;
+        operation.cardPaymentProcessorBalanceChange = amountDiff -
+          (operation.cashbackRequestedChange - operation.cashbackActualChange);
+        operation.compensationAmountChange = operation.cashbackRequestedChange;
+      }
+    }
+  }
+
+  #registerPaymentUpdatingOperation(operation: PaymentOperation, payment: PaymentModel) {
+    payment.baseAmount = operation.newBaseAmount;
+    payment.extraAmount = operation.newExtraAmount;
+    payment.compensationAmount += operation.compensationAmountChange;
+    const amountDiff =
+      operation.newBaseAmount + operation.newExtraAmount - operation.oldBaseAmount - operation.oldExtraAmount;
+    this.#changeBalanceMap(
+      this.#unclearedBalancePerAccount,
+      operation.account.address,
+      amountDiff
+    );
+    this.#totalUnclearedBalance += amountDiff;
+    this.#totalBalance += operation.cardPaymentProcessorBalanceChange;
+    return this.#paymentOperations.push(operation) - 1;
+  }
+
+  #checkPaymentClearing(payment: PaymentModel) {
+    if (payment.status !== PaymentStatus.Uncleared) {
+      throw new Error(
+        `The payment has inappropriate status: ${payment.status}`
+      );
+    }
+  }
+
+  #registerPaymentClearingOperation(operation: PaymentOperation, payment: PaymentModel) {
+    this.#changeBalanceMap(this.#unclearedBalancePerAccount, operation.account.address, -operation.totalAmount);
+    this.#totalUnclearedBalance -= operation.totalAmount;
+    this.#changeBalanceMap(this.#clearedBalancePerAccount, operation.account.address, +operation.totalAmount);
+    this.#totalClearedBalance += operation.totalAmount;
+    payment.status = PaymentStatus.Cleared;
+    operation.unclearedBalance = this.#unclearedBalancePerAccount.get(operation.account.address) ?? 0;
+    operation.clearedBalance = this.#clearedBalancePerAccount.get(operation.account.address) ?? 0;
+    return this.#paymentOperations.push(operation) - 1;
+  }
+
+  #getOperationByIndex(operations: any[], index: number, kind: string): any {
+    if (index < 0) {
+      index = operations.length + index;
+    }
+    if (index >= operations.length) {
+      throw new Error(
+        `A payment ${kind} operation with index ${index} does not exist. `
+      );
+    }
+    return operations[index];
+  }
+
+  #checkPaymentUnclearing(payment: PaymentModel) {
+    if (payment.status !== PaymentStatus.Cleared) {
+      throw new Error(
+        `The payment has inappropriate status: ${payment.status}`
+      );
+    }
+  }
+
+  #registerPaymentUnclearingOperation(operation: PaymentOperation, payment: PaymentModel) {
+    this.#changeBalanceMap(this.#clearedBalancePerAccount, operation.account.address, -operation.totalAmount);
+    this.#totalClearedBalance -= operation.totalAmount;
+    this.#changeBalanceMap(this.#unclearedBalancePerAccount, operation.account.address, +operation.totalAmount);
+    this.#totalUnclearedBalance += operation.totalAmount;
+    payment.status = PaymentStatus.Uncleared;
+    operation.unclearedBalance = this.#unclearedBalancePerAccount.get(operation.account.address) ?? 0;
+    operation.clearedBalance = this.#clearedBalancePerAccount.get(operation.account.address) ?? 0;
+    return this.#paymentOperations.push(operation) - 1;
+  }
+
+  #checkPaymentCanceling(payment: PaymentModel) {
+    if (!(payment.status === PaymentStatus.Uncleared || payment.status === PaymentStatus.Cleared)) {
+      throw new Error(
+        `The payment has inappropriate status: ${payment.status}`
+      );
+    }
+  }
+
+  #definePaymentCancelingOperation(operation: PaymentOperation, payment: PaymentModel) {
+    operation.userBalanceChange = payment.baseAmount + payment.extraAmount - payment.compensationAmount;
+    if (payment.cashbackEnabled) {
+      operation.cashbackRevocationRequested = true;
+      operation.cashbackRequestedChange = -(operation.totalAmount - operation.userBalanceChange);
+      const cashbackModel = this.getCashbackByAuthorizationId(operation.authorizationId);
+      operation.cashbackNonce = cashbackModel?.lastCashbackNonce ?? 0;
+      if (this.#cashbackDistributorMockConfig.revokeCashbackSuccessResult) {
+        operation.cashbackActualChange = operation.cashbackRequestedChange;
+        operation.cashbackRevocationSuccess = true;
+      }
+    }
+    operation.cardPaymentProcessorBalanceChange =
+      -(operation.userBalanceChange - operation.cashbackActualChange);
+  }
+
+  #updateModelDueToPaymentCancelingOperation(operation: PaymentOperation, payment: PaymentModel) {
+    if (operation.paymentStatus === PaymentStatus.Cleared) {
+      this.#changeBalanceMap(this.#clearedBalancePerAccount, operation.account.address, -operation.totalAmount);
+      this.#totalClearedBalance -= operation.totalAmount;
+    } else {
+      this.#changeBalanceMap(this.#unclearedBalancePerAccount, operation.account.address, -operation.totalAmount);
+      this.#totalUnclearedBalance -= operation.totalAmount;
+    }
+    operation.unclearedBalance = this.#unclearedBalancePerAccount.get(operation.account.address) ?? 0;
+    operation.clearedBalance = this.#clearedBalancePerAccount.get(operation.account.address) ?? 0;
+    this.#totalBalance += operation.cardPaymentProcessorBalanceChange;
+
+    payment.compensationAmount = 0;
+    payment.refundAmount = 0;
+  }
+
+  #registerPaymentRevokingOperation(operation: PaymentOperation, payment: PaymentModel) {
+    payment.status = PaymentStatus.Revoked;
+    payment.revocationParentTxHashes.push(operation.parentTransactionHash);
+    return this.#paymentOperations.push(operation) - 1;
+  }
+
+  #registerPaymentReversingOperation(operation: PaymentOperation, payment: PaymentModel) {
+    payment.status = PaymentStatus.Reversed;
+    payment.reversalParentTxHashes.push(operation.parentTransactionHash);
+    return this.#paymentOperations.push(operation) - 1;
+  }
+
+  #checkPaymentConfirming(payment: PaymentModel) {
+    if (payment.status !== PaymentStatus.Cleared) {
+      throw new Error(
+        `The payment has inappropriate status: ${payment.status}`
+      );
+    }
+  }
+
+  #registerPaymentConfirmingOperation(operation: PaymentOperation, payment: PaymentModel) {
+    this.#changeBalanceMap(this.#clearedBalancePerAccount, operation.account.address, -operation.totalAmount);
+    this.#totalClearedBalance -= operation.totalAmount;
+    operation.clearedBalance = this.#clearedBalancePerAccount.get(operation.account.address) ?? 0;
+    this.#totalBalance -= operation.totalAmount;
+
+    payment.status = PaymentStatus.Confirmed;
+    return this.#paymentOperations.push(operation) - 1;
+  }
+
+  #checkPaymentRefunding(operation: PaymentOperation, payment: PaymentModel) {
+    if (!(
+      payment.status === PaymentStatus.Uncleared
+      || payment.status === PaymentStatus.Cleared
+      || payment.status === PaymentStatus.Confirmed
+    )) {
+      throw new Error(
+        `The payment has inappropriate status: ${payment.status}`
+      );
+    }
+    if (operation.refundAmount > (payment.baseAmount - payment.refundAmount)) {
+      throw new Error(
+        `The refund amount is wrong for the payment with authorizationId=${payment.authorizationId}.` +
+        `The requested amount: ${operation.refundAmount}. ` +
+        `The payment initial amount: ${payment.baseAmount}. ` +
+        `The current payment refund amount: ${payment.refundAmount}`
+      );
+    }
+    if (operation.newExtraAmount > payment.extraAmount) {
+      throw new Error(
+        `The new extra amount is wrong for the payment with authorizationId=${payment.authorizationId}.` +
+        `The requested new extra amount: ${operation.newExtraAmount}. ` +
+        `The payment initial extra amount: ${payment.extraAmount}`
+      );
+    }
+  }
+
+  #definePaymentRefundingOperation(operation: PaymentOperation, payment: PaymentModel) {
+    const newRefundAmount = operation.refundAmount + payment.refundAmount;
+    operation.userBalanceChange = operation.refundAmount + (operation.oldExtraAmount - operation.newExtraAmount);
+    if (payment.cashbackEnabled) {
+      operation.cashbackRevocationRequested = true;
+      const cashbackModel = this.getCashbackByAuthorizationId(operation.authorizationId);
+      operation.cashbackNonce = cashbackModel?.lastCashbackNonce ?? 0;
+      const oldCashback = this.#calculateCashback(
+        payment.baseAmount - payment.refundAmount,
+        payment.cashbackRate
+      );
+      const newCashback = this.#calculateCashback(
+        payment.baseAmount - newRefundAmount,
+        payment.cashbackRate
+      );
+      const cashbackRevocationAmount = oldCashback - newCashback;
+      if (this.#cashbackDistributorMockConfig.revokeCashbackSuccessResult) {
+        operation.cashbackActualChange = -cashbackRevocationAmount;
+        operation.cashbackRevocationSuccess = true;
+      }
+      operation.cashbackRequestedChange = -cashbackRevocationAmount;
+      operation.userBalanceChange -= cashbackRevocationAmount;
+    }
+    const serviceBalanceChange = -(operation.userBalanceChange - operation.cashbackRequestedChange);
+    if (operation.paymentStatus === PaymentStatus.Confirmed) {
+      operation.cardPaymentProcessorBalanceChange =
+        operation.cashbackRequestedChange - operation.cashbackActualChange;
+      operation.cashOutAccountBalanceChange = serviceBalanceChange;
+    } else {
+      operation.cardPaymentProcessorBalanceChange = serviceBalanceChange;
+    }
+    operation.totalAmount = payment.baseAmount + operation.newExtraAmount - newRefundAmount;
+    operation.compensationAmountChange = operation.refundAmount + operation.cashbackActualChange;
+  }
+
+  #registerPaymentRefundingOperation(operation: PaymentOperation, payment: PaymentModel): number {
+    const balanceChange = -operation.refundAmount + (operation.newExtraAmount - payment.extraAmount);
+    payment.refundAmount += operation.refundAmount;
+    payment.compensationAmount += operation.compensationAmountChange;
+    payment.extraAmount = operation.newExtraAmount;
+    if (operation.paymentStatus === PaymentStatus.Uncleared) {
+      this.#changeBalanceMap(
+        this.#unclearedBalancePerAccount,
+        operation.account.address,
+        balanceChange
+      );
+      this.#totalUnclearedBalance += balanceChange;
+      this.#totalBalance += operation.cardPaymentProcessorBalanceChange;
+    } else if (operation.paymentStatus == PaymentStatus.Cleared) {
+      this.#changeBalanceMap(
+        this.#clearedBalancePerAccount,
+        operation.account.address,
+        balanceChange
+      );
+      this.#totalClearedBalance += balanceChange;
+      this.#totalBalance += operation.cardPaymentProcessorBalanceChange;
+    } else {
+      this.#totalBalance +=
+        -(operation.cashbackRequestedChange - operation.cashbackActualChange);
+    }
+    return this.#paymentOperations.push(operation) - 1;
+  }
+}
+
+interface OperationResult {
+  operationIndex: number,
+  tx: Promise<TransactionResponse>,
+  txReceipt: TransactionReceipt,
+}
+
+class CardPaymentProcessorShell {
+  contract: Contract;
+  model: CardPaymentProcessorModel;
+  executor: SignerWithAddress;
+
+  constructor(props: {
+    cardPaymentProcessorContract: Contract,
+    cardPaymentProcessorModel: CardPaymentProcessorModel,
+    executor: SignerWithAddress,
+  }) {
+    this.contract = props.cardPaymentProcessorContract;
+    this.model = props.cardPaymentProcessorModel;
+    this.executor = props.executor;
+  }
+
+  async enableCashback() {
+    this.model.enableCashback();
+    await proveTx(this.contract.enableCashback());
+  }
+
+  async disableCashback() {
+    this.model.disableCashback();
+    await proveTx(this.contract.disableCashback());
+  }
+
+  async makePayments(
+    payments: TestPayment[],
+    sender: SignerWithAddress = this.executor
+  ): Promise<OperationResult[]> {
+    const operationResults: OperationResult[] = [];
+    for (let payment of payments) {
+      const operationIndex = this.model.makePayment(payment, sender);
+      const tx = this.contract.connect(sender).functions[FUNCTION_MAKE_PAYMENT_FROM](
+        payment.account.address,
+        payment.baseAmount,
+        payment.extraAmount,
+        payment.authorizationId,
+        payment.correlationId,
+      );
+      const txReceipt: TransactionReceipt = await proveTx(tx);
+      operationResults.push({
+        operationIndex,
+        tx,
+        txReceipt,
+      });
+      payment.parentTxHash = txReceipt.transactionHash;
+    }
+    return operationResults;
+  }
+
+  async updatePaymentAmount(
+    payment: TestPayment,
+    newBaseAmount: number,
+    newExtraAmount: number = payment.extraAmount,
+    sender: SignerWithAddress = this.executor
+  ): Promise<OperationResult> {
+    const operationIndex = this.model.updatePaymentAmount(
+      newBaseAmount,
+      newExtraAmount,
+      payment.authorizationId,
+      payment.correlationId
+    );
+    const tx = this.contract.connect(sender).functions[FUNCTION_UPDATE_PAYMENT_AMOUNT](
+      newBaseAmount,
+      newExtraAmount,
+      payment.authorizationId,
+      payment.correlationId
+    );
+    const txReceipt: TransactionReceipt = await proveTx(tx);
+    return {
+      operationIndex,
+      tx,
+      txReceipt
+    };
+  }
+
+  async clearPayments(
+    payments: TestPayment[],
+    sender: SignerWithAddress = this.executor
+  ): Promise<OperationResult[]> {
+    const operationResults: OperationResult[] = [];
+    for (let payment of payments) {
+      const operationIndex = this.model.clearPayment(payment.authorizationId);
+      const tx = this.contract.connect(sender).clearPayment(payment.authorizationId);
+      const txReceipt: TransactionReceipt = await proveTx(tx);
+      operationResults.push({
+        operationIndex,
+        tx,
+        txReceipt,
+      });
+    }
+    return operationResults;
+  }
+
+  async unclearPayments(
+    payments: TestPayment[],
+    sender: SignerWithAddress = this.executor
+  ): Promise<OperationResult[]> {
+    const operationResults: OperationResult[] = [];
+    for (let payment of payments) {
+      const operationIndex = this.model.unclearPayment(payment.authorizationId);
+      const tx = this.contract.connect(sender).unclearPayment(payment.authorizationId);
+      const txReceipt: TransactionReceipt = await proveTx(tx);
+      operationResults.push({
+        operationIndex,
+        tx,
+        txReceipt,
+      });
+    }
+    return operationResults;
+  }
+
+  async revokePayment(
+    payment: TestPayment,
+    sender: SignerWithAddress = this.executor
+  ): Promise<OperationResult> {
+    const operationIndex = this.model.revokePayment(
+      payment.authorizationId,
+      payment.correlationId,
+      payment.parentTxHash
+    );
+    const tx = this.contract.connect(sender).revokePayment(
+      payment.authorizationId,
+      payment.correlationId,
+      payment.parentTxHash
+    );
+    const txReceipt: TransactionReceipt = await proveTx(tx);
+    return {
+      operationIndex,
+      tx,
+      txReceipt
+    };
+  }
+
+  async reversePayment(
+    payment: TestPayment,
+    sender: SignerWithAddress = this.executor
+  ): Promise<OperationResult> {
+    const operationIndex = this.model.reversePayment(
+      payment.authorizationId,
+      payment.correlationId,
+      payment.parentTxHash
+    );
+    const tx = this.contract.connect(sender).reversePayment(
+      payment.authorizationId,
+      payment.correlationId,
+      payment.parentTxHash
+    );
+    const txReceipt: TransactionReceipt = await proveTx(tx);
+    return {
+      operationIndex,
+      tx,
+      txReceipt
+    };
+  }
+
+  async confirmPayments(
+    payments: TestPayment[],
+    sender: SignerWithAddress = this.executor
+  ): Promise<OperationResult[]> {
+    const operationResults: OperationResult[] = [];
+    for (let payment of payments) {
+      const operationIndex = this.model.confirmPayment(payment.authorizationId);
+      const tx = this.contract.connect(sender).confirmPayment(payment.authorizationId);
+      const txReceipt: TransactionReceipt = await proveTx(tx);
+      operationResults.push({
+        operationIndex,
+        tx,
+        txReceipt,
+      });
+      payment.parentTxHash = txReceipt.transactionHash;
+    }
+    return operationResults;
+  }
+
+  async refundPayment(
+    payment: TestPayment,
+    refundAmount: number,
+    newExtraAmount: number = payment.extraAmount,
+    sender: SignerWithAddress = this.executor
+  ): Promise<OperationResult> {
+    const operationIndex = this.model.refundPayment(
+      refundAmount,
+      newExtraAmount,
+      payment.authorizationId,
+      payment.correlationId
+    );
+    const tx = this.contract.connect(sender).functions[FUNCTION_REFUND_PAYMENT](
+      refundAmount,
+      newExtraAmount,
+      payment.authorizationId,
+      payment.correlationId
+    );
+    const txReceipt: TransactionReceipt = await proveTx(tx);
+    return {
+      operationIndex,
+      tx,
+      txReceipt
+    };
+  }
+}
+
+class TestContext {
+  cashbackDistributorMockConfig: CashbackDistributorMockConfig;
+  tokenMock: Contract;
+  cardPaymentProcessorShell: CardPaymentProcessorShell;
+  cashbackDistributorMockShell: CashbackDistributorMockShell;
+  cashOutAccount: SignerWithAddress;
+  payments: TestPayment[];
+
+  constructor(props: {
+    fixture: Fixture,
+    cashbackRateInPermil: number,
+    cashOutAccount: SignerWithAddress,
+    cardPaymentProcessorExecutor: SignerWithAddress,
+    payments: TestPayment[]
+  }) {
+    this.cashbackDistributorMockConfig = { ...props.fixture.cashbackDistributorMockConfig };
+    this.tokenMock = props.fixture.tokenMock;
+    this.cashbackDistributorMockShell = new CashbackDistributorMockShell({
+      cashbackDistributorMockContract: props.fixture.cashbackDistributorMock,
+      cashbackDistributorMockConfig: this.cashbackDistributorMockConfig
+    });
+    this.cardPaymentProcessorShell = new CardPaymentProcessorShell({
+      cardPaymentProcessorContract: props.fixture.cardPaymentProcessor,
+      cardPaymentProcessorModel: new CardPaymentProcessorModel({
+        cashbackDistributorMockConfig: this.cashbackDistributorMockConfig,
+        cashbackRateInPermil: props.cashbackRateInPermil
+      }),
+      executor: props.cardPaymentProcessorExecutor,
+    });
+    this.cashOutAccount = props.cashOutAccount;
+    this.payments = props.payments;
+  }
+
+  async checkPaymentOperationsForTx(tx: Promise<TransactionResponse>, paymentOperationIndexes: number[] = [-1]) {
+    const operations: PaymentOperation[] = paymentOperationIndexes.map(
+      (index) => this.cardPaymentProcessorShell.model.getPaymentOperation(index)
+    );
+
+    for (let operation of operations) {
+      switch (operation.kind) {
+        case OperationKind.Undefined:
+          break;
+        case OperationKind.Making:
+          await this.checkMakingEvent(tx, operation);
+          break;
+        case OperationKind.Updating:
+          await this.checkUpdatingEvent(tx, operation);
+          break;
+        case OperationKind.Clearing:
+          await this.checkClearingEvent(tx, operation);
+          break;
+        case OperationKind.Unclearing:
+          await this.checkUnclearingEvent(tx, operation);
+          break;
+        case OperationKind.Revoking:
+          await this.checkCancelingEvent(tx, operation, EVENT_NAME_REVOKE_PAYMENT);
+          break;
+        case OperationKind.Reversing:
+          await this.checkCancelingEvent(tx, operation, EVENT_NAME_REVERSE_PAYMENT);
+          break;
+        case OperationKind.Confirming:
+          await this.checkConfirmingEvent(tx, operation);
+          break;
+        case OperationKind.Refunding:
+          await this.checkRefundingEvent(tx, operation);
+          break;
+      }
+
+      if (operation.newExtraAmount !== operation.oldExtraAmount) {
+        await expect(tx).to.emit(
+          this.cardPaymentProcessorShell.contract,
+          EVENT_NAME_PAYMENT_EXTRA_AMOUNT_CHANGED
+        ).withArgs(
+          checkEventField("authorizationId", operation.authorizationId),
+          checkEventField("account", operation.account.address),
+          checkEventField("sumAmount", operation.newBaseAmount + operation.newExtraAmount),
+          checkEventField("newExtraAmount", operation.newExtraAmount),
+          checkEventField("oldExtraAmount", operation.oldExtraAmount)
+        );
+      } else {
+        await expect(tx).not.to.emit(
+          this.cardPaymentProcessorShell.contract,
+          EVENT_NAME_PAYMENT_EXTRA_AMOUNT_CHANGED
+        );
+      }
+
+      if (operation.kind === OperationKind.Making && operation.cashbackEnabled) {
+        await expect(tx).to.emit(
+          this.cashbackDistributorMockShell.contract,
+          EVENT_NAME_SEND_CASHBACK_MOCK
+        ).withArgs(
+          checkEventField("sender", this.cardPaymentProcessorShell.contract.address),
+          checkEventField("token", this.tokenMock.address),
+          checkEventField("kind", CashbackKind.CardPayment),
+          checkEventField(
+            "externalId",
+            operation.authorizationId.padEnd(BYTES32_LENGTH * 2 + 2, "0")
+          ),
+          checkEventField("recipient", operation.account.address),
+          checkEventField("amount", operation.cashbackRequestedChange)
+        );
+        if (operation.cashbackSendingSucceeded) {
+          await expect(tx).to.emit(
+            this.cardPaymentProcessorShell.contract,
+            EVENT_NAME_SEND_CASHBACK_SUCCESS
+          ).withArgs(
+            checkEventField("cashbackDistributor", this.cashbackDistributorMockShell.contract.address),
+            checkEventField("amount", operation.cashbackActualChange),
+            checkEventField("nonce", operation.cashbackNonce)
+          );
+          await expect(tx).not.to.emit(
+            this.cardPaymentProcessorShell.contract,
+            EVENT_NAME_SEND_CASHBACK_FAILURE
+          );
+        } else {
+          await expect(tx).to.emit(
+            this.cardPaymentProcessorShell.contract,
+            EVENT_NAME_SEND_CASHBACK_FAILURE
+          ).withArgs(
+            checkEventField("cashbackDistributor", this.cashbackDistributorMockShell.contract.address),
+            checkEventField("amount", operation.cashbackRequestedChange),
+            checkEventField("nonce", operation.cashbackNonce)
+          );
+          await expect(tx).not.to.emit(
+            this.cardPaymentProcessorShell.contract,
+            EVENT_NAME_SEND_CASHBACK_SUCCESS
+          );
+        }
+      } else { // !(operation.kind === OperationKind.Making && operation.cashbackEnabled)
+        await expect(tx).not.to.emit(
+          this.cashbackDistributorMockShell.contract,
+          EVENT_NAME_SEND_CASHBACK_MOCK
+        );
+        await expect(tx).not.to.emit(
+          this.cardPaymentProcessorShell.contract,
+          EVENT_NAME_SEND_CASHBACK_SUCCESS
+        );
+        await expect(tx).not.to.emit(
+          this.cardPaymentProcessorShell.contract,
+          EVENT_NAME_SEND_CASHBACK_FAILURE
+        );
+      }
+
+      if (operation.cashbackRevocationRequested) {
+        await expect(tx).to.emit(
+          this.cashbackDistributorMockShell.contract,
+          EVENT_NAME_REVOKE_CASHBACK_MOCK
+        ).withArgs(
+          checkEventField("sender", this.cardPaymentProcessorShell.contract.address),
+          checkEventField("nonce", operation.cashbackNonce),
+          checkEventField("amount", -operation.cashbackRequestedChange),
+        );
+
+        if (operation.cashbackRevocationSuccess) {
+          await expect(tx).to.emit(
+            this.cardPaymentProcessorShell.contract,
+            EVENT_NAME_REVOKE_CASHBACK_SUCCESS
+          ).withArgs(
+            checkEventField("cashbackDistributor", this.cashbackDistributorMockShell.contract.address),
+            checkEventField("amount", -operation.cashbackActualChange),
+            checkEventField("nonce", operation.cashbackNonce)
+          );
+          await expect(tx).not.to.emit(
+            this.cardPaymentProcessorShell.contract,
+            EVENT_NAME_REVOKE_CASHBACK_FAILURE
+          );
+        } else { // !(operation.cashbackRevocationSuccess)
+          await expect(tx).to.emit(
+            this.cardPaymentProcessorShell.contract,
+            EVENT_NAME_REVOKE_CASHBACK_FAILURE
+          ).withArgs(
+            checkEventField("cashbackDistributor", this.cashbackDistributorMockShell.contract.address),
+            checkEventField("amount", -operation.cashbackRequestedChange),
+            checkEventField("nonce", operation.cashbackNonce)
+          );
+          await expect(tx).not.to.emit(
+            this.cardPaymentProcessorShell.contract,
+            EVENT_NAME_REVOKE_CASHBACK_SUCCESS
+          );
+        }
+
+        await expect(tx).not.to.emit(
+          this.cashbackDistributorMockShell.contract,
+          EVENT_NAME_INCREASE_CASHBACK_MOCK
+        );
+        await expect(tx).not.to.emit(
+          this.cardPaymentProcessorShell.contract,
+          EVENT_NAME_INCREASE_CASHBACK_SUCCESS
+        );
+        await expect(tx).not.to.emit(
+          this.cardPaymentProcessorShell.contract,
+          EVENT_NAME_INCREASE_CASHBACK_FAILURE
+        );
+      } else if (operation.cashbackIncreaseRequested) {
+        await expect(tx).to.emit(
+          this.cashbackDistributorMockShell.contract,
+          EVENT_NAME_INCREASE_CASHBACK_MOCK
+        ).withArgs(
+          checkEventField("sender", this.cardPaymentProcessorShell.contract.address),
+          checkEventField("nonce", operation.cashbackNonce),
+          checkEventField("amount", operation.cashbackRequestedChange),
+        );
+
+        if (operation.cashbackIncreaseSuccess) {
+          await expect(tx).to.emit(
+            this.cardPaymentProcessorShell.contract,
+            EVENT_NAME_INCREASE_CASHBACK_SUCCESS
+          ).withArgs(
+            checkEventField("cashbackDistributor", this.cashbackDistributorMockShell.contract.address),
+            checkEventField("amount", operation.cashbackActualChange),
+            checkEventField("nonce", operation.cashbackNonce)
+          );
+          await expect(tx).not.to.emit(
+            this.cardPaymentProcessorShell.contract,
+            EVENT_NAME_INCREASE_CASHBACK_FAILURE
+          );
+        } else { // !(operation.cashbackIncreaseSuccess)
+          await expect(tx).to.emit(
+            this.cardPaymentProcessorShell.contract,
+            EVENT_NAME_INCREASE_CASHBACK_FAILURE
+          ).withArgs(
+            checkEventField("cashbackDistributor", this.cashbackDistributorMockShell.contract.address),
+            checkEventField("amount", operation.cashbackRequestedChange),
+            checkEventField("nonce", operation.cashbackNonce)
+          );
+          await expect(tx).not.to.emit(
+            this.cardPaymentProcessorShell.contract,
+            EVENT_NAME_INCREASE_CASHBACK_SUCCESS
+          );
+        }
+
+        await expect(tx).not.to.emit(
+          this.cashbackDistributorMockShell.contract,
+          EVENT_NAME_REVOKE_CASHBACK_MOCK
+        );
+        await expect(tx).not.to.emit(
+          this.cardPaymentProcessorShell.contract,
+          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
+        );
+        await expect(tx).not.to.emit(
+          this.cardPaymentProcessorShell.contract,
+          EVENT_NAME_REVOKE_CASHBACK_FAILURE
+        );
+      } else {  // !(operation.cashbackIncreaseSuccess || operation.cashbackRevocationRequested)
+        await expect(tx).not.to.emit(
+          this.cashbackDistributorMockShell.contract,
+          EVENT_NAME_REVOKE_CASHBACK_MOCK
+        );
+        await expect(tx).not.to.emit(
+          this.cardPaymentProcessorShell.contract,
+          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
+        );
+        await expect(tx).not.to.emit(
+          this.cardPaymentProcessorShell.contract,
+          EVENT_NAME_REVOKE_CASHBACK_FAILURE
+        );
+
+        await expect(tx).not.to.emit(
+          this.cashbackDistributorMockShell.contract,
+          EVENT_NAME_INCREASE_CASHBACK_MOCK
+        );
+        await expect(tx).not.to.emit(
+          this.cardPaymentProcessorShell.contract,
+          EVENT_NAME_INCREASE_CASHBACK_SUCCESS
+        );
+        await expect(tx).not.to.emit(
+          this.cardPaymentProcessorShell.contract,
+          EVENT_NAME_INCREASE_CASHBACK_FAILURE
+        );
+      }
+    }
+
+    await this.checkBalanceChanges(tx, operations);
+  }
+
+  private async checkBalanceChanges(tx: Promise<TransactionResponse>, operations: PaymentOperation[]) {
+    const cardPaymentProcessorBalanceChange = operations
+      .map(operation => operation.cardPaymentProcessorBalanceChange)
+      .reduce((sum: number, currentValue: number) => sum + currentValue);
+    const cashbackDistributorBalanceChange = operations
+      .map(operation => -operation.cashbackActualChange)
+      .reduce((sum: number, currentValue: number) => sum + currentValue);
+    const cashOutAccountBalanceChange = operations
+      .map(operation => operation.cashOutAccountBalanceChange)
+      .reduce((sum: number, currentValue: number) => sum + currentValue);
+    const balanceChangePerUser: Map<SignerWithAddress, number> = this.#getBalanceChangePerAccount(operations);
+    const accounts: SignerWithAddress[] = Array.from(balanceChangePerUser.keys());
+    const accountBalanceChanges: number[] = accounts.map(user => balanceChangePerUser.get(user) ?? 0);
+
+
+    await expect(tx).to.changeTokenBalances(
+      this.tokenMock,
+      [
+        this.cardPaymentProcessorShell.contract,
+        this.cashbackDistributorMockShell.contract,
+        this.cashOutAccount,
+        ...accounts
+      ],
+      [
+        cardPaymentProcessorBalanceChange,
+        cashbackDistributorBalanceChange,
+        cashOutAccountBalanceChange,
+        ...accountBalanceChanges
+      ]
+    );
+  }
+
+  async checkCardPaymentProcessorState() {
+    await this.#checkPaymentStructures();
+    await this.#checkCashbacks();
+    await this.#checkClearedAndUnclearedBalances();
+    await this.#checkTokenBalance();
+  }
+
+  async setUpContractsForPayments(payments: TestPayment[] = this.payments) {
+    const accounts: Set<SignerWithAddress> = new Set(payments.map(payment => payment.account));
+    for (let account of accounts) {
+      await proveTx(this.tokenMock.mint(account.address, INITIAL_USER_BALANCE));
+      const allowance: BigNumber = await this.tokenMock.allowance(
+        account.address,
+        this.cardPaymentProcessorShell.contract.address
+      );
+      if (allowance.lt(MAX_UINT256)) {
+        await proveTx(
+          this.tokenMock.connect(account).approve(
+            this.cardPaymentProcessorShell.contract.address,
+            MAX_UINT256
+          )
+        );
+      }
+    }
+  }
+
+  async checkMakingEvent(tx: Promise<TransactionResponse>, operation: PaymentOperation) {
+    await expect(tx).to.emit(
+      this.cardPaymentProcessorShell.contract,
+      EVENT_NAME_MAKE_PAYMENT
+    ).withArgs(
+      checkEventField("authorizationId", operation.authorizationId),
+      checkEventField("correlationId", operation.correlationId),
+      checkEventField("account", operation.account.address),
+      checkEventField("sumAmount", operation.newBaseAmount + operation.newExtraAmount),
+      checkEventField("revocationCounter", operation.revocationCounter),
+      checkEventField("sender", operation.sender?.address)
+    );
+  }
+
+  async checkUpdatingEvent(tx: Promise<TransactionResponse>, operation: PaymentOperation) {
+    await expect(tx).to.emit(
+      this.cardPaymentProcessorShell.contract,
+      EVENT_NAME_UPDATE_PAYMENT_AMOUNT
+    ).withArgs(
+      checkEventField("authorizationId", operation.authorizationId),
+      checkEventField("correlationId", operation.correlationId),
+      checkEventField("account", operation.account.address),
+      checkEventField("oldSumAmount", operation.oldBaseAmount + operation.oldExtraAmount),
+      checkEventField("newSumAmount", operation.newBaseAmount + operation.newExtraAmount),
+    );
+  }
+
+  async checkClearingEvent(tx: Promise<TransactionResponse>, operation: PaymentOperation) {
+    await expect(tx).to.emit(
+      this.cardPaymentProcessorShell.contract,
+      EVENT_NAME_CLEAR_PAYMENT
+    ).withArgs(
+      checkEventField("authorizationId", operation.authorizationId),
+      checkEventField("account", operation.account.address),
+      checkEventField("totalAmount", operation.totalAmount),
+      checkEventField("clearedBalance", operation.clearedBalance),
+      checkEventField("unclearedBalance", operation.unclearedBalance),
+      checkEventField("revocationCounter", operation.revocationCounter)
+    );
+  }
+
+  async checkUnclearingEvent(tx: Promise<TransactionResponse>, operation: PaymentOperation) {
+    await expect(tx).to.emit(
+      this.cardPaymentProcessorShell.contract,
+      EVENT_NAME_UNCLEAR_PAYMENT
+    ).withArgs(
+      checkEventField("authorizationId", operation.authorizationId),
+      checkEventField("account", operation.account.address),
+      checkEventField("totalAmount", operation.totalAmount),
+      checkEventField("clearedBalance", operation.clearedBalance),
+      checkEventField("unclearedBalance", operation.unclearedBalance),
+      checkEventField("revocationCounter", operation.revocationCounter)
+    );
+  }
+
+  async checkCancelingEvent(tx: Promise<TransactionResponse>, operation: PaymentOperation, eventName: string) {
+    await expect(tx).to.emit(
+      this.cardPaymentProcessorShell.contract,
+      eventName
+    ).withArgs(
+      checkEventField("authorizationId", operation.authorizationId),
+      checkEventField("correlationId", operation.correlationId),
+      checkEventField("account", operation.account.address),
+      checkEventField("sentAmount", operation.userBalanceChange),
+      checkEventField("clearedBalance", operation.clearedBalance),
+      checkEventField("unclearedBalance", operation.unclearedBalance),
+      checkEventField("wasPaymentCleared", operation.paymentStatus === PaymentStatus.Cleared),
+      checkEventField("parentTransactionHash", operation.parentTransactionHash),
+      checkEventField("revocationCounter", operation.revocationCounter)
+    );
+  }
+
+  async checkConfirmingEvent(tx: Promise<TransactionResponse>, operation: PaymentOperation) {
+    await expect(tx).to.emit(
+      this.cardPaymentProcessorShell.contract,
+      EVENT_NAME_CONFIRM_PAYMENT
+    ).withArgs(
+      checkEventField("authorizationId", operation.authorizationId),
+      checkEventField("account", operation.account.address),
+      checkEventField("totalAmount", operation.totalAmount),
+      checkEventField("clearedBalance", operation.clearedBalance),
+      checkEventField("revocationCounter", operation.revocationCounter)
+    );
+  }
+
+  async checkRefundingEvent(tx: Promise<TransactionResponse>, operation: PaymentOperation) {
+    await expect(tx).to.emit(
+      this.cardPaymentProcessorShell.contract,
+      EVENT_NAME_REFUND_PAYMENT
+    ).withArgs(
+      checkEventField("authorizationId", operation.authorizationId),
+      checkEventField("correlationId", operation.correlationId),
+      checkEventField("account", operation.account.address),
+      checkEventField("refundAmount", operation.refundAmount),
+      checkEventField("sentAmount", operation.userBalanceChange),
+      checkEventField("status", operation.paymentStatus)
+    );
+  }
+
+  async #checkPaymentStructures() {
+    const expectedPayments: PaymentModel[] = this.cardPaymentProcessorShell.model.getPaymentModelsInMakingOrder();
+    const paymentNumber = expectedPayments.length;
+    const checkedAuthorizationIds: Set<string> = new Set();
+    for (let i = 0; i < paymentNumber; ++i) {
+      const expectedPayment: PaymentModel = expectedPayments[i];
+      if (checkedAuthorizationIds.has(expectedPayment.authorizationId)) {
+        continue;
+      }
+      checkedAuthorizationIds.add(expectedPayment.authorizationId);
+      const actualPayment = await this.cardPaymentProcessorShell.contract.paymentFor(expectedPayment.authorizationId);
+      this.#checkPaymentsEquality(actualPayment, expectedPayment, i);
+      if (expectedPayment.revocationParentTxHashes.length > 0) {
+        await this.#checkPaymentRevocationsByParentHashes(expectedPayment.revocationParentTxHashes);
+      }
+      if (expectedPayment.reversalParentTxHashes.length > 0) {
+        expect(expectedPayment.reversalParentTxHashes.length).to.lessThanOrEqual(
+          1,
+          `The reversal count of a payment with the authorization ID ${expectedPayment.authorizationId} is wrong`
+        );
+        await this.#checkPaymentReversalsByParentHashes(expectedPayment.reversalParentTxHashes);
+      }
+    }
+  }
+
+  #checkPaymentsEquality(actualOnChainPayment: any, expectedPayment: PaymentModel, paymentIndex: number) {
     expect(actualOnChainPayment.account).to.equal(
       expectedPayment.account.address,
-      `payment[${paymentIndex}].account is incorrect`
+      `payment[${paymentIndex}].account is wrong`
     );
-    expect(actualOnChainPayment.amount).to.equal(
-      expectedPayment.amount,
-      `payment[${paymentIndex}].amount is incorrect`
+    expect(actualOnChainPayment.baseAmount).to.equal(
+      expectedPayment.baseAmount,
+      `payment[${paymentIndex}].baseAmount is wrong`
+    );
+    expect(actualOnChainPayment.extraAmount).to.equal(
+      expectedPayment.extraAmount,
+      `payment[${paymentIndex}].extraAmount is wrong`
     );
     expect(actualOnChainPayment.status).to.equal(
       expectedPayment.status,
-      `payment[${paymentIndex}].status is incorrect`
+      `payment[${paymentIndex}].status is wrong`
     );
     expect(actualOnChainPayment.revocationCounter).to.equal(
-      expectedPayment.revocationCounter || 0,
-      `payment[${paymentIndex}].revocationCounter is incorrect`
+      expectedPayment.revocationParentTxHashes.length,
+      `payment[${paymentIndex}].revocationCounter is wrong`
     );
     expect(actualOnChainPayment.compensationAmount).to.equal(
-      (expectedPayment.compensationAmount || 0),
-      `payment[${paymentIndex}].compensationAmount is incorrect`
+      (expectedPayment.compensationAmount),
+      `payment[${paymentIndex}].compensationAmount is wrong`
     );
     expect(actualOnChainPayment.refundAmount).to.equal(
-      expectedPayment.refundAmount || 0,
-      `payment[${paymentIndex}].refundAmount is incorrect`
+      expectedPayment.refundAmount,
+      `payment[${paymentIndex}].refundAmount is wrong`
     );
     expect(actualOnChainPayment.cashbackRate).to.equal(
-      expectedPayment.cashbackRateInPermil || 0,
-      `payment[${paymentIndex}].cashbackRate is incorrect`
+      expectedPayment.cashbackRate,
+      `payment[${paymentIndex}].cashbackRate is wrong`
     );
+  }
+
+  async #checkPaymentRevocationsByParentHashes(revocationParentTxHashes: string[]) {
+    const revocationCount = revocationParentTxHashes.length;
+    for (let index = 0; index < revocationCount; ++index) {
+      const parentTxHash = revocationParentTxHashes[index];
+      expect(
+        await this.cardPaymentProcessorShell.contract.isPaymentRevoked(parentTxHash)
+      ).to.equal(
+        true,
+        `The result of the "isPaymentRevoked()" function is wrong for parentTxHash=${parentTxHash} and` +
+        `the revocation index is ${index}`
+      );
+    }
+  }
+
+  async #checkPaymentReversalsByParentHashes(reversalParentTxHashes: string[]) {
+    const reversalCount = reversalParentTxHashes.length;
+    for (let index = 0; index < reversalCount; ++index) {
+      const parentTxHash = reversalParentTxHashes[index];
+      expect(
+        await this.cardPaymentProcessorShell.contract.isPaymentReversed(parentTxHash)
+      ).to.equal(
+        true,
+        `The result of the "isPaymentReversed()" function is wrong for parentTxHash=${parentTxHash} and` +
+        `the reversal index is ${index}`
+      );
+    }
+  }
+
+  async #checkCashbacks() {
+    const authorizationIds: Set<string> = this.cardPaymentProcessorShell.model.getAuthorizationIds();
+    for (const authorizationId of authorizationIds) {
+      const expectedCashback = this.cardPaymentProcessorShell.model.getCashbackByAuthorizationId(authorizationId);
+      const actualCashback = await this.cardPaymentProcessorShell.contract.getCashback(authorizationId);
+      const note = `The last cashback nonce of a payment with authorizationId=${authorizationId} is wrong`;
+      if (!expectedCashback) {
+        expect(actualCashback.lastCashbackNonce).to.equal(ethers.constants.Zero, note);
+      } else {
+        expect(actualCashback.lastCashbackNonce).to.equal(expectedCashback.lastCashbackNonce, note);
+      }
+    }
+  }
+
+  async #checkClearedAndUnclearedBalances() {
+    const accountAddresses: Set<string> = this.cardPaymentProcessorShell.model.getAccountAddresses();
+
+    for (const account of accountAddresses) {
+      const expectedBalance = this.cardPaymentProcessorShell.model.getAccountUnclearedBalance(account);
+      const actualBalance = await this.cardPaymentProcessorShell.contract.unclearedBalanceOf(account);
+      expect(actualBalance).to.equal(
+        expectedBalance,
+        `The uncleared balance for account ${account} is wrong`
+      );
+    }
+
+    for (const account of accountAddresses) {
+      const expectedBalance = this.cardPaymentProcessorShell.model.getAccountClearedBalance(account);
+      const actualBalance = await this.cardPaymentProcessorShell.contract.clearedBalanceOf(account);
+      expect(actualBalance).to.equal(
+        expectedBalance,
+        `The cleared balance for account ${account} is wrong`
+      );
+    }
+
+    expect(await this.cardPaymentProcessorShell.contract.totalUnclearedBalance()).to.equal(
+      this.cardPaymentProcessorShell.model.totalUnclearedBalance,
+      `The total uncleared balance is wrong`
+    );
+
+    expect(await this.cardPaymentProcessorShell.contract.totalClearedBalance()).to.equal(
+      this.cardPaymentProcessorShell.model.totalClearedBalance,
+      `The total cleared balance is wrong`
+    );
+  }
+
+  async #checkTokenBalance() {
+    expect(
+      await this.tokenMock.balanceOf(this.cardPaymentProcessorShell.contract.address)
+    ).to.equal(
+      this.cardPaymentProcessorShell.model.totalBalance,
+      `The card payment processor token balance is wrong`
+    );
+  }
+
+  #getBalanceChangePerAccount(operations: PaymentOperation[]) {
+    const result: Map<SignerWithAddress, number> = new Map();
+    operations.forEach(operation => {
+      let balanceChange: number = result.get(operation.account) ?? 0;
+      balanceChange += operation.userBalanceChange;
+      result.set(operation.account, balanceChange);
+    });
+    return result;
   }
 }
 
@@ -125,30 +1565,6 @@ function increaseBytesString(bytesString: string, targetLength: number) {
     parseInt(bytesString.substring(2), 16) + 1,
     targetLength
   );
-}
-
-function calculateCashback(
-  payment: TestPayment,
-  cashbackRateInPermil = payment.cashbackRateInPermil || 0,
-  paymentAmount = payment.amount
-): number {
-  return Math.floor((paymentAmount - (payment.refundAmount || 0)) * cashbackRateInPermil / 1000);
-}
-
-function calculateInitialCashback(payment: TestPayment): number {
-  return Math.floor(payment.amount * (payment.cashbackRateInPermil || 0) / 1000);
-}
-
-function calculateRefundCashbackDifference(payment: TestPayment): number {
-  return calculateInitialCashback(payment) - calculateCashback(payment);
-}
-
-function calculateCompensationAmount(payment: TestPayment): number {
-  return (payment.refundAmount || 0) + calculateCashback(payment);
-}
-
-function calculateCashbackChangeIfNewPaymentAmount(payment: TestPayment, newPaymentAmount: number) {
-  return calculateCashback(payment, payment.cashbackRateInPermil, newPaymentAmount) - calculateCashback(payment);
 }
 
 async function setUpFixture(func: any) {
@@ -172,30 +1588,6 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   const MAX_CASHBACK_RATE_IN_PERMIL = 250; // 25%
   const CASHBACK_RATE_IN_PERMIL = 100; // 10%
   const CASHBACK_NONCE = 111222333;
-
-  const EVENT_NAME_CONFIRM_PAYMENT = "ConfirmPayment";
-  const EVENT_NAME_CLEAR_PAYMENT = "ClearPayment";
-  const EVENT_NAME_ENABLE_CASHBACK = "EnableCashback";
-  const EVENT_NAME_DISABLE_CASHBACK = "DisableCashback";
-  const EVENT_NAME_INCREASE_CASHBACK_FAILURE = "IncreaseCashbackFailure";
-  const EVENT_NAME_INCREASE_CASHBACK_MOCK = "IncreaseCashbackMock";
-  const EVENT_NAME_INCREASE_CASHBACK_SUCCESS = "IncreaseCashbackSuccess";
-  const EVENT_NAME_MAKE_PAYMENT = "MakePayment";
-  const EVENT_NAME_REFUND_PAYMENT = "RefundPayment";
-  const EVENT_NAME_REVERSE_PAYMENT = "ReversePayment";
-  const EVENT_NAME_REVOKE_CASHBACK_FAILURE = "RevokeCashbackFailure";
-  const EVENT_NAME_REVOKE_CASHBACK_MOCK = "RevokeCashbackMock";
-  const EVENT_NAME_REVOKE_CASHBACK_SUCCESS = "RevokeCashbackSuccess";
-  const EVENT_NAME_REVOKE_PAYMENT = "RevokePayment";
-  const EVENT_NAME_SEND_CASHBACK_FAILURE = "SendCashbackFailure";
-  const EVENT_NAME_SEND_CASHBACK_MOCK = "SendCashbackMock";
-  const EVENT_NAME_SEND_CASHBACK_SUCCESS = "SendCashbackSuccess";
-  const EVENT_NAME_SET_CASH_OUT_ACCOUNT = "SetCashOutAccount";
-  const EVENT_NAME_SET_CASHBACK_DISTRIBUTOR = "SetCashbackDistributor";
-  const EVENT_NAME_SET_CASHBACK_RATE = "SetCashbackRate";
-  const EVENT_NAME_SET_REVOCATION_LIMIT = "SetRevocationLimit";
-  const EVENT_NAME_UNCLEAR_PAYMENT = "UnclearPayment";
-  const EVENT_NAME_UPDATE_PAYMENT_AMOUNT = "UpdatePaymentAmount";
 
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
   const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
@@ -223,7 +1615,8 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   const REVERT_ERROR_IF_CASHBACK_ALREADY_DISABLED = "CashbackAlreadyDisabled";
   const REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO = "ZeroCashOutAccount";
   const REVERT_ERROR_IF_REFUND_AMOUNT_IS_INAPPROPRIATE = "InappropriateRefundAmount";
-  const REVERT_ERROR_IF_NEW_PAYMENT_AMOUNT_IS_INAPPROPRIATE = "InappropriateNewPaymentAmount";
+  const REVERT_ERROR_IF_NEW_BASE_PAYMENT_AMOUNT_IS_INAPPROPRIATE = "InappropriateNewBasPaymentAmount";
+  const REVERT_ERROR_IF_NEW_EXTRA_PAYMENT_AMOUNT_IS_INAPPROPRIATE = "InappropriateNewExtraPaymentAmount";
 
   const ownerRole: string = ethers.utils.id("OWNER_ROLE");
   const blacklisterRole: string = ethers.utils.id("BLACKLISTER_ROLE");
@@ -327,246 +1720,43 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     };
   }
 
-  async function setUpContractsForPayments(fixture: Fixture, payments: TestPayment[]) {
-    const { tokenMock, cardPaymentProcessor } = fixture;
-    for (let payment of payments) {
-      await proveTx(tokenMock.mint(payment.account.address, payment.amount));
-      const allowance: BigNumber = await tokenMock.allowance(payment.account.address, cardPaymentProcessor.address);
-      if (allowance.lt(MAX_UINT256)) {
-        await proveTx(
-          tokenMock.connect(payment.account).approve(
-            cardPaymentProcessor.address,
-            MAX_UINT256
-          )
-        );
-      }
-    }
-  }
-
-  function setCashbackNonce(payment: TestPayment, fixture: Fixture) {
-    payment.cashbackNonce = fixture.cashbackDistributorMockConfig.sendCashbackNonceResult;
-  }
-
-  function setCashback(
-    payment: TestPayment,
-    fixture: Fixture,
-    newCashbackRateInPermil: number = CASHBACK_RATE_IN_PERMIL
-  ) {
-    payment.cashbackRateInPermil = newCashbackRateInPermil;
-    payment.compensationAmount = calculateCompensationAmount(payment);
-    setCashbackNonce(payment, fixture);
-  }
-
-  function setRefundAmount(payment: TestPayment, newRefundAmount: number) {
-    payment.refundAmount = newRefundAmount;
-    payment.compensationAmount = calculateCompensationAmount(payment);
-  }
-
-  function setNewAmount(payment: TestPayment, newAmount: number, isCashbackIncreasingFails: boolean = false) {
-    payment.amount = newAmount;
-    if (!isCashbackIncreasingFails) {
-      payment.compensationAmount = calculateCompensationAmount(payment);
-    }
-  }
-
   async function pauseContract(contract: Contract) {
     await proveTx(contract.grantRole(pauserRole, deployer.address));
     await proveTx(contract.pause());
   }
 
-  async function makePayments(cardPaymentProcessor: Contract, payments: TestPayment[]) {
-    for (let payment of payments) {
-      await proveTx(
-        cardPaymentProcessor.connect(payment.account).makePayment(
-          payment.amount,
-          payment.authorizationId,
-          payment.correlationId,
-        )
-      );
-      payment.status = PaymentStatus.Uncleared;
-      if (!!payment.revocationCounter) {
-        payment.parentTxHash = increaseBytesString(payment.parentTxHash, BYTES32_LENGTH);
-      }
+  function createTestPayments(numberOfPayments: number = 1): TestPayment[] {
+    const testPayments: TestPayment[] = [];
+    for (let i = 0; i < numberOfPayments; ++i) {
+      const payment: TestPayment = {
+        account: (i % 2 > 0) ? user1 : user2,
+        baseAmount: 235 + i * 235,
+        extraAmount: 235 + i * 235,
+        authorizationId: createBytesString(123 + i * 123, BYTES16_LENGTH),
+        correlationId: createBytesString(345 + i * 345, BYTES16_LENGTH),
+        parentTxHash: createBytesString(1 + i, BYTES32_LENGTH),
+      };
+      testPayments.push(payment);
     }
+    return testPayments;
   }
 
-  async function clearPayments(cardPaymentProcessor: Contract, payments: TestPayment[]) {
-    const authorizationIds: string[] = [];
-    payments.forEach((payment: TestPayment) => {
-      authorizationIds.push(payment.authorizationId);
-      payment.status = PaymentStatus.Cleared;
-    });
-    await proveTx(cardPaymentProcessor.connect(executor).clearPayments(authorizationIds));
-  }
-
-  async function unclearPayments(cardPaymentProcessor: Contract, payments: TestPayment[]) {
-    const authorizationIds: string[] = [];
-    payments.forEach((payment: TestPayment) => {
-      authorizationIds.push(payment.authorizationId);
-      payment.status = PaymentStatus.Uncleared;
-    });
-    await proveTx(cardPaymentProcessor.connect(executor).unclearPayments(authorizationIds));
-  }
-
-  async function confirmPayments(cardPaymentProcessor: Contract, payments: TestPayment[]) {
-    const authorizationIds: string[] = [];
-    payments.forEach((payment: TestPayment) => {
-      authorizationIds.push(payment.authorizationId);
-      payment.status = PaymentStatus.Confirmed;
-    });
-    await proveTx(cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds));
-  }
-
-  async function checkPaymentStructures(cardPaymentProcessor: Contract, payments: TestPayment[]) {
-    for (let i = 0; i < payments.length; ++i) {
-      const expectedPayment: TestPayment = payments[i];
-      const actualPayment = await cardPaymentProcessor.paymentFor(expectedPayment.authorizationId);
-      checkEquality(actualPayment, expectedPayment, i);
-      if (!!expectedPayment.parentTxHash) {
-        expect(
-          await cardPaymentProcessor.isPaymentReversed(expectedPayment.parentTxHash)
-        ).to.equal(
-          expectedPayment.status == PaymentStatus.Reversed,
-          `The reversing status of payment[${i}] is wrong`
-        );
-        expect(
-          await cardPaymentProcessor.isPaymentRevoked(expectedPayment.parentTxHash)
-        ).to.equal(
-          expectedPayment.status == PaymentStatus.Revoked,
-          `The revoking status of payment[${i}] is wrong`
-        );
-      }
-    }
-  }
-
-  async function checkCashbackNonces(cardPaymentProcessor: Contract, payments: TestPayment[]) {
-    for (let i = 0; i < payments.length; ++i) {
-      const payment: TestPayment = payments[i];
-      const expectedNonce: BigNumber = payment.status != PaymentStatus.Nonexistent
-        ? BigNumber.from(payment.cashbackNonce || 0)
-        : ethers.constants.Zero;
-      const cashback = await cardPaymentProcessor.getCashback(payment.authorizationId);
-      expect(cashback.lastCashbackNonce).to.equal(expectedNonce);
-    }
-  }
-
-  async function checkClearedAndUnclearedBalances(cardPaymentProcessor: Contract, payments: TestPayment[]) {
-    const expectedBalancesPerAccount: Map<string, { unclearedBalance: number, clearedBalance: number, }> = new Map();
-    let expectedTotalUnclearedBalance = 0;
-    let expectedTotalClearedBalance = 0;
-
-    payments.forEach((payment: TestPayment) => {
-      const address: string = payment.account.address;
-      let newBalances = expectedBalancesPerAccount.get(address) || { unclearedBalance: 0, clearedBalance: 0 };
-      const amount = payment.amount - (payment.refundAmount || 0);
-      if (payment.status == PaymentStatus.Uncleared) {
-        newBalances.unclearedBalance += amount;
-        expectedTotalUnclearedBalance += amount;
-      } else if (payment.status == PaymentStatus.Cleared) {
-        newBalances.clearedBalance += amount;
-        expectedTotalClearedBalance += amount;
-      }
-      expectedBalancesPerAccount.set(address, newBalances);
-    });
-
-    for (const account of expectedBalancesPerAccount.keys()) {
-      const expectedBalances = expectedBalancesPerAccount.get(account);
-      if (!expectedBalances) {
-        continue;
-      }
-      expect(
-        await cardPaymentProcessor.clearedBalanceOf(account)
-      ).to.equal(
-        expectedBalances.clearedBalance,
-        `The cleared balance for account ${account} is wrong`
-      );
-      expect(
-        await cardPaymentProcessor.unclearedBalanceOf(account)
-      ).to.equal(
-        expectedBalances.unclearedBalance,
-        `The uncleared balance for account ${account} is wrong`
-      );
-    }
-    expect(
-      await cardPaymentProcessor.totalUnclearedBalance()
-    ).to.equal(
-      expectedTotalUnclearedBalance,
-      `The total uncleared balance is wrong`
-    );
-
-    expect(
-      await cardPaymentProcessor.totalClearedBalance()
-    ).to.equal(
-      expectedTotalClearedBalance,
-      `The total cleared balance is wrong`
-    );
-  }
-
-  async function checkTokenBalance(fixture: Fixture, payments: TestPayment[]) {
-    const { cardPaymentProcessor, tokenMock } = fixture;
-    const expectedTokenBalance: number = countNumberArrayTotal(
-      payments.map(
-        function (payment: TestPayment): number {
-          if (payment.status == PaymentStatus.Uncleared || payment.status == PaymentStatus.Cleared) {
-            return payment.amount - (payment.refundAmount || 0) + (payment.unrevokedCashback || 0);
-          } else {
-            return (payment.unrevokedCashback || 0);
-          }
-        }
-      )
-    );
-    expect(
-      await tokenMock.balanceOf(cardPaymentProcessor.address)
-    ).to.equal(
-      expectedTokenBalance,
-      `The processor token balance is wrong`
-    );
-  }
-
-  async function checkCardPaymentProcessorState(fixture: Fixture, payments: TestPayment[]) {
-    await checkPaymentStructures(fixture.cardPaymentProcessor, payments);
-    await checkCashbackNonces(fixture.cardPaymentProcessor, payments);
-    await checkClearedAndUnclearedBalances(fixture.cardPaymentProcessor, payments);
-    await checkTokenBalance(fixture, payments);
-  }
-
-  function createTestPayments(): TestPayment[] {
-    return [
-      {
-        authorizationId: createBytesString(123, BYTES16_LENGTH),
-        account: user1,
-        amount: 234,
-        status: PaymentStatus.Nonexistent,
-        correlationId: createBytesString(345, BYTES16_LENGTH),
-        parentTxHash: createBytesString("aaa1", BYTES32_LENGTH),
-        compensationAmount: 0,
-        refundAmount: 0,
-      },
-      {
-        authorizationId: createBytesString(456, BYTES16_LENGTH),
-        account: user2,
-        amount: 567,
-        status: PaymentStatus.Nonexistent,
-        correlationId: createBytesString(789, BYTES16_LENGTH),
-        parentTxHash: createBytesString("aaa2", BYTES32_LENGTH),
-        compensationAmount: 0,
-        refundAmount: 0,
-      },
-    ];
-  }
-
-  async function prepareForSinglePayment(): Promise<{ fixture: Fixture, payment: TestPayment }> {
+  async function prepareForPayments(props: { paymentNumber: number } = { paymentNumber: 1 }): Promise<TestContext> {
     const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
-    const [payment] = createTestPayments();
-
-    return { fixture, payment };
+    const payments = createTestPayments(props.paymentNumber);
+    return new TestContext({
+      fixture,
+      cashbackRateInPermil: CASHBACK_RATE_IN_PERMIL,
+      cashOutAccount,
+      cardPaymentProcessorExecutor: executor,
+      payments,
+    });
   }
 
-  async function beforeMakingPayment(): Promise<{ fixture: Fixture, payment: TestPayment }> {
-    const { fixture, payment } = await prepareForSinglePayment();
-    await setUpContractsForPayments(fixture, [payment]);
-
-    return { fixture, payment };
+  async function beforeMakingPayments(props: { paymentNumber: number } = { paymentNumber: 1 }): Promise<TestContext> {
+    const context = await prepareForPayments(props);
+    await context.setUpContractsForPayments();
+    return context;
   }
 
   describe("Function 'initialize()'", async () => {
@@ -577,7 +1767,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       expect(await cardPaymentProcessor.underlyingToken()).to.equal(tokenMock.address);
 
       // The revocation limit
-      expect(await cardPaymentProcessor.revocationLimit()).to.equal(255);
+      expect(await cardPaymentProcessor.revocationLimit()).to.equal(REVOCATION_LIMIT_DEFAULT_VALUE);
 
       // The admins of roles
       expect(await cardPaymentProcessor.getRoleAdmin(ownerRole)).to.equal(ownerRole);
@@ -873,69 +2063,37 @@ describe("Contract 'CardPaymentProcessor'", async () => {
      * the main checks of the functions are provided in the section for the 'makePaymentFrom()' function.
      * In this section, only specific checks for the 'makePayment()' function are provided.
      */
-    describe("Executes as expected if the cashback is enabled and the payment amount is", async () => {
-      it("Nonzero", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
-        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
-        await proveTx(fixture.cardPaymentProcessor.enableCashback());
-        setCashback(payment, fixture);
-        const cashbackAmount: number = calculateCashback(payment);
+    describe("Executes as expected if the cashback is enabled and the base and extra payment amounts are", async () => {
+      it("Both nonzero", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-        await checkCardPaymentProcessorState(fixture, [payment]);
+        await cardPaymentProcessorShell.enableCashback();
 
-        const tx: TransactionResponse = await cardPaymentProcessor.connect(payment.account).makePayment(
-          payment.amount,
+        cardPaymentProcessorShell.model.makePayment(context.payments[0], context.payments[0].account);
+        const tx = cardPaymentProcessorShell.contract.connect(payment.account).functions[FUNCTION_MAKE_PAYMENT](
+          payment.baseAmount,
+          payment.extraAmount,
           payment.authorizationId,
           payment.correlationId
         );
-        await expect(tx).to.changeTokenBalances(
-          tokenMock,
-          [cardPaymentProcessor, payment.account, cashbackDistributorMock],
-          [+payment.amount, -payment.amount + cashbackAmount, -cashbackAmount]
-        ).and.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_MAKE_PAYMENT
-        ).withArgs(
-          payment.authorizationId,
-          payment.correlationId,
-          payment.account.address,
-          payment.amount,
-          payment.revocationCounter || 0,
-          payment.account.address
-        );
-        await expect(tx).and.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_SEND_CASHBACK_SUCCESS
-        ).withArgs(
-          cashbackDistributorMock.address,
-          cashbackAmount,
-          payment.cashbackNonce || 0
-        );
-        await expect(tx).to.emit(
-          cashbackDistributorMock,
-          EVENT_NAME_SEND_CASHBACK_MOCK
-        ).withArgs(
-          cardPaymentProcessor.address,
-          tokenMock.address,
-          CashbackKind.CardPayment,
-          payment.authorizationId.padEnd(BYTES32_LENGTH * 2 + 2, "0"),
-          payment.account.address,
-          cashbackAmount
-        );
-
-        payment.status = PaymentStatus.Uncleared;
-        await checkCardPaymentProcessorState(fixture, [payment]);
+        expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
+        await context.checkPaymentOperationsForTx(tx);
+        await context.checkCardPaymentProcessorState();
       });
     });
 
     describe("Is reverted if", async () => {
       it("The contract is paused", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-        await pauseContract(cardPaymentProcessor);
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+        await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessor.connect(payment.account).makePayment(
-            payment.amount,
+          cardPaymentProcessorShell.contract.connect(payment.account).functions[FUNCTION_MAKE_PAYMENT](
+            payment.baseAmount,
+            payment.extraAmount,
             payment.authorizationId,
             payment.correlationId
           )
@@ -943,224 +2101,141 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       });
 
       it("The caller is blacklisted", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-        await proveTx(cardPaymentProcessor.grantRole(blacklisterRole, deployer.address));
-        await proveTx(cardPaymentProcessor.blacklist(payment.account.address));
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+        await proveTx(cardPaymentProcessorShell.contract.grantRole(blacklisterRole, deployer.address));
+        await proveTx(cardPaymentProcessorShell.contract.blacklist(payment.account.address));
 
         await expect(
-          cardPaymentProcessor.connect(payment.account).makePayment(
-            payment.amount,
+          cardPaymentProcessorShell.contract.connect(payment.account).functions[FUNCTION_MAKE_PAYMENT](
+            payment.baseAmount,
+            payment.extraAmount,
             payment.authorizationId,
             payment.correlationId
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
+        ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
       });
     });
   });
 
   describe("Function 'makePaymentFrom()'", async () => {
-    enum CashbackSendingConditions {
-      Success = 0,
-      PartialWithNonZeroAmount = 1,
-      PartialWithZeroAmount = 2,
-    }
 
-    async function checkPaymentMakingFromWithCashback(
-      fixture: Fixture,
-      payment: TestPayment,
-      cashbackSendingConditions: CashbackSendingConditions
-    ) {
-      const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
-      await proveTx(fixture.cardPaymentProcessor.enableCashback());
-      setCashback(payment, fixture);
-      const requestedCashbackAmount: number = calculateCashback(payment);
-      let sentCashbackAmount = requestedCashbackAmount;
-      if (cashbackSendingConditions === CashbackSendingConditions.PartialWithZeroAmount) {
-        sentCashbackAmount = 0;
-        await proveTx(fixture.cashbackDistributorMock.setSendCashbackAmountResult(sentCashbackAmount));
-        payment.compensationAmount = sentCashbackAmount;
-      } else if (cashbackSendingConditions === CashbackSendingConditions.PartialWithNonZeroAmount) {
-        sentCashbackAmount = 1;
-        await proveTx(fixture.cashbackDistributorMock.setSendCashbackAmountResult(sentCashbackAmount));
-        payment.compensationAmount = sentCashbackAmount;
-      }
+    async function checkPaymentMakingFromWithCashback(context: TestContext) {
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-      await checkCardPaymentProcessorState(fixture, [payment]);
+      await cardPaymentProcessorShell.enableCashback();
 
-      const tx: TransactionResponse = await cardPaymentProcessor.connect(executor).makePaymentFrom(
+      cardPaymentProcessorShell.model.makePayment(payment, executor);
+      const tx = cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_MAKE_PAYMENT_FROM](
         payment.account.address,
-        payment.amount,
+        payment.baseAmount,
+        payment.extraAmount,
         payment.authorizationId,
         payment.correlationId
       );
-      await expect(tx).to.changeTokenBalances(
-        tokenMock,
-        [cardPaymentProcessor, payment.account, executor, cashbackDistributorMock],
-        [+payment.amount, -payment.amount + sentCashbackAmount, 0, -sentCashbackAmount]
-      ).and.to.emit(
-        cardPaymentProcessor,
-        EVENT_NAME_MAKE_PAYMENT
-      ).withArgs(
-        payment.authorizationId,
-        payment.correlationId,
-        payment.account.address,
-        payment.amount,
-        payment.revocationCounter || 0,
-        executor.address
-      );
-      await expect(tx).to.emit(
-        cardPaymentProcessor,
-        EVENT_NAME_SEND_CASHBACK_SUCCESS
-      ).withArgs(
-        cashbackDistributorMock.address,
-        sentCashbackAmount,
-        payment.cashbackNonce || 0
-      );
-      await expect(tx).to.emit(
-        cashbackDistributorMock,
-        EVENT_NAME_SEND_CASHBACK_MOCK
-      ).withArgs(
-        cardPaymentProcessor.address,
-        tokenMock.address,
-        CashbackKind.CardPayment,
-        payment.authorizationId.padEnd(BYTES32_LENGTH * 2 + 2, "0"),
-        payment.account.address,
-        requestedCashbackAmount
-      );
-
-      payment.status = PaymentStatus.Uncleared;
-      await checkCardPaymentProcessorState(fixture, [payment]);
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
+      await context.checkPaymentOperationsForTx(tx);
+      await context.checkCardPaymentProcessorState();
     }
 
-    describe("Executes as expected if the cashback is enabled and the payment amount is", async () => {
-      it("Nonzero", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
-        await checkPaymentMakingFromWithCashback(fixture, payment, CashbackSendingConditions.Success);
+    describe("Executes as expected if the cashback is enabled and the base and extra payment amounts are", async () => {
+      it("Both nonzero", async () => {
+        const context = await beforeMakingPayments();
+        await checkPaymentMakingFromWithCashback(context);
       });
 
-      it("Zero", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
-        payment.amount = 0;
-        payment.compensationAmount = calculateCompensationAmount(payment);
-        await checkPaymentMakingFromWithCashback(fixture, payment, CashbackSendingConditions.Success);
+      it("Both zero", async () => {
+        const context = await beforeMakingPayments();
+        context.payments[0].baseAmount = 0;
+        context.payments[0].extraAmount = 0;
+        await checkPaymentMakingFromWithCashback(context);
       });
 
-      it("Nonzero even if the revocation limit of payments is zero", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
-        await proveTx(fixture.cardPaymentProcessor.setRevocationLimit(0));
-        await checkPaymentMakingFromWithCashback(fixture, payment, CashbackSendingConditions.Success);
+      it("Different: base is zero, extra is nonzero", async () => {
+        const context = await beforeMakingPayments();
+        context.payments[0].baseAmount = 0;
+        await checkPaymentMakingFromWithCashback(context);
       });
 
-      it("Nonzero and if cashback is partially sent with non-zero amount", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
+      it("Different: base is nonzero, extra is zero", async () => {
+        const context = await beforeMakingPayments();
+        context.payments[0].extraAmount = 0;
+        await checkPaymentMakingFromWithCashback(context);
+      });
+
+      it("Both nonzero even if the revocation limit of payments is zero", async () => {
+        const context = await beforeMakingPayments();
+        await proveTx(context.cardPaymentProcessorShell.contract.setRevocationLimit(0));
+        await checkPaymentMakingFromWithCashback(context);
+      });
+
+      it("Both nonzero and if cashback is partially sent with non-zero amount", async () => {
+        const context = await beforeMakingPayments();
         const sentCashbackAmount = 1;
-        await proveTx(fixture.cashbackDistributorMock.setSendCashbackAmountResult(sentCashbackAmount));
-        await checkPaymentMakingFromWithCashback(fixture, payment, CashbackSendingConditions.PartialWithNonZeroAmount);
+        await context.cashbackDistributorMockShell.setSendCashbackAmountResult(sentCashbackAmount);
+        await checkPaymentMakingFromWithCashback(context);
       });
 
       it("Nonzero and if cashback is partially sent with zero amount", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
+        const context = await beforeMakingPayments();
         const sentCashbackAmount = 0;
-        await proveTx(fixture.cashbackDistributorMock.setSendCashbackAmountResult(sentCashbackAmount));
-        await checkPaymentMakingFromWithCashback(fixture, payment, CashbackSendingConditions.PartialWithZeroAmount);
+        await context.cashbackDistributorMockShell.setSendCashbackAmountResult(sentCashbackAmount);
+        await checkPaymentMakingFromWithCashback(context);
       });
     });
 
-    describe("Executes successfully if the payment amount is nonzero but does not send cashback if", async () => {
+    describe("Executes as expected if if the payment base and extra amounts are nonzero and", async () => {
       it("Cashback is disabled", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
-        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-        await expect(
-          cardPaymentProcessor.connect(executor).makePaymentFrom(
-            payment.account.address,
-            payment.amount,
-            payment.authorizationId,
-            payment.correlationId
-          )
-        ).to.changeTokenBalances(
-          tokenMock,
-          [cardPaymentProcessor, payment.account, cashbackDistributorMock],
-          [+payment.amount, -payment.amount, 0]
-        ).and.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_MAKE_PAYMENT
-        ).and.not.to.emit(
-          cashbackDistributorMock,
-          EVENT_NAME_SEND_CASHBACK_MOCK
-        );
-
-        payment.status = PaymentStatus.Uncleared;
-        await checkCardPaymentProcessorState(fixture, [payment]);
-      });
-
-      it("Cashback sending fails", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
-        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
-        await proveTx(cashbackDistributorMock.setSendCashbackSuccessResult(false));
-        await proveTx(cardPaymentProcessor.enableCashback());
-
-        const cashbackAmount: number = calculateCashback(payment, CASHBACK_RATE_IN_PERMIL);
-        setCashbackNonce(payment, fixture);
-
-        const tx: TransactionResponse = await cardPaymentProcessor.connect(executor).makePaymentFrom(
+        cardPaymentProcessorShell.model.makePayment(payment, executor);
+        const tx = cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_MAKE_PAYMENT_FROM](
           payment.account.address,
-          payment.amount,
+          payment.baseAmount,
+          payment.extraAmount,
           payment.authorizationId,
           payment.correlationId
         );
-        await expect(tx).to.changeTokenBalances(
-          tokenMock,
-          [cardPaymentProcessor, payment.account, cashbackDistributorMock],
-          [+payment.amount, -payment.amount, 0]
-        ).and.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_MAKE_PAYMENT
-        ).withArgs(
-          payment.authorizationId,
-          payment.correlationId,
-          payment.account.address,
-          payment.amount,
-          payment.revocationCounter || 0,
-          executor.address
-        ).and.not.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_SEND_CASHBACK_SUCCESS
-        );
-        await expect(tx).to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_SEND_CASHBACK_FAILURE
-        ).withArgs(
-          cashbackDistributorMock.address,
-          cashbackAmount,
-          payment.cashbackNonce || 0
-        );
-        await expect(tx).to.emit(
-          cashbackDistributorMock,
-          EVENT_NAME_SEND_CASHBACK_MOCK
-        ).withArgs(
-          cardPaymentProcessor.address,
-          tokenMock.address,
-          CashbackKind.CardPayment,
-          payment.authorizationId.padEnd(BYTES32_LENGTH * 2 + 2, "0"),
-          payment.account.address,
-          cashbackAmount,
-        );
+        expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
+        await context.checkPaymentOperationsForTx(tx);
+        await context.checkCardPaymentProcessorState();
+      });
 
-        payment.status = PaymentStatus.Uncleared;
-        await checkCardPaymentProcessorState(fixture, [payment]);
+      it("Cashback sending fails", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, cashbackDistributorMockShell, payments: [payment] } = context;
+
+        await cashbackDistributorMockShell.setSendCashbackSuccessResult(false);
+        await cardPaymentProcessorShell.enableCashback();
+
+        cardPaymentProcessorShell.model.makePayment(payment, executor);
+        const tx = cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_MAKE_PAYMENT_FROM](
+          payment.account.address,
+          payment.baseAmount,
+          payment.extraAmount,
+          payment.authorizationId,
+          payment.correlationId
+        );
+        expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
+        await context.checkPaymentOperationsForTx(tx);
+        await context.checkCardPaymentProcessorState();
       });
     });
 
     describe("Is reverted if", async () => {
       it("The contract is paused", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-        await pauseContract(cardPaymentProcessor);
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+        await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessor.connect(executor).makePaymentFrom(
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_MAKE_PAYMENT_FROM](
             payment.account.address,
-            payment.amount,
+            payment.baseAmount,
+            payment.extraAmount,
             payment.authorizationId,
             payment.correlationId
           )
@@ -1168,11 +2243,14 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       });
 
       it("The caller does not have the executor role", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(payment.account).makePaymentFrom(
+          cardPaymentProcessorShell.contract.connect(payment.account).functions[FUNCTION_MAKE_PAYMENT_FROM](
             payment.account.address,
-            payment.amount,
+            payment.baseAmount,
+            payment.extraAmount,
             payment.authorizationId,
             payment.correlationId
           )
@@ -1180,37 +2258,49 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       });
 
       it("The payment account address is zero", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(executor).makePaymentFrom(
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_MAKE_PAYMENT_FROM](
             ZERO_ADDRESS,
-            payment.amount,
+            payment.baseAmount,
+            payment.extraAmount,
             payment.authorizationId,
             payment.correlationId
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ACCOUNT_IS_ZERO);
+        ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_ACCOUNT_IS_ZERO);
       });
 
       it("The payment authorization ID is zero", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(executor).makePaymentFrom(
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_MAKE_PAYMENT_FROM](
             payment.account.address,
-            payment.amount,
+            payment.baseAmount,
+            payment.extraAmount,
             ZERO_AUTHORIZATION_ID,
             payment.correlationId
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+        ).to.be.revertedWithCustomError(
+          cardPaymentProcessorShell.contract,
+          REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
+        );
       });
 
       it("The account has not enough token balance", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
-        const excessTokenAmount: number = payment.amount + 1;
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+        const excessTokenAmount: number = INITIAL_USER_BALANCE + 1;
 
         await expect(
-          cardPaymentProcessor.connect(executor).makePaymentFrom(
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_MAKE_PAYMENT_FROM](
             payment.account.address,
             excessTokenAmount,
+            payment.extraAmount,
             payment.authorizationId,
             payment.correlationId
           )
@@ -1218,30 +2308,40 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       });
 
       it("The payment with the provided authorization ID already exists", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
-        await makePayments(cardPaymentProcessor, [payment]);
-        const otherMakingPaymentCorrelationsId: string = increaseBytesString(
-          payment.correlationId,
-          BYTES16_LENGTH
-        );
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+        await cardPaymentProcessorShell.makePayments([payment]);
+
+        const anotherCorrelationId: string = increaseBytesString(payment.correlationId, BYTES16_LENGTH);
 
         await expect(
-          cardPaymentProcessor.connect(executor).makePaymentFrom(
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_MAKE_PAYMENT_FROM](
             payment.account.address,
-            payment.amount,
+            payment.baseAmount,
+            payment.extraAmount,
             payment.authorizationId,
-            otherMakingPaymentCorrelationsId
+            anotherCorrelationId
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
+        ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
       });
     });
   });
 
   describe("Function 'updatePaymentAmount()'", async () => {
-    enum NewPaymentAmountType {
+    enum NewBasePaymentAmountType {
       Same = 0,
       Less = 1,
-      More = 2
+      More = 2,
+    }
+
+    enum NewExtraPaymentAmountType {
+      Same = 0,
+      FarLess = 1,
+      FarMore = 2,
+      SlightlyLess = 3,
+      SlightlyMore = 4,
+      Zero = 5,
     }
 
     enum UpdatingConditionType {
@@ -1253,229 +2353,284 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       CashbackEnabledButIncreasingPartial = 5,
     }
 
-    async function checkUpdating(newPaymentAmountType: NewPaymentAmountType, updatingCondition: UpdatingConditionType) {
-      const { fixture, payment } = await beforeMakingPayment();
-      const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
+    async function checkUpdating(
+      newBasePaymentAmountType: NewBasePaymentAmountType,
+      newExtraPaymentAmountType: NewExtraPaymentAmountType,
+      updatingCondition: UpdatingConditionType
+    ) {
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+      payment.baseAmount = 1234;
+      payment.extraAmount = 1234;
+
       if (updatingCondition !== UpdatingConditionType.CashbackDisabledBeforePaymentMaking) {
-        setCashback(payment, fixture);
-        await proveTx(fixture.cardPaymentProcessor.enableCashback());
+        await cardPaymentProcessorShell.enableCashback();
       }
-      await makePayments(cardPaymentProcessor, [payment]);
+      await cardPaymentProcessorShell.makePayments([payment]);
       if (updatingCondition === UpdatingConditionType.CashbackDisabledAfterPaymentMaking) {
-        await proveTx(cardPaymentProcessor.disableCashback());
+        await cardPaymentProcessorShell.disableCashback();
       }
 
-      let newAmount = payment.amount;
-      if (newPaymentAmountType === NewPaymentAmountType.Less) {
-        newAmount = Math.floor(payment.amount * 0.5);
-      } else if (newPaymentAmountType === NewPaymentAmountType.More) {
-        newAmount = Math.floor(payment.amount * 2);
-        await proveTx(tokenMock.mint(payment.account.address, newAmount - payment.amount));
+      let newBaseAmount = payment.baseAmount;
+      switch (newBasePaymentAmountType) {
+        case NewBasePaymentAmountType.Less:
+          newBaseAmount = Math.floor(payment.baseAmount * 0.5);
+          break;
+        case NewBasePaymentAmountType.More:
+          newBaseAmount = Math.floor(payment.baseAmount * 2);
+          break;
       }
-      const refundAmount = Math.floor(payment.amount * 0.1);
-      await cardPaymentProcessor.connect(executor).refundPayment(
-        refundAmount,
-        payment.authorizationId,
-        PAYMENT_REFUNDING_CORRELATION_ID_STUB
-      );
-      setRefundAmount(payment, refundAmount);
 
-      await checkCardPaymentProcessorState(fixture, [payment]);
+      let newExtraAmount = payment.extraAmount;
+      switch (newExtraPaymentAmountType) {
+        case NewExtraPaymentAmountType.FarLess:
+          newExtraAmount = Math.floor(payment.extraAmount * 0.5);
+          break;
+        case NewExtraPaymentAmountType.FarMore:
+          newExtraAmount = Math.floor(payment.extraAmount * 2);
+          break;
+        case NewExtraPaymentAmountType.SlightlyLess:
+          newExtraAmount = payment.extraAmount - 1;
+          break;
+        case NewExtraPaymentAmountType.SlightlyMore:
+          newExtraAmount = payment.extraAmount + 1;
+          break;
+        case NewExtraPaymentAmountType.Zero:
+          newExtraAmount = 0;
+          break;
+      }
 
-      let requestCashbackChange = calculateCashbackChangeIfNewPaymentAmount(payment, newAmount);
-      let actualCashbackChange = requestCashbackChange;
+      const refundAmount = Math.floor(payment.baseAmount * 0.1);
+      await cardPaymentProcessorShell.refundPayment(payment, refundAmount);
+
+      await context.checkCardPaymentProcessorState();
+
       if (
         updatingCondition === UpdatingConditionType.CashbackEnabledButIncreasingPartial
-        && requestCashbackChange > 2
+        && newBasePaymentAmountType === NewBasePaymentAmountType.More
       ) {
-        actualCashbackChange = 1;
-        await proveTx(fixture.cashbackDistributorMock.setIncreaseCashbackAmountResult(actualCashbackChange));
-      }
-      let processorBalanceChange = newAmount - payment.amount;
-      let accountBalanceChange = -processorBalanceChange + actualCashbackChange;
-      let distributorBalanceChange = -actualCashbackChange;
-
-      if (
-        newPaymentAmountType === NewPaymentAmountType.Less
-        && updatingCondition === UpdatingConditionType.CashbackEnabledButRevokingFails
-      ) {
-        processorBalanceChange -= actualCashbackChange;
-        accountBalanceChange += 0;
-        distributorBalanceChange = 0;
-      }
-
-      if (
-        newPaymentAmountType !== NewPaymentAmountType.Less
-        && updatingCondition === UpdatingConditionType.CashbackEnabledButIncreasingFails
-      ) {
-        processorBalanceChange += 0;
-        accountBalanceChange -= actualCashbackChange;
-        distributorBalanceChange = 0;
+        const actualCashbackChange = 1;
+        await context.cashbackDistributorMockShell.setIncreaseCashbackAmountResult(actualCashbackChange);
       }
 
       if (updatingCondition === UpdatingConditionType.CashbackEnabledButRevokingFails) {
-        await proveTx(cashbackDistributorMock.setRevokeCashbackSuccessResult(false));
+        await context.cashbackDistributorMockShell.setRevokeCashbackSuccessResult(false);
       }
       if (updatingCondition === UpdatingConditionType.CashbackEnabledButIncreasingFails) {
-        await proveTx(cashbackDistributorMock.setIncreaseCashbackSuccessResult(false));
+        await context.cashbackDistributorMockShell.setIncreaseCashbackSuccessResult(false);
       }
 
-      const tx: TransactionResponse = await cardPaymentProcessor.connect(executor).updatePaymentAmount(
-        newAmount,
+      cardPaymentProcessorShell.model.updatePaymentAmount(
+        newBaseAmount,
+        newExtraAmount,
         payment.authorizationId,
         PAYMENT_UPDATING_CORRELATION_ID_STUB
       );
-      await expect(tx).to.changeTokenBalances(
-        tokenMock,
-        [cardPaymentProcessor, payment.account, cashOutAccount, cashbackDistributorMock],
-        [processorBalanceChange, accountBalanceChange, 0, distributorBalanceChange]
-      ).and.to.emit(
-        cardPaymentProcessor,
-        EVENT_NAME_UPDATE_PAYMENT_AMOUNT
-      ).withArgs(
+      const tx = cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_UPDATE_PAYMENT_AMOUNT](
+        newBaseAmount,
+        newExtraAmount,
         payment.authorizationId,
-        PAYMENT_UPDATING_CORRELATION_ID_STUB,
-        payment.account.address,
-        payment.amount,
-        newAmount
+        PAYMENT_UPDATING_CORRELATION_ID_STUB
       );
 
-      if (updatingCondition === UpdatingConditionType.CashbackDisabledBeforePaymentMaking) {
-        await expect(tx).not.to.emit(cardPaymentProcessor, EVENT_NAME_REVOKE_CASHBACK_SUCCESS);
-        await expect(tx).not.to.emit(cardPaymentProcessor, EVENT_NAME_REVOKE_CASHBACK_FAILURE);
-        await expect(tx).not.to.emit(cashbackDistributorMock, EVENT_NAME_REVOKE_CASHBACK_MOCK);
-        await expect(tx).not.to.emit(cardPaymentProcessor, EVENT_NAME_INCREASE_CASHBACK_SUCCESS);
-        await expect(tx).not.to.emit(cardPaymentProcessor, EVENT_NAME_INCREASE_CASHBACK_FAILURE);
-        await expect(tx).not.to.emit(cashbackDistributorMock, EVENT_NAME_INCREASE_CASHBACK_MOCK);
-      } else {
-        if (newPaymentAmountType === NewPaymentAmountType.Less) {
-          await expect(tx).not.to.emit(cardPaymentProcessor, EVENT_NAME_INCREASE_CASHBACK_SUCCESS);
-          await expect(tx).not.to.emit(cardPaymentProcessor, EVENT_NAME_INCREASE_CASHBACK_FAILURE);
-          await expect(tx).not.to.emit(cashbackDistributorMock, EVENT_NAME_INCREASE_CASHBACK_MOCK);
-
-          await expect(tx).to.emit(
-            cashbackDistributorMock,
-            EVENT_NAME_REVOKE_CASHBACK_MOCK
-          ).withArgs(
-            cardPaymentProcessor.address,
-            payment.cashbackNonce || 0,
-            -requestCashbackChange
-          );
-
-          if (updatingCondition === UpdatingConditionType.CashbackEnabledButRevokingFails) {
-            await expect(tx).to.emit(
-              cardPaymentProcessor,
-              EVENT_NAME_REVOKE_CASHBACK_FAILURE
-            ).withArgs(
-              cashbackDistributorMock.address,
-              -requestCashbackChange,
-              payment.cashbackNonce || 0
-            );
-          } else {
-            await expect(tx).to.emit(
-              cardPaymentProcessor,
-              EVENT_NAME_REVOKE_CASHBACK_SUCCESS
-            ).withArgs(
-              cashbackDistributorMock.address,
-              -actualCashbackChange,
-              payment.cashbackNonce || 0
-            );
-          }
-        } else { // newPaymentAmountType !== NewPaymentAmountType.Less
-          await expect(tx).not.to.emit(cardPaymentProcessor, EVENT_NAME_REVOKE_CASHBACK_SUCCESS);
-          await expect(tx).not.to.emit(cardPaymentProcessor, EVENT_NAME_REVOKE_CASHBACK_FAILURE);
-          await expect(tx).not.to.emit(cashbackDistributorMock, EVENT_NAME_REVOKE_CASHBACK_MOCK);
-
-          await expect(tx).to.emit(
-            cashbackDistributorMock,
-            EVENT_NAME_INCREASE_CASHBACK_MOCK
-          ).withArgs(
-            cardPaymentProcessor.address,
-            payment.cashbackNonce || 0,
-            requestCashbackChange
-          );
-
-          if (updatingCondition === UpdatingConditionType.CashbackEnabledButIncreasingFails) {
-            await expect(tx).to.emit(
-              cardPaymentProcessor,
-              EVENT_NAME_INCREASE_CASHBACK_FAILURE
-            ).withArgs(
-              cashbackDistributorMock.address,
-              requestCashbackChange,
-              payment.cashbackNonce || 0
-            );
-          } else {
-            await expect(tx).to.emit(
-              cardPaymentProcessor,
-              EVENT_NAME_INCREASE_CASHBACK_SUCCESS
-            ).withArgs(
-              cashbackDistributorMock.address,
-              actualCashbackChange,
-              payment.cashbackNonce || 0
-            );
-          }
-        }
-      }
-
-      setNewAmount(payment, newAmount, updatingCondition === UpdatingConditionType.CashbackEnabledButIncreasingFails);
-      if (updatingCondition === UpdatingConditionType.CashbackEnabledButRevokingFails) {
-        payment.unrevokedCashback = -actualCashbackChange;
-      }
-      if (updatingCondition === UpdatingConditionType.CashbackEnabledButIncreasingPartial) {
-        payment.compensationAmount -= requestCashbackChange;
-        payment.compensationAmount += actualCashbackChange;
-      }
-      await checkCardPaymentProcessorState(fixture, [payment]);
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
+      await context.checkPaymentOperationsForTx(tx);
+      await context.checkCardPaymentProcessorState();
     }
 
-    describe("Executes as expected and emits the correct events if the new amount is", async () => {
-      describe("Less than the initial one and cashback sending is", async () => {
-        it("Enabled and cashback revoking is executed successfully", async () => {
-          await checkUpdating(NewPaymentAmountType.Less, UpdatingConditionType.CashbackEnabled);
+    describe("Executes as expected and emits the correct events if the new base amount is", async () => {
+      describe("Less than the initial one and the extra amount is", async () => {
+        describe("The same as the initial one and cashback sending is", async () => {
+          it("Enabled and cashback revoking is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.Less,
+              NewExtraPaymentAmountType.Same,
+              UpdatingConditionType.CashbackEnabled
+            );
+          });
+          it("Disabled before payment making", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.Less,
+              NewExtraPaymentAmountType.Same,
+              UpdatingConditionType.CashbackDisabledBeforePaymentMaking
+            );
+          });
+          it("Disabled after payment making", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.Less,
+              NewExtraPaymentAmountType.Same,
+              UpdatingConditionType.CashbackDisabledAfterPaymentMaking
+            );
+          });
+          it("Enabled but cashback revoking fails", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.Less,
+              NewExtraPaymentAmountType.Same,
+              UpdatingConditionType.CashbackEnabledButRevokingFails
+            );
+          });
         });
-        it("Disabled before payment making", async () => {
-          await checkUpdating(NewPaymentAmountType.Less, UpdatingConditionType.CashbackDisabledBeforePaymentMaking);
+        describe("Far less than the initial one and cashback sending is", async () => {
+          it("Enabled and cashback revoking is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.Less,
+              NewExtraPaymentAmountType.FarLess,
+              UpdatingConditionType.CashbackEnabled
+            );
+          });
         });
-        it("Disabled after payment making", async () => {
-          await checkUpdating(NewPaymentAmountType.Less, UpdatingConditionType.CashbackDisabledAfterPaymentMaking);
+        describe("Far more than the initial one and cashback sending is", async () => {
+          it("Enabled and cashback revoking is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.Less,
+              NewExtraPaymentAmountType.FarMore,
+              UpdatingConditionType.CashbackEnabled
+            );
+          });
         });
-        it("Enabled but cashback revoking fails", async () => {
-          await checkUpdating(NewPaymentAmountType.Less, UpdatingConditionType.CashbackEnabledButRevokingFails);
+        describe("Slightly more than the initial one and cashback sending is", async () => {
+          it("Enabled and cashback revoking is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.Less,
+              NewExtraPaymentAmountType.SlightlyMore,
+              UpdatingConditionType.CashbackEnabled
+            );
+          });
+        });
+        describe("Zero and cashback sending is", async () => {
+          it("Enabled and cashback revoking is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.Less,
+              NewExtraPaymentAmountType.Zero,
+              UpdatingConditionType.CashbackEnabled
+            );
+          });
         });
       });
-      describe("The same as the initial one and cashback sending is", async () => {
-        it("Enabled and cashback revoking is executed successfully", async () => {
-          await checkUpdating(NewPaymentAmountType.Same, UpdatingConditionType.CashbackEnabled);
+      describe("The same as the initial one and the extra amount is", async () => {
+        describe("The same as the initial one and cashback sending is", async () => {
+          it("Enabled and cashback revoking is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.Same,
+              NewExtraPaymentAmountType.Same,
+              UpdatingConditionType.CashbackEnabled);
+          });
+        });
+        describe("Far less than the initial one and cashback sending is", async () => {
+          it("Enabled and cashback revoking is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.Same,
+              NewExtraPaymentAmountType.FarLess,
+              UpdatingConditionType.CashbackEnabled
+            );
+          });
+        });
+        describe("Far more than the initial one and cashback sending is", async () => {
+          it("Enabled and cashback revoking is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.Same,
+              NewExtraPaymentAmountType.FarMore,
+              UpdatingConditionType.CashbackEnabled
+            );
+          });
+        });
+        describe("Zero and cashback sending is", async () => {
+          it("Enabled and cashback revoking is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.Same,
+              NewExtraPaymentAmountType.Zero,
+              UpdatingConditionType.CashbackEnabled
+            );
+          });
         });
       });
 
-      describe("More than the initial one and cashback sending is", async () => {
-        it("Enabled and cashback increasing is executed successfully", async () => {
-          await checkUpdating(NewPaymentAmountType.More, UpdatingConditionType.CashbackEnabled);
+      describe("More than the initial one and the extra amount is", async () => {
+        describe("The same as the initial one and cashback sending is", async () => {
+          it("Enabled and cashback increasing is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.More,
+              NewExtraPaymentAmountType.Same,
+              UpdatingConditionType.CashbackEnabled
+            );
+          });
+          it("Disabled before payment making", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.More,
+              NewExtraPaymentAmountType.Same,
+              UpdatingConditionType.CashbackDisabledBeforePaymentMaking
+            );
+          });
+          it("Disabled after payment making", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.More,
+              NewExtraPaymentAmountType.Same,
+              UpdatingConditionType.CashbackDisabledAfterPaymentMaking
+            );
+          });
+          it("Enabled but cashback increasing fails", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.More,
+              NewExtraPaymentAmountType.Same,
+              UpdatingConditionType.CashbackEnabledButIncreasingFails);
+          });
+          it("Enabled but cashback increasing executes partially", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.More,
+              NewExtraPaymentAmountType.Same,
+              UpdatingConditionType.CashbackEnabledButIncreasingPartial
+            );
+          });
         });
-        it("Disabled before payment making", async () => {
-          await checkUpdating(NewPaymentAmountType.More, UpdatingConditionType.CashbackDisabledBeforePaymentMaking);
+        describe("Far less than the initial one and cashback sending is", async () => {
+          it("Enabled and cashback increasing is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.More,
+              NewExtraPaymentAmountType.FarLess,
+              UpdatingConditionType.CashbackEnabled
+            );
+          });
         });
-        it("Disabled after payment making", async () => {
-          await checkUpdating(NewPaymentAmountType.More, UpdatingConditionType.CashbackDisabledAfterPaymentMaking);
+        describe("Slightly less than the initial one and cashback sending is", async () => {
+          it("Enabled and cashback increasing is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.More,
+              NewExtraPaymentAmountType.SlightlyLess,
+              UpdatingConditionType.CashbackEnabled
+            );
+          });
         });
-        it("Enabled but cashback increasing fails", async () => {
-          await checkUpdating(NewPaymentAmountType.More, UpdatingConditionType.CashbackEnabledButIncreasingFails);
+        describe("Far more than the initial one and cashback sending is", async () => {
+          it("Enabled and cashback increasing is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.More,
+              NewExtraPaymentAmountType.FarMore,
+              UpdatingConditionType.CashbackEnabled
+            );
+          });
         });
-        it("Enabled but cashback increasing executes partially", async () => {
-          await checkUpdating(NewPaymentAmountType.More, UpdatingConditionType.CashbackEnabledButIncreasingPartial);
+        describe("Zero and cashback sending is", async () => {
+          it("Enabled and cashback increasing is executed successfully", async () => {
+            await checkUpdating(
+              NewBasePaymentAmountType.More,
+              NewExtraPaymentAmountType.Zero,
+              UpdatingConditionType.CashbackEnabled
+            );
+          });
         });
       });
     });
 
     describe("Is reverted if", async () => {
       it("The contract is paused", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-        await pauseContract(cardPaymentProcessor);
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+        await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessor.connect(executor).updatePaymentAmount(
-            payment.amount,
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_UPDATE_PAYMENT_AMOUNT](
+            payment.baseAmount,
+            payment.extraAmount,
             payment.authorizationId,
             PAYMENT_UPDATING_CORRELATION_ID_STUB
           )
@@ -1483,10 +2638,13 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       });
 
       it("The caller does not have the executor role", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(deployer).updatePaymentAmount(
-            payment.amount,
+          cardPaymentProcessorShell.contract.connect(deployer).functions[FUNCTION_UPDATE_PAYMENT_AMOUNT](
+            payment.baseAmount,
+            payment.extraAmount,
             payment.authorizationId,
             PAYMENT_UPDATING_CORRELATION_ID_STUB
           )
@@ -1494,60 +2652,73 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       });
 
       it("The payment authorization ID is zero", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(executor).updatePaymentAmount(
-            payment.amount,
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_UPDATE_PAYMENT_AMOUNT](
+            payment.baseAmount,
+            payment.extraAmount,
             ZERO_AUTHORIZATION_ID,
             PAYMENT_UPDATING_CORRELATION_ID_STUB
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+        ).to.be.revertedWithCustomError(
+          cardPaymentProcessorShell.contract,
+          REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
+        );
       });
 
       it("The payment with the provided authorization ID does not exist", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(executor).updatePaymentAmount(
-            payment.amount,
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_UPDATE_PAYMENT_AMOUNT](
+            payment.baseAmount,
+            payment.extraAmount,
             payment.authorizationId,
             PAYMENT_UPDATING_CORRELATION_ID_STUB
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
+        ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
       });
 
-      it("The new amount is less than the refund amount", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
-        await makePayments(cardPaymentProcessor, [payment]);
-        const refundAmount = Math.floor(payment.amount * 0.5);
-        await proveTx(cardPaymentProcessor.connect(executor).refundPayment(
-          refundAmount,
-          payment.authorizationId,
-          PAYMENT_REFUNDING_CORRELATION_ID_STUB
-        ));
-        setRefundAmount(payment, refundAmount);
+      it("The new base amount is less than the refund amount", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+        await cardPaymentProcessorShell.makePayments([payment]);
+        const refundAmount = Math.floor(payment.baseAmount * 0.5);
+        await cardPaymentProcessorShell.refundPayment(payment, refundAmount);
 
         await expect(
-          cardPaymentProcessor.connect(executor).updatePaymentAmount(
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_UPDATE_PAYMENT_AMOUNT](
             refundAmount - 1,
-            payment.authorizationId,
-            PAYMENT_UPDATING_CORRELATION_ID_STUB
-          )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_NEW_PAYMENT_AMOUNT_IS_INAPPROPRIATE);
-      });
-
-      it("The payment status is 'Cleared'", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
-        await makePayments(cardPaymentProcessor, [payment]);
-        await clearPayments(cardPaymentProcessor, [payment]);
-
-        await expect(
-          cardPaymentProcessor.connect(executor).updatePaymentAmount(
-            payment.amount,
+            payment.extraAmount,
             payment.authorizationId,
             PAYMENT_UPDATING_CORRELATION_ID_STUB
           )
         ).to.be.revertedWithCustomError(
-          cardPaymentProcessor,
+          cardPaymentProcessorShell.contract,
+          REVERT_ERROR_IF_NEW_BASE_PAYMENT_AMOUNT_IS_INAPPROPRIATE
+        );
+      });
+
+      it("The payment status is 'Cleared'", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+        await cardPaymentProcessorShell.makePayments([payment]);
+        await cardPaymentProcessorShell.clearPayments([payment]);
+
+        await expect(
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_UPDATE_PAYMENT_AMOUNT](
+            payment.baseAmount,
+            payment.extraAmount,
+            payment.authorizationId,
+            PAYMENT_UPDATING_CORRELATION_ID_STUB
+          )
+        ).to.be.revertedWithCustomError(
+          cardPaymentProcessorShell.contract,
           REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
         ).withArgs(PaymentStatus.Cleared);
       });
@@ -1555,596 +2726,455 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   });
 
   describe("Function 'clearPayment()'", async () => {
-    it("Executes as expected, emits the correct event, and does not transfer tokens", async () => {
-      const { fixture, payment } = await beforeMakingPayment();
-      const { cardPaymentProcessor, tokenMock } = fixture;
-      await makePayments(fixture.cardPaymentProcessor, [payment]);
-      const expectedClearedBalance: number = payment.amount;
-      const expectedUnclearedBalance: number = 0;
+    it("Executes as expected and emits the correct event if there was no refunding", async () => {
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-      await checkCardPaymentProcessorState(fixture, [payment]);
+      await cardPaymentProcessorShell.enableCashback();
+      await cardPaymentProcessorShell.makePayments([payment]);
 
-      await expect(
-        cardPaymentProcessor.connect(executor).clearPayment(payment.authorizationId)
-      ).to.changeTokenBalances(
-        tokenMock,
-        [cardPaymentProcessor, payment.account],
-        [0, 0]
-      ).and.to.emit(
-        cardPaymentProcessor,
-        EVENT_NAME_CLEAR_PAYMENT
-      ).withArgs(
-        payment.authorizationId,
-        payment.account.address,
-        payment.amount,
-        expectedClearedBalance,
-        expectedUnclearedBalance,
-        payment.revocationCounter || 0
-      );
+      cardPaymentProcessorShell.model.clearPayment(payment.authorizationId);
+      const tx = cardPaymentProcessorShell.contract.connect(executor).clearPayment(payment.authorizationId);
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
-      payment.status = PaymentStatus.Cleared;
-      await checkCardPaymentProcessorState(fixture, [payment]);
+      await context.checkPaymentOperationsForTx(tx);
+      await context.checkCardPaymentProcessorState();
+    });
+
+    it("Executes as expected and emits the correct event if there was a refund operation", async () => {
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+      await cardPaymentProcessorShell.enableCashback();
+      await cardPaymentProcessorShell.makePayments([payment]);
+      const refundAmount = Math.floor(payment.baseAmount * 0.1);
+      await cardPaymentProcessorShell.refundPayment(payment, refundAmount);
+
+      cardPaymentProcessorShell.model.clearPayment(payment.authorizationId);
+      const tx = cardPaymentProcessorShell.contract.connect(executor).clearPayment(payment.authorizationId);
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
+
+      await context.checkPaymentOperationsForTx(tx);
+      await context.checkCardPaymentProcessorState();
     });
 
     it("Is reverted if the caller does not have the executor role", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
       await expect(
-        cardPaymentProcessor.connect(deployer).clearPayment(payment.authorizationId)
+        cardPaymentProcessorShell.contract.connect(deployer).clearPayment(payment.authorizationId)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
     it("Is reverted if the contract is paused", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-      await pauseContract(cardPaymentProcessor);
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+      await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessor.connect(executor).clearPayment(payment.authorizationId)
+        cardPaymentProcessorShell.contract.connect(executor).clearPayment(payment.authorizationId)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the payment authorization ID is zero", async () => {
-      const { fixture: { cardPaymentProcessor } } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell } = context;
       await expect(
-        cardPaymentProcessor.connect(executor).clearPayment(ZERO_AUTHORIZATION_ID)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+        cardPaymentProcessorShell.contract.connect(executor).clearPayment(ZERO_AUTHORIZATION_ID)
+      ).to.be.revertedWithCustomError(
+        cardPaymentProcessorShell.contract,
+        REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
+      );
     });
 
     it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
       await expect(
-        cardPaymentProcessor.connect(executor).clearPayment(payment.authorizationId)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
+        cardPaymentProcessorShell.contract.connect(executor).clearPayment(payment.authorizationId)
+      ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Is reverted if the payment has already been cleared", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
-      await makePayments(cardPaymentProcessor, [payment]);
-      await proveTx(cardPaymentProcessor.connect(executor).clearPayment(payment.authorizationId));
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+      await cardPaymentProcessorShell.makePayments([payment]);
+      await proveTx(cardPaymentProcessorShell.contract.connect(executor).clearPayment(payment.authorizationId));
 
       await expect(
-        cardPaymentProcessor.connect(executor).clearPayment(payment.authorizationId)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_CLEARED);
+        cardPaymentProcessorShell.contract.connect(executor).clearPayment(payment.authorizationId)
+      ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_CLEARED);
     });
   });
 
   describe("Function 'clearPayments()'", async () => {
-    async function beforeClearingPayments(): Promise<{
-      fixture: Fixture,
-      payments: TestPayment[],
-      accountAddresses: string[],
-      authorizationIds: string[]
-    }> {
-      const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
-      const payments: TestPayment[] = createTestPayments().slice(0, 2);
-      await setUpContractsForPayments(fixture, payments);
-      await makePayments(fixture.cardPaymentProcessor, payments);
-      const accountAddresses: string[] = payments.map(payment => payment.account.address);
-      const authorizationIds: string[] = payments.map(payment => payment.authorizationId);
+    it("Executes as expected and emits the correct events", async () => {
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
+      await cardPaymentProcessorShell.makePayments(payments);
 
-      return {
-        fixture,
-        payments,
-        accountAddresses,
-        authorizationIds
-      };
-    }
+      const operationIndex1 = cardPaymentProcessorShell.model.clearPayment(payments[0].authorizationId);
+      const operationIndex2 = cardPaymentProcessorShell.model.clearPayment(payments[1].authorizationId);
+      const tx = cardPaymentProcessorShell.contract.connect(executor).clearPayments([
+        payments[0].authorizationId,
+        payments[1].authorizationId,
+      ]);
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
-    it("Executes as expected, emits the correct event, and does not transfer tokens", async () => {
-      const { fixture, payments, accountAddresses, authorizationIds } = await beforeClearingPayments();
-      const { cardPaymentProcessor, tokenMock } = fixture;
-      const expectedClearedBalances: number[] = payments.map((payment: TestPayment) => payment.amount);
-      const expectedUnclearedBalances: number[] = payments.map(() => 0);
-
-      await checkCardPaymentProcessorState(fixture, payments);
-
-      const tx: TransactionResponse = cardPaymentProcessor.connect(executor).clearPayments(authorizationIds);
-      await expect(tx).to.changeTokenBalances(
-        tokenMock,
-        [cardPaymentProcessor, ...accountAddresses],
-        [0, ...accountAddresses.map(() => 0)]
-      ).and.to.emit(
-        cardPaymentProcessor,
-        EVENT_NAME_CLEAR_PAYMENT
-      ).withArgs(
-        authorizationIds[0],
-        payments[0].account.address,
-        payments[0].amount,
-        expectedClearedBalances[0],
-        expectedUnclearedBalances[0],
-        payments[0].revocationCounter || 0
-      );
-      await expect(tx).to.emit(
-        cardPaymentProcessor,
-        EVENT_NAME_CLEAR_PAYMENT
-      ).withArgs(
-        authorizationIds[1],
-        payments[1].account.address,
-        payments[1].amount,
-        expectedClearedBalances[1],
-        expectedUnclearedBalances[1],
-        payments[1].revocationCounter || 0
-      );
-
-      payments.forEach((payment: TestPayment) => payment.status = PaymentStatus.Cleared);
-      await checkCardPaymentProcessorState(fixture, payments);
+      await context.checkPaymentOperationsForTx(tx, [operationIndex1, operationIndex2]);
+      await context.checkCardPaymentProcessorState();
     });
 
     it("Is reverted if the contract is paused", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-      await pauseContract(cardPaymentProcessor);
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+      await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessor.connect(executor).clearPayments([payment.authorizationId])
+        cardPaymentProcessorShell.contract.connect(executor).clearPayments([payment.authorizationId])
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the executor role", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
       await expect(
-        cardPaymentProcessor.connect(deployer).clearPayments([payment.authorizationId])
+        cardPaymentProcessorShell.contract.connect(deployer).clearPayments([payment.authorizationId])
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
     it("Is reverted if the payment authorization IDs array is empty", async () => {
-      const { fixture: { cardPaymentProcessor } } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell } = context;
+
       await expect(
-        cardPaymentProcessor.connect(executor).clearPayments([])
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
+        cardPaymentProcessorShell.contract.connect(executor).clearPayments([])
+      ).to.be.revertedWithCustomError(
+        cardPaymentProcessorShell.contract,
+        REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY
+      );
     });
 
     it("Is reverted if one of the payment authorization IDs is zero", async () => {
-      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeClearingPayments();
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
+      await cardPaymentProcessorShell.makePayments(payments);
+
       await expect(
-        cardPaymentProcessor.connect(executor).clearPayments([authorizationIds[0], ZERO_AUTHORIZATION_ID])
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+        cardPaymentProcessorShell.contract.connect(executor).clearPayments([
+          payments[0].authorizationId,
+          ZERO_AUTHORIZATION_ID
+        ])
+      ).to.be.revertedWithCustomError(
+        cardPaymentProcessorShell.contract,
+        REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
+      );
     });
 
     it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
-      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeClearingPayments();
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
+      await cardPaymentProcessorShell.makePayments(payments);
+
       await expect(
-        cardPaymentProcessor.connect(executor).clearPayments(
-          [
-            authorizationIds[0],
-            increaseBytesString(authorizationIds[1], BYTES16_LENGTH)
-          ]
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
+        cardPaymentProcessorShell.contract.connect(executor).clearPayments([
+          payments[0].authorizationId,
+          increaseBytesString(payments[1].authorizationId, BYTES16_LENGTH)
+        ])
+      ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Is reverted if one of the payments has been already cleared", async () => {
-      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeClearingPayments();
-      await proveTx(cardPaymentProcessor.connect(executor).clearPayment(authorizationIds[0]));
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
+      await cardPaymentProcessorShell.makePayments(payments);
+
+      await proveTx(cardPaymentProcessorShell.contract.connect(executor).clearPayment(payments[1].authorizationId));
 
       await expect(
-        cardPaymentProcessor.connect(executor).clearPayments(authorizationIds)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_CLEARED);
+        cardPaymentProcessorShell.contract.connect(executor).clearPayments([
+          payments[0].authorizationId,
+          payments[1].authorizationId
+        ])
+      ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_CLEARED);
     });
   });
 
   describe("Function 'unclearPayment()'", async () => {
-    it("Executes as expected, emits the correct event, and does not transfer tokens", async () => {
-      const { fixture, payment } = await beforeMakingPayment();
-      const { cardPaymentProcessor, tokenMock } = fixture;
-      await makePayments(cardPaymentProcessor, [payment]);
-      await clearPayments(cardPaymentProcessor, [payment]);
-      const expectedClearedBalance: number = 0;
-      const expectedUnclearedBalance: number = payment.amount;
+    it("Executes as expected and emits the correct event if there was no refunding", async () => {
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-      await checkCardPaymentProcessorState(fixture, [payment]);
+      await cardPaymentProcessorShell.enableCashback();
+      await cardPaymentProcessorShell.makePayments([payment]);
+      await cardPaymentProcessorShell.clearPayments([payment]);
 
-      await expect(
-        cardPaymentProcessor.connect(executor).unclearPayment(payment.authorizationId)
-      ).to.changeTokenBalances(
-        tokenMock,
-        [cardPaymentProcessor, payment.account],
-        [0, 0]
-      ).and.to.emit(
-        cardPaymentProcessor,
-        EVENT_NAME_UNCLEAR_PAYMENT
-      ).withArgs(
-        payment.authorizationId,
-        payment.account.address,
-        payment.amount,
-        expectedClearedBalance,
-        expectedUnclearedBalance,
-        payment.revocationCounter || 0
-      );
+      await context.checkCardPaymentProcessorState();
 
-      payment.status = PaymentStatus.Uncleared;
-      await checkCardPaymentProcessorState(fixture, [payment]);
+      cardPaymentProcessorShell.model.unclearPayment(payment.authorizationId);
+      const tx = cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payment.authorizationId);
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
+
+      await context.checkPaymentOperationsForTx(tx);
+      await context.checkCardPaymentProcessorState();
+    });
+
+    it("Executes as expected and emits the correct event if there was a refund operation", async () => {
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+      await cardPaymentProcessorShell.enableCashback();
+      await cardPaymentProcessorShell.makePayments([payment]);
+      await cardPaymentProcessorShell.clearPayments([payment]);
+      const refundAmount = Math.floor(payment.baseAmount * 0.1);
+      await cardPaymentProcessorShell.refundPayment(payment, refundAmount);
+
+      await context.checkCardPaymentProcessorState();
+
+      cardPaymentProcessorShell.model.unclearPayment(payment.authorizationId);
+      const tx = cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payment.authorizationId);
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
+
+      await context.checkPaymentOperationsForTx(tx);
+      await context.checkCardPaymentProcessorState();
     });
 
     it("Is reverted if the contract is paused", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-      await pauseContract(cardPaymentProcessor);
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+      await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayment(payment.authorizationId)
+        cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payment.authorizationId)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the executor role", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
       await expect(
-        cardPaymentProcessor.connect(deployer).unclearPayment(payment.authorizationId)
+        cardPaymentProcessorShell.contract.connect(deployer).unclearPayment(payment.authorizationId)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
     it("Is reverted if the payment authorization ID is zero", async () => {
-      const { fixture: { cardPaymentProcessor } } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell } = context;
+
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayment(ZERO_AUTHORIZATION_ID)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+        cardPaymentProcessorShell.contract.connect(executor).unclearPayment(ZERO_AUTHORIZATION_ID)
+      ).to.be.revertedWithCustomError(
+        cardPaymentProcessorShell.contract,
+        REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
+      );
     });
 
     it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayment(payment.authorizationId)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
+        cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payment.authorizationId)
+      ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Is reverted if the payment is uncleared", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
-      await makePayments(cardPaymentProcessor, [payment]);
-      await clearPayments(cardPaymentProcessor, [payment]);
-      await proveTx(cardPaymentProcessor.connect(executor).unclearPayment(payment.authorizationId));
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+      await cardPaymentProcessorShell.makePayments([payment]);
+      await cardPaymentProcessorShell.clearPayments([payment]);
+
+      await proveTx(cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payment.authorizationId));
 
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayment(payment.authorizationId)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
+        cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payment.authorizationId)
+      ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
     });
   });
 
   describe("Function 'unclearPayments()'", async () => {
-    async function beforeUnclearingPayments(): Promise<{
-      fixture: Fixture,
-      payments: TestPayment[],
-      accountAddresses: string[],
-      authorizationIds: string[]
-    }> {
-      const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
-      const payments: TestPayment[] = createTestPayments().slice(0, 2);
-      await setUpContractsForPayments(fixture, payments);
-      await makePayments(fixture.cardPaymentProcessor, payments);
-      await clearPayments(fixture.cardPaymentProcessor, payments);
-      const accountAddresses: string[] = payments.map(payment => payment.account.address);
-      const authorizationIds: string[] = payments.map(payment => payment.authorizationId);
+    it("Executes as expected and emits the correct events", async () => {
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
+      await cardPaymentProcessorShell.makePayments(payments);
+      await cardPaymentProcessorShell.clearPayments(payments);
 
-      return {
-        fixture,
-        payments,
-        accountAddresses,
-        authorizationIds
-      };
-    }
+      const operationIndex1 = cardPaymentProcessorShell.model.unclearPayment(payments[0].authorizationId);
+      const operationIndex2 = cardPaymentProcessorShell.model.unclearPayment(payments[1].authorizationId);
+      const tx = cardPaymentProcessorShell.contract.connect(executor).unclearPayments([
+        payments[0].authorizationId,
+        payments[1].authorizationId,
+      ]);
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
-    it("Executes as expected, emits the correct event, and does not transfer tokens", async () => {
-      const { fixture, payments, accountAddresses, authorizationIds } = await beforeUnclearingPayments();
-      const { cardPaymentProcessor, tokenMock } = fixture;
-      const expectedClearedBalances: number[] = payments.map(() => 0);
-      const expectedUnclearedBalances: number[] = payments.map((payment: TestPayment) => payment.amount);
-
-      await checkCardPaymentProcessorState(fixture, payments);
-
-      const tx: TransactionResponse = cardPaymentProcessor.connect(executor).unclearPayments(authorizationIds);
-      await expect(tx).to.changeTokenBalances(
-        tokenMock,
-        [cardPaymentProcessor, ...accountAddresses],
-        [0, ...accountAddresses.map(() => 0)]
-      ).and.to.emit(
-        cardPaymentProcessor,
-        EVENT_NAME_UNCLEAR_PAYMENT
-      ).withArgs(
-        authorizationIds[0],
-        payments[0].account.address,
-        payments[0].amount,
-        expectedClearedBalances[0],
-        expectedUnclearedBalances[0],
-        payments[0].revocationCounter || 0
-      );
-      await expect(tx).to.emit(
-        cardPaymentProcessor,
-        EVENT_NAME_UNCLEAR_PAYMENT
-      ).withArgs(
-        authorizationIds[1],
-        payments[1].account.address,
-        payments[1].amount,
-        expectedClearedBalances[1],
-        expectedUnclearedBalances[1],
-        payments[1].revocationCounter || 0
-      );
-
-      payments.forEach((payment: TestPayment) => payment.status = PaymentStatus.Uncleared);
-      await checkCardPaymentProcessorState(fixture, payments);
+      await context.checkPaymentOperationsForTx(tx, [operationIndex1, operationIndex2]);
+      await context.checkCardPaymentProcessorState();
     });
 
     it("Is reverted if the contract is paused", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-      await pauseContract(cardPaymentProcessor);
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+      await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayments([payment.authorizationId])
+        cardPaymentProcessorShell.contract.connect(executor).unclearPayments([payment.authorizationId])
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the executor role", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
       await expect(
-        cardPaymentProcessor.connect(deployer).unclearPayments([payment.authorizationId])
+        cardPaymentProcessorShell.contract.connect(deployer).unclearPayments([payment.authorizationId])
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
     it("Is reverted if the payment authorization IDs array is empty", async () => {
-      const { fixture: { cardPaymentProcessor } } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell } = context;
+
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayments([])
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
+        cardPaymentProcessorShell.contract.connect(executor).unclearPayments([])
+      ).to.be.revertedWithCustomError(
+        cardPaymentProcessorShell.contract,
+        REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY
+      );
     });
 
     it("Is reverted if one of the payment authorization IDs is zero", async () => {
-      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeUnclearingPayments();
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
+      await cardPaymentProcessorShell.makePayments(payments);
+      await cardPaymentProcessorShell.clearPayments(payments);
+
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayments([authorizationIds[0], ZERO_AUTHORIZATION_ID])
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+        cardPaymentProcessorShell.contract.connect(executor).unclearPayments([
+          payments[0].authorizationId,
+          ZERO_AUTHORIZATION_ID
+        ])
+      ).to.be.revertedWithCustomError(
+        cardPaymentProcessorShell.contract,
+        REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
+      );
     });
 
     it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
-      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeUnclearingPayments();
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
+      await cardPaymentProcessorShell.makePayments(payments);
+      await cardPaymentProcessorShell.clearPayments(payments);
+
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayments(
-          [
-            authorizationIds[0],
-            increaseBytesString(authorizationIds[1], BYTES16_LENGTH)
-          ]
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
+        cardPaymentProcessorShell.contract.connect(executor).unclearPayments([
+          payments[0].authorizationId,
+          increaseBytesString(payments[1].authorizationId, BYTES16_LENGTH)
+        ])
+      ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Is reverted if one of the payments is uncleared", async () => {
-      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeUnclearingPayments();
-      await proveTx(cardPaymentProcessor.connect(executor).unclearPayment(authorizationIds[1]));
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
+      await cardPaymentProcessorShell.makePayments(payments);
+      await cardPaymentProcessorShell.clearPayments(payments);
+
+      await proveTx(cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payments[1].authorizationId));
 
       await expect(
-        cardPaymentProcessor.connect(executor).unclearPayments(authorizationIds)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
+        cardPaymentProcessorShell.contract.connect(executor).unclearPayments([
+          payments[0].authorizationId,
+          payments[1].authorizationId,
+        ])
+      ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
     });
   });
 
   describe("Function 'revokePayment()'", async () => {
-    describe("Executes as expected and emits the correct events if the payment status is", async () => {
-      const expectedClearedBalance: number = 0;
-      const expectedUnclearedBalance: number = 0;
-      const expectedRevocationCounter: number = 1;
+    async function revokeSinglePaymentAndCheck(context: TestContext) {
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+      cardPaymentProcessorShell.model.revokePayment(
+        payment.authorizationId,
+        PAYMENT_REVOKING_CORRELATION_ID_STUB,
+        payment.parentTxHash
+      );
+      const tx = cardPaymentProcessorShell.contract.connect(executor).revokePayment(
+        payment.authorizationId,
+        PAYMENT_REVOKING_CORRELATION_ID_STUB,
+        payment.parentTxHash
+      );
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
-      async function checkRevocationWithCashback(props: { isPaymentCleared: boolean }) {
-        const { fixture, payment } = await beforeMakingPayment();
-        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
-        setCashback(payment, fixture);
-        const cashbackAmount: number = calculateCashback(payment);
-        const revokedPaymentAmount: number = payment.amount - cashbackAmount;
-        await proveTx(cardPaymentProcessor.enableCashback());
-        await makePayments(cardPaymentProcessor, [payment]);
+      await context.checkPaymentOperationsForTx(tx);
+      await context.checkCardPaymentProcessorState();
+    }
 
-        if (props.isPaymentCleared) {
-          await clearPayments(cardPaymentProcessor, [payment]);
-        }
+    describe("Executes as expected and emits the correct events if", async () => {
+      it("Cashback operations are enabled and the payment status is 'Uncleared'", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-        await checkCardPaymentProcessorState(fixture, [payment]);
-
-        const tx: TransactionResponse = cardPaymentProcessor.connect(executor).revokePayment(
-          payment.authorizationId,
-          PAYMENT_REVOKING_CORRELATION_ID_STUB,
-          payment.parentTxHash
-        );
-        await expect(tx).to.changeTokenBalances(
-          tokenMock,
-          [cardPaymentProcessor, payment.account, cashbackDistributorMock],
-          [-revokedPaymentAmount - cashbackAmount, +revokedPaymentAmount, +cashbackAmount]
-        ).and.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_PAYMENT
-        ).withArgs(
-          payment.authorizationId,
-          PAYMENT_REVOKING_CORRELATION_ID_STUB,
-          payment.account.address,
-          revokedPaymentAmount,
-          expectedClearedBalance,
-          expectedUnclearedBalance,
-          props.isPaymentCleared,
-          payment.parentTxHash,
-          expectedRevocationCounter
-        );
-        await expect(tx).to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
-        ).withArgs(
-          cashbackDistributorMock.address,
-          cashbackAmount,
-          payment.cashbackNonce || 0
-        );
-        await expect(tx).to.emit(
-          cashbackDistributorMock,
-          EVENT_NAME_REVOKE_CASHBACK_MOCK
-        ).withArgs(
-          cardPaymentProcessor.address,
-          payment.cashbackNonce || 0,
-          cashbackAmount
-        );
-
-        payment.status = PaymentStatus.Revoked;
-        payment.revocationCounter = expectedRevocationCounter;
-        payment.compensationAmount = 0;
-        await checkCardPaymentProcessorState(fixture, [payment]);
-      }
-
-      it("Uncleared", async () => {
-        await checkRevocationWithCashback({ isPaymentCleared: false });
+        await cardPaymentProcessorShell.enableCashback();
+        await cardPaymentProcessorShell.makePayments([payment]);
+        await revokeSinglePaymentAndCheck(context);
       });
 
-      it("Cleared", async () => {
-        await checkRevocationWithCashback({ isPaymentCleared: true });
-      });
-    });
+      it("Cashback operations are enabled and the payment status is 'Cleared'", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-    describe("Executes successfully and does the following with cashback operations", async () => {
-      it("Does not revoke cashback if cashback operations are disabled before sending", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
-        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
-        await makePayments(cardPaymentProcessor, [payment]);
-
-        await expect(
-          cardPaymentProcessor.connect(executor).revokePayment(
-            payment.authorizationId,
-            PAYMENT_REVOKING_CORRELATION_ID_STUB,
-            payment.parentTxHash
-          )
-        ).to.changeTokenBalances(
-          tokenMock,
-          [cardPaymentProcessor, payment.account, cashbackDistributorMock],
-          [-payment.amount, +payment.amount, 0]
-        ).and.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_PAYMENT
-        ).and.not.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
-        ).and.not.to.emit(
-          cashbackDistributorMock,
-          EVENT_NAME_REVOKE_CASHBACK_MOCK
-        );
-
-        payment.status = PaymentStatus.Revoked;
-        payment.revocationCounter = 1;
-        await checkCardPaymentProcessorState(fixture, [payment]);
+        await cardPaymentProcessorShell.enableCashback();
+        await cardPaymentProcessorShell.makePayments([payment]);
+        await cardPaymentProcessorShell.clearPayments([payment]);
+        await revokeSinglePaymentAndCheck(context);
       });
 
-      it("Does revoke cashback if cashback operations are disabled after sending", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
-        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
-        setCashback(payment, fixture);
-        const cashbackAmount: number = calculateCashback(payment);
-        const revokedPaymentAmount: number = payment.amount - cashbackAmount;
+      it("Cashback operations are enabled but cashback revoking fails", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-        await proveTx(cardPaymentProcessor.enableCashback());
-        await makePayments(cardPaymentProcessor, [payment]);
-        await proveTx(cardPaymentProcessor.disableCashback());
+        await cardPaymentProcessorShell.enableCashback();
+        await cardPaymentProcessorShell.makePayments([payment]);
+        await cardPaymentProcessorShell.disableCashback();
+        await context.cashbackDistributorMockShell.setRevokeCashbackSuccessResult(false);
 
-        const tx: TransactionResponse = await cardPaymentProcessor.connect(executor).revokePayment(
-          payment.authorizationId,
-          PAYMENT_REVOKING_CORRELATION_ID_STUB,
-          payment.parentTxHash
-        );
-        await expect(tx).to.changeTokenBalances(
-          tokenMock,
-          [cardPaymentProcessor, payment.account, cashbackDistributorMock],
-          [-revokedPaymentAmount - cashbackAmount, +revokedPaymentAmount, cashbackAmount]
-        ).and.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_PAYMENT
-        );
-        await expect(tx).to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
-        ).withArgs(
-          cashbackDistributorMock.address,
-          cashbackAmount,
-          payment.cashbackNonce || 0
-        );
-        await expect(tx).to.emit(
-          cashbackDistributorMock,
-          EVENT_NAME_REVOKE_CASHBACK_MOCK
-        ).withArgs(
-          cardPaymentProcessor.address,
-          payment.cashbackNonce || 0,
-          cashbackAmount
-        );
-
-        payment.status = PaymentStatus.Revoked;
-        payment.revocationCounter = 1;
-        payment.compensationAmount = 0;
-        await checkCardPaymentProcessorState(fixture, [payment]);
+        await revokeSinglePaymentAndCheck(context);
       });
 
-      it("Emits correct events if cashback operations are enabled but cashback revoking fails", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
-        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
-        setCashback(payment, fixture);
-        const cashbackAmount: number = calculateCashback(payment);
-        const revokedPaymentAmount: number = payment.amount - cashbackAmount;
+      it("Cashback operations are disabled before sending", async () => {
+        const context = await beforeMakingPayments();
+        await context.cardPaymentProcessorShell.makePayments([context.payments[0]]);
+        await revokeSinglePaymentAndCheck(context);
+      });
 
-        await proveTx(cardPaymentProcessor.enableCashback());
-        await makePayments(cardPaymentProcessor, [payment]);
-        await proveTx(cashbackDistributorMock.setRevokeCashbackSuccessResult(false));
+      it("Cashback operations are disabled after sending", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-        const tx: TransactionResponse = cardPaymentProcessor.connect(executor).revokePayment(
-          payment.authorizationId,
-          PAYMENT_REVOKING_CORRELATION_ID_STUB,
-          payment.parentTxHash
-        );
-        await expect(tx).to.changeTokenBalances(
-          tokenMock,
-          [cardPaymentProcessor, payment.account, cashbackDistributorMock],
-          [-revokedPaymentAmount, +revokedPaymentAmount, 0]
-        ).and.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_PAYMENT
-        ).and.not.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
-        );
-        await expect(tx).to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_CASHBACK_FAILURE
-        ).withArgs(
-          cashbackDistributorMock.address,
-          cashbackAmount,
-          payment.cashbackNonce || 0
-        );
-        await expect(tx).to.emit(
-          cashbackDistributorMock,
-          EVENT_NAME_REVOKE_CASHBACK_MOCK
-        ).withArgs(
-          cardPaymentProcessor.address,
-          payment.cashbackNonce || 0,
-          cashbackAmount
-        );
+        await cardPaymentProcessorShell.enableCashback();
+        await cardPaymentProcessorShell.makePayments([payment]);
+        await cardPaymentProcessorShell.disableCashback();
 
-        payment.status = PaymentStatus.Revoked;
-        payment.revocationCounter = 1;
-        payment.compensationAmount = 0;
-        payment.unrevokedCashback = cashbackAmount;
-        await checkCardPaymentProcessorState(fixture, [payment]);
+        await revokeSinglePaymentAndCheck(context);
       });
     });
 
     describe("Is reverted if", async () => {
       it("The contract is paused", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-        await pauseContract(cardPaymentProcessor);
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+        await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessor.connect(executor).revokePayment(
+          cardPaymentProcessorShell.contract.connect(executor).revokePayment(
             payment.authorizationId,
             PAYMENT_REVOKING_CORRELATION_ID_STUB,
             payment.parentTxHash
@@ -2153,9 +3183,11 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       });
 
       it("The caller does not have the executor role", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(deployer).revokePayment(
+          cardPaymentProcessorShell.contract.connect(deployer).revokePayment(
             payment.authorizationId,
             PAYMENT_REVOKING_CORRELATION_ID_STUB,
             payment.parentTxHash
@@ -2164,260 +3196,144 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       });
 
       it("The configured revocation limit of payments is zero", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-        await proveTx(cardPaymentProcessor.setRevocationLimit(0));
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+        await proveTx(cardPaymentProcessorShell.contract.setRevocationLimit(0));
 
         await expect(
-          cardPaymentProcessor.connect(executor).revokePayment(
+          cardPaymentProcessorShell.contract.connect(executor).revokePayment(
             payment.authorizationId,
             PAYMENT_REVOKING_CORRELATION_ID_STUB,
             payment.parentTxHash
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_REVOCATION_COUNTER_REACHED_LIMIT);
+        ).to.be.revertedWithCustomError(
+          cardPaymentProcessorShell.contract,
+          REVERT_ERROR_IF_PAYMENT_REVOCATION_COUNTER_REACHED_LIMIT
+        );
       });
 
       it("The payment authorization ID is zero", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(executor).revokePayment(
+          cardPaymentProcessorShell.contract.connect(executor).revokePayment(
             ZERO_AUTHORIZATION_ID,
             PAYMENT_REVOKING_CORRELATION_ID_STUB,
             payment.parentTxHash
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+        ).to.be.revertedWithCustomError(
+          cardPaymentProcessorShell.contract,
+          REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
+        );
       });
 
       it("The parent transaction hash is zero", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(executor).revokePayment(
+          cardPaymentProcessorShell.contract.connect(executor).revokePayment(
             payment.authorizationId,
             PAYMENT_REVOKING_CORRELATION_ID_STUB,
             ZERO_TRANSACTION_HASH,
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PARENT_TX_HASH_IS_ZERO);
+        ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PARENT_TX_HASH_IS_ZERO);
       });
 
       it("The payment with the provided authorization ID does not exist", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(executor).revokePayment(
+          cardPaymentProcessorShell.contract.connect(executor).revokePayment(
             increaseBytesString(payment.authorizationId, BYTES16_LENGTH),
             PAYMENT_REVOKING_CORRELATION_ID_STUB,
             payment.parentTxHash
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
+        ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
       });
     });
   });
 
   describe("Function 'reversePayment()'", async () => {
-    describe("Executes as expected and emits the correct events if the payment is", async () => {
-      const expectedClearedBalance: number = 0;
-      const expectedUnclearedBalance: number = 0;
+    async function reverseSinglePaymentAndCheck(context: TestContext) {
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+      cardPaymentProcessorShell.model.reversePayment(
+        payment.authorizationId,
+        PAYMENT_REVOKING_CORRELATION_ID_STUB,
+        payment.parentTxHash
+      );
+      const tx = cardPaymentProcessorShell.contract.connect(executor).reversePayment(
+        payment.authorizationId,
+        PAYMENT_REVOKING_CORRELATION_ID_STUB,
+        payment.parentTxHash
+      );
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
-      async function checkReversionWithCashback(props: { isPaymentCleared: boolean }) {
-        const { fixture, payment } = await beforeMakingPayment();
-        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
-        setCashback(payment, fixture);
-        const cashbackAmount: number = calculateCashback(payment);
-        const revokedPaymentAmount: number = payment.amount - cashbackAmount;
-        await proveTx(cardPaymentProcessor.enableCashback());
-        await makePayments(cardPaymentProcessor, [payment]);
+      await context.checkPaymentOperationsForTx(tx);
+      await context.checkCardPaymentProcessorState();
+    }
 
-        if (props.isPaymentCleared) {
-          await clearPayments(cardPaymentProcessor, [payment]);
-        }
+    describe("Executes as expected and emits the correct events if", async () => {
+      it("Cashback operations are enabled and the payment status is 'Uncleared'", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-        const tx: TransactionResponse = cardPaymentProcessor.connect(executor).reversePayment(
-          payment.authorizationId,
-          PAYMENT_REVERSING_CORRELATION_ID_STUB,
-          payment.parentTxHash
-        );
-        await expect(tx).to.changeTokenBalances(
-          tokenMock,
-          [cardPaymentProcessor, payment.account, cashbackDistributorMock],
-          [-revokedPaymentAmount - cashbackAmount, +revokedPaymentAmount, +cashbackAmount]
-        ).and.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVERSE_PAYMENT
-        ).withArgs(
-          payment.authorizationId,
-          PAYMENT_REVERSING_CORRELATION_ID_STUB,
-          payment.account.address,
-          revokedPaymentAmount,
-          expectedClearedBalance,
-          expectedUnclearedBalance,
-          props.isPaymentCleared,
-          payment.parentTxHash,
-          payment.revocationCounter || 0
-        );
-        await expect(tx).to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
-        ).withArgs(
-          cashbackDistributorMock.address,
-          cashbackAmount,
-          payment.cashbackNonce || 0
-        );
-        await expect(tx).to.emit(
-          cashbackDistributorMock,
-          EVENT_NAME_REVOKE_CASHBACK_MOCK
-        ).withArgs(
-          cardPaymentProcessor.address,
-          payment.cashbackNonce || 0,
-          cashbackAmount
-        );
-
-        payment.status = PaymentStatus.Reversed;
-        payment.compensationAmount = 0;
-        await checkCardPaymentProcessorState(fixture, [payment]);
-      }
-
-      it("Uncleared", async () => {
-        await checkReversionWithCashback({ isPaymentCleared: false });
+        await cardPaymentProcessorShell.enableCashback();
+        await cardPaymentProcessorShell.makePayments([payment]);
+        await reverseSinglePaymentAndCheck(context);
       });
 
-      it("Cleared", async () => {
-        await checkReversionWithCashback({ isPaymentCleared: true });
-      });
-    });
+      it("Cashback operations are enabled and the payment status is 'Cleared'", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-    describe("Executes successfully and does the following with cashback operations", async () => {
-      it("Does not revoke cashback if cashback operations are disabled before sending", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
-        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
-        await makePayments(cardPaymentProcessor, [payment]);
-
-        await expect(
-          cardPaymentProcessor.connect(executor).reversePayment(
-            payment.authorizationId,
-            PAYMENT_REVERSING_CORRELATION_ID_STUB,
-            payment.parentTxHash
-          )
-        ).to.changeTokenBalances(
-          tokenMock,
-          [cardPaymentProcessor, payment.account, cashbackDistributorMock],
-          [-payment.amount, +payment.amount, 0]
-        ).and.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVERSE_PAYMENT
-        ).and.not.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
-        ).and.not.to.emit(
-          cashbackDistributorMock,
-          EVENT_NAME_REVOKE_CASHBACK_MOCK
-        );
-
-        payment.status = PaymentStatus.Reversed;
-        await checkCardPaymentProcessorState(fixture, [payment]);
+        await cardPaymentProcessorShell.enableCashback();
+        await cardPaymentProcessorShell.makePayments([payment]);
+        await cardPaymentProcessorShell.clearPayments([payment]);
+        await reverseSinglePaymentAndCheck(context);
       });
 
-      it("Does revoke cashback if cashback operations are disabled after sending", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
-        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
-        setCashback(payment, fixture);
-        const cashbackAmount: number = calculateCashback(payment);
-        const revokedPaymentAmount: number = payment.amount - cashbackAmount;
+      it("Cashback operations are enabled but cashback revoking fails", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-        await proveTx(cardPaymentProcessor.enableCashback());
-        await makePayments(cardPaymentProcessor, [payment]);
-        await proveTx(cardPaymentProcessor.disableCashback());
+        await cardPaymentProcessorShell.enableCashback();
+        await cardPaymentProcessorShell.makePayments([payment]);
+        await cardPaymentProcessorShell.disableCashback();
+        await context.cashbackDistributorMockShell.setRevokeCashbackSuccessResult(false);
 
-        const tx: TransactionResponse = cardPaymentProcessor.connect(executor).reversePayment(
-          payment.authorizationId,
-          PAYMENT_REVERSING_CORRELATION_ID_STUB,
-          payment.parentTxHash
-        );
-        await expect(tx).to.changeTokenBalances(
-          tokenMock,
-          [cardPaymentProcessor, payment.account, cashbackDistributorMock],
-          [-revokedPaymentAmount - cashbackAmount, +revokedPaymentAmount, +cashbackAmount]
-        ).and.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVERSE_PAYMENT
-        );
-        await expect(tx).to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
-        ).withArgs(
-          cashbackDistributorMock.address,
-          cashbackAmount,
-          payment.cashbackNonce || 0
-        );
-        await expect(tx).to.emit(
-          cashbackDistributorMock,
-          EVENT_NAME_REVOKE_CASHBACK_MOCK
-        ).withArgs(
-          cardPaymentProcessor.address,
-          payment.cashbackNonce || 0,
-          cashbackAmount
-        );
-
-        payment.status = PaymentStatus.Reversed;
-        payment.compensationAmount = 0;
-        await checkCardPaymentProcessorState(fixture, [payment]);
+        await reverseSinglePaymentAndCheck(context);
       });
 
-      it("Does not revoke cashback if cashback operations are enabled but cashback revoking fails", async () => {
-        const { fixture, payment } = await beforeMakingPayment();
-        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
-        setCashback(payment, fixture);
-        const cashbackAmount: number = calculateCashback(payment);
-        const revokedPaymentAmount: number = payment.amount - cashbackAmount;
+      it("Cashback operations are disabled before sending", async () => {
+        const context = await beforeMakingPayments();
+        await context.cardPaymentProcessorShell.makePayments([context.payments[0]]);
+        await reverseSinglePaymentAndCheck(context);
+      });
 
-        await proveTx(cardPaymentProcessor.enableCashback());
-        await makePayments(cardPaymentProcessor, [payment]);
-        await proveTx(cashbackDistributorMock.setRevokeCashbackSuccessResult(false));
+      it("Cashback operations are disabled after sending", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-        const tx: TransactionResponse = cardPaymentProcessor.connect(executor).reversePayment(
-          payment.authorizationId,
-          PAYMENT_REVERSING_CORRELATION_ID_STUB,
-          payment.parentTxHash
-        );
-        await expect(tx).to.changeTokenBalances(
-          tokenMock,
-          [cardPaymentProcessor, payment.account, cashbackDistributorMock],
-          [-revokedPaymentAmount, +revokedPaymentAmount, 0]
-        ).and.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVERSE_PAYMENT
-        ).and.not.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_CASHBACK_SUCCESS
-        );
-        await expect(tx).to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REVOKE_CASHBACK_FAILURE
-        ).withArgs(
-          cashbackDistributorMock.address,
-          cashbackAmount,
-          payment.cashbackNonce || 0
-        );
-        await expect(tx).to.emit(
-          cashbackDistributorMock,
-          EVENT_NAME_REVOKE_CASHBACK_MOCK
-        ).withArgs(
-          cardPaymentProcessor.address,
-          payment.cashbackNonce || 0,
-          cashbackAmount
-        );
+        await cardPaymentProcessorShell.enableCashback();
+        await cardPaymentProcessorShell.makePayments([payment]);
+        await cardPaymentProcessorShell.disableCashback();
 
-        payment.status = PaymentStatus.Reversed;
-        payment.compensationAmount = 0;
-        payment.unrevokedCashback = cashbackAmount;
-        await checkCardPaymentProcessorState(fixture, [payment]);
+        await reverseSinglePaymentAndCheck(context);
       });
     });
 
     describe("Is reverted if", async () => {
       it("The contract is paused", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-        await pauseContract(cardPaymentProcessor);
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+        await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessor.connect(executor).reversePayment(
+          cardPaymentProcessorShell.contract.connect(executor).reversePayment(
             payment.authorizationId,
             PAYMENT_REVERSING_CORRELATION_ID_STUB,
             payment.parentTxHash
@@ -2426,9 +3342,11 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       });
 
       it("The caller does not have the executor role", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(deployer).reversePayment(
+          cardPaymentProcessorShell.contract.connect(deployer).reversePayment(
             payment.authorizationId,
             PAYMENT_REVERSING_CORRELATION_ID_STUB,
             payment.parentTxHash
@@ -2437,389 +3355,445 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       });
 
       it("The payment authorization ID is zero", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(executor).reversePayment(
+          cardPaymentProcessorShell.contract.connect(executor).reversePayment(
             ZERO_AUTHORIZATION_ID,
             PAYMENT_REVERSING_CORRELATION_ID_STUB,
             payment.parentTxHash
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+        ).to.be.revertedWithCustomError(
+          cardPaymentProcessorShell.contract,
+          REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
+        );
       });
 
       it("The parent transaction hash is zero", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(executor).reversePayment(
+          cardPaymentProcessorShell.contract.connect(executor).reversePayment(
             payment.authorizationId,
             PAYMENT_REVERSING_CORRELATION_ID_STUB,
             ZERO_TRANSACTION_HASH,
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PARENT_TX_HASH_IS_ZERO);
+        ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PARENT_TX_HASH_IS_ZERO);
       });
 
       it("The payment with the provided authorization ID does not exist", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(executor).reversePayment(
+          cardPaymentProcessorShell.contract.connect(executor).reversePayment(
             increaseBytesString(payment.authorizationId, BYTES16_LENGTH),
             PAYMENT_REVERSING_CORRELATION_ID_STUB,
             payment.parentTxHash
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
+        ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
       });
     });
   });
 
   describe("Function 'confirmPayment()'", async () => {
-    it("Executes as expected and emits the correct event", async () => {
-      const { fixture, payment } = await beforeMakingPayment();
-      const { cardPaymentProcessor, tokenMock } = fixture;
-      const expectedClearedBalance: number = 0;
+    it("Executes as expected and emits the correct event if there was no refunding", async () => {
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
 
-      await checkCardPaymentProcessorState(fixture, [payment]);
+      await cardPaymentProcessorShell.enableCashback();
+      await cardPaymentProcessorShell.makePayments([payment]);
+      await cardPaymentProcessorShell.clearPayments([payment]);
 
-      await makePayments(cardPaymentProcessor, [payment]);
-      await clearPayments(cardPaymentProcessor, [payment]);
+      cardPaymentProcessorShell.model.confirmPayment(payment.authorizationId);
+      const tx = cardPaymentProcessorShell.contract.connect(executor).confirmPayment(payment.authorizationId);
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
-      await expect(
-        cardPaymentProcessor.connect(executor).confirmPayment(payment.authorizationId)
-      ).to.changeTokenBalances(
-        tokenMock,
-        [cardPaymentProcessor, cashOutAccount, payment.account],
-        [-payment.amount, +payment.amount, 0]
-      ).and.to.emit(
-        cardPaymentProcessor,
-        EVENT_NAME_CONFIRM_PAYMENT
-      ).withArgs(
-        payment.authorizationId,
-        payment.account.address,
-        payment.amount,
-        expectedClearedBalance,
-        payment.revocationCounter || 0
-      );
+      await context.checkPaymentOperationsForTx(tx);
+      await context.checkCardPaymentProcessorState();
+    });
 
-      payment.status = PaymentStatus.Confirmed;
-      await checkCardPaymentProcessorState(fixture, [payment]);
+    it("Executes as expected and emits the correct event if there was a refund operation", async () => {
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+      await cardPaymentProcessorShell.enableCashback();
+      await cardPaymentProcessorShell.makePayments([payment]);
+      await cardPaymentProcessorShell.clearPayments([payment]);
+      const refundAmount = Math.floor(payment.baseAmount * 0.1);
+      await cardPaymentProcessorShell.refundPayment(payment, refundAmount);
+
+      cardPaymentProcessorShell.model.confirmPayment(payment.authorizationId);
+      const tx = cardPaymentProcessorShell.contract.connect(executor).confirmPayment(payment.authorizationId);
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
+
+      await context.checkPaymentOperationsForTx(tx);
+      await context.checkCardPaymentProcessorState();
     });
 
     it("Is reverted if the contract is paused", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-      await pauseContract(cardPaymentProcessor);
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+      await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessor.connect(executor).confirmPayment(payment.authorizationId)
+        cardPaymentProcessorShell.contract.connect(executor).confirmPayment(payment.authorizationId)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the executor role", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
       await expect(
-        cardPaymentProcessor.connect(deployer).confirmPayment(payment.authorizationId)
+        cardPaymentProcessorShell.contract.connect(deployer).confirmPayment(payment.authorizationId)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
     it("Is reverted if the payment authorization ID is zero", async () => {
-      const { fixture: { cardPaymentProcessor } } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell } = context;
+
       await expect(
-        cardPaymentProcessor.connect(executor).confirmPayment(ZERO_AUTHORIZATION_ID)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+        cardPaymentProcessorShell.contract.connect(executor).confirmPayment(ZERO_AUTHORIZATION_ID)
+      ).to.be.revertedWithCustomError(
+        cardPaymentProcessorShell.contract,
+        REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
+      );
     });
 
     it("Is reverted if the payment with the provided authorization ID does not exist", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
       await expect(
-        cardPaymentProcessor.connect(executor).confirmPayment(
+        cardPaymentProcessorShell.contract.connect(executor).confirmPayment(
           payment.authorizationId
         )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
+      ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Is reverted if the payment is uncleared", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
-      await makePayments(cardPaymentProcessor, [payment]);
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+      await cardPaymentProcessorShell.makePayments([payment]);
 
       await expect(
-        cardPaymentProcessor.connect(executor).confirmPayment(payment.authorizationId)
+        cardPaymentProcessorShell.contract.connect(executor).confirmPayment(payment.authorizationId)
       ).to.be.revertedWithCustomError(
-        cardPaymentProcessor,
+        cardPaymentProcessorShell.contract,
         REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
       ).withArgs(PaymentStatus.Uncleared);
     });
 
     it("Is reverted if the cash-out account is the zero address", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
-      await makePayments(cardPaymentProcessor, [payment]);
-      await clearPayments(cardPaymentProcessor, [payment]);
-      await proveTx(cardPaymentProcessor.setCashOutAccount(ZERO_ADDRESS));
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+      await cardPaymentProcessorShell.makePayments([payment]);
+      await cardPaymentProcessorShell.clearPayments([payment]);
+
+      await proveTx(cardPaymentProcessorShell.contract.setCashOutAccount(ZERO_ADDRESS));
 
       await expect(
-        cardPaymentProcessor.connect(executor).confirmPayment(payment.authorizationId)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO);
+        cardPaymentProcessorShell.contract.connect(executor).confirmPayment(payment.authorizationId)
+      ).to.be.revertedWithCustomError(
+        cardPaymentProcessorShell.contract,
+        REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO
+      );
     });
   });
 
   describe("Function 'confirmPayments()'", async () => {
-    async function beforeConfirmingPayments(): Promise<{
-      fixture: Fixture,
-      payments: TestPayment[],
-      accountAddresses: string[],
-      authorizationIds: string[]
-    }> {
-      const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
-      const payments: TestPayment[] = createTestPayments().slice(0, 2);
-      await setUpContractsForPayments(fixture, payments);
-      await makePayments(fixture.cardPaymentProcessor, payments);
-      await clearPayments(fixture.cardPaymentProcessor, payments);
-      const accountAddresses: string[] = payments.map(payment => payment.account.address);
-      const authorizationIds: string[] = payments.map(payment => payment.authorizationId);
+    it("Executes as expected and emits the correct events", async () => {
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
+      await cardPaymentProcessorShell.makePayments(payments);
+      await cardPaymentProcessorShell.clearPayments(payments);
 
-      return {
-        fixture,
-        payments,
-        accountAddresses,
-        authorizationIds
-      };
-    }
+      const operationIndex1 = cardPaymentProcessorShell.model.confirmPayment(payments[0].authorizationId);
+      const operationIndex2 = cardPaymentProcessorShell.model.confirmPayment(payments[1].authorizationId);
+      const tx = cardPaymentProcessorShell.contract.connect(executor).confirmPayments([
+        payments[0].authorizationId,
+        payments[1].authorizationId
+      ]);
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
-    it("Executes as expected and emits the correct event", async () => {
-      const { fixture, payments, accountAddresses, authorizationIds } = await beforeConfirmingPayments();
-      const { cardPaymentProcessor, tokenMock } = fixture;
-      const expectedClearedBalance: number = 0;
-      const totalAmount: number = countNumberArrayTotal(
-        payments.map(
-          function (payment: TestPayment): number {
-            return payment.amount;
-          }
-        )
-      );
-
-      await checkCardPaymentProcessorState(fixture, payments);
-
-      const tx: TransactionResponse = await cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds);
-      await expect(tx).to.changeTokenBalances(
-        tokenMock,
-        [cardPaymentProcessor, cashOutAccount, ...accountAddresses],
-        [-totalAmount, +totalAmount, ...accountAddresses.map(() => 0)]
-      ).and.to.emit(
-        cardPaymentProcessor,
-        EVENT_NAME_CONFIRM_PAYMENT
-      ).withArgs(
-        authorizationIds[0],
-        payments[0].account.address,
-        payments[0].amount,
-        expectedClearedBalance,
-        payments[0].revocationCounter || 0
-      );
-      await expect(tx).to.emit(
-        cardPaymentProcessor,
-        EVENT_NAME_CONFIRM_PAYMENT
-      ).withArgs(
-        authorizationIds[1],
-        payments[1].account.address,
-        payments[1].amount,
-        expectedClearedBalance,
-        payments[1].revocationCounter || 0
-      );
-
-      payments.forEach((payment: TestPayment) => payment.status = PaymentStatus.Confirmed);
-      await checkCardPaymentProcessorState(fixture, payments);
+      await context.checkPaymentOperationsForTx(tx, [operationIndex1, operationIndex2]);
+      await context.checkCardPaymentProcessorState();
     });
 
     it("Is reverted if the contract is paused", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-      await pauseContract(cardPaymentProcessor);
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+      await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessor.connect(executor).confirmPayments([payment.authorizationId])
+        cardPaymentProcessorShell.contract.connect(executor).confirmPayments([payment.authorizationId])
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the executor role", async () => {
-      const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+
       await expect(
-        cardPaymentProcessor.connect(deployer).confirmPayments([payment.authorizationId])
+        cardPaymentProcessorShell.contract.connect(deployer).confirmPayments([payment.authorizationId])
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
     it("Is reverted if the payment authorization IDs array is empty", async () => {
-      const { fixture: { cardPaymentProcessor } } = await prepareForSinglePayment();
+      const context = await prepareForPayments();
+      const { cardPaymentProcessorShell } = context;
+
       await expect(
-        cardPaymentProcessor.connect(executor).confirmPayments([])
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY);
+        cardPaymentProcessorShell.contract.connect(executor).confirmPayments([])
+      ).to.be.revertedWithCustomError(
+        cardPaymentProcessorShell.contract,
+        REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY
+      );
     });
 
     it("Is reverted if one of the payment authorization IDs is zero", async () => {
-      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeConfirmingPayments();
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
+      await cardPaymentProcessorShell.makePayments(payments);
+      await cardPaymentProcessorShell.clearPayments(payments);
+
       await expect(
-        cardPaymentProcessor.connect(executor).confirmPayments(
-          [authorizationIds[0], ZERO_AUTHORIZATION_ID]
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+        cardPaymentProcessorShell.contract.connect(executor).confirmPayments([
+          payments[0].authorizationId,
+          ZERO_AUTHORIZATION_ID
+        ])
+      ).to.be.revertedWithCustomError(
+        cardPaymentProcessorShell.contract,
+        REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
+      );
     });
 
     it("Is reverted if one of the payments with provided authorization IDs does not exist", async () => {
-      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeConfirmingPayments();
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
+      await cardPaymentProcessorShell.makePayments(payments);
+      await cardPaymentProcessorShell.clearPayments(payments);
+
       await expect(
-        cardPaymentProcessor.connect(executor).confirmPayments(
-          [
-            authorizationIds[0],
-            increaseBytesString(authorizationIds[1], BYTES16_LENGTH)
-          ]
-        )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
+        cardPaymentProcessorShell.contract.connect(executor).confirmPayments([
+          payments[0].authorizationId,
+          increaseBytesString(payments[1].authorizationId, BYTES16_LENGTH)
+        ])
+      ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
     it("Is reverted if one of the payments is uncleared", async () => {
-      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeConfirmingPayments();
-      await proveTx(cardPaymentProcessor.connect(executor).unclearPayment(authorizationIds[1]));
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
+      await cardPaymentProcessorShell.makePayments(payments);
+      await cardPaymentProcessorShell.clearPayments(payments);
+
+      await proveTx(cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payments[1].authorizationId));
 
       await expect(
-        cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds)
+        cardPaymentProcessorShell.contract.connect(executor).confirmPayments([
+          payments[0].authorizationId,
+          payments[1].authorizationId
+        ])
       ).to.be.revertedWithCustomError(
-        cardPaymentProcessor,
+        cardPaymentProcessorShell.contract,
         REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
       ).withArgs(PaymentStatus.Uncleared);
     });
 
     it("Is reverted if the cash-out account is the zero address", async () => {
-      const { fixture: { cardPaymentProcessor }, authorizationIds } = await beforeConfirmingPayments();
-      await proveTx(cardPaymentProcessor.setCashOutAccount(ZERO_ADDRESS));
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
+      await cardPaymentProcessorShell.makePayments(payments);
+      await cardPaymentProcessorShell.clearPayments(payments);
+
+      await proveTx(cardPaymentProcessorShell.contract.setCashOutAccount(ZERO_ADDRESS));
 
       await expect(
-        cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds)
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO);
+        cardPaymentProcessorShell.contract.connect(executor).confirmPayments([
+          payments[0].authorizationId,
+          payments[1].authorizationId
+        ])
+      ).to.be.revertedWithCustomError(
+        cardPaymentProcessorShell.contract,
+        REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO
+      );
     });
   });
 
   describe("Function 'refundPayment()'", async () => {
+
+    enum RefundType {
+      Zero = 0,
+      Nonzero = 1,
+      Full = 2
+    }
+
+    enum NewExtraAmountType {
+      Same = 0,
+      Less = 1,
+      Zero = 2,
+    }
+
+    async function checkRefunding(
+      refundType: RefundType,
+      newExtraAmountType: NewExtraAmountType,
+      paymentStatus: PaymentStatus
+    ) {
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+      await cardPaymentProcessorShell.enableCashback();
+      await cardPaymentProcessorShell.makePayments([payment]);
+
+      let refundAmount = 0;
+      switch (refundType) {
+        case RefundType.Nonzero:
+          refundAmount = Math.floor(payment.baseAmount * 0.1);
+          break;
+        case RefundType.Full:
+          refundAmount = payment.baseAmount;
+          break;
+      }
+
+      let newExtraAmount = 0;
+      switch (newExtraAmountType) {
+        case NewExtraAmountType.Same:
+          newExtraAmount = payment.extraAmount;
+          break;
+        case NewExtraAmountType.Less:
+          newExtraAmount = Math.floor(payment.extraAmount * 0.5);
+          break;
+        case NewExtraAmountType.Zero:
+          newExtraAmount = 0;
+          break;
+      }
+
+      if (paymentStatus == PaymentStatus.Cleared) {
+        await cardPaymentProcessorShell.clearPayments([payment]);
+      }
+      if (paymentStatus == PaymentStatus.Confirmed) {
+        await cardPaymentProcessorShell.clearPayments([payment]);
+        await cardPaymentProcessorShell.confirmPayments([payment]);
+      }
+
+      cardPaymentProcessorShell.model.refundPayment(
+        refundAmount,
+        newExtraAmount,
+        payment.authorizationId,
+        PAYMENT_REFUNDING_CORRELATION_ID_STUB
+      );
+      const tx = cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT](
+        refundAmount,
+        newExtraAmount,
+        payment.authorizationId,
+        PAYMENT_REFUNDING_CORRELATION_ID_STUB
+      );
+      expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
+
+      await context.checkPaymentOperationsForTx(tx);
+      await context.checkCardPaymentProcessorState();
+    }
+
     describe("Executes as expected and emits the correct events if the refund amount is", async () => {
-      enum RefundType {
-        Zero = 0,
-        Nonzero = 1,
-        Full = 2
-      }
-
-      async function checkRefunding(props: { refundType: RefundType, paymentStatus: PaymentStatus }) {
-        const { fixture, payment } = await beforeMakingPayment();
-        const { cardPaymentProcessor, tokenMock, cashbackDistributorMock } = fixture;
-        setCashback(payment, fixture);
-        await proveTx(fixture.cardPaymentProcessor.enableCashback());
-        await makePayments(cardPaymentProcessor, [payment]);
-
-        let refundAmount = 0;
-        if (props.refundType === RefundType.Nonzero) {
-          refundAmount = Math.floor(payment.amount * 0.1);
-        } else if (props.refundType === RefundType.Full) {
-          refundAmount = payment.amount;
-        }
-
-        let tokenSourceAccount: SignerWithAddress | Contract = cardPaymentProcessor;
-        if (props.paymentStatus == PaymentStatus.Cleared) {
-          await clearPayments(cardPaymentProcessor, [payment]);
-        }
-        if (props.paymentStatus == PaymentStatus.Confirmed) {
-          tokenSourceAccount = cashOutAccount;
-          await clearPayments(cardPaymentProcessor, [payment]);
-          await confirmPayments(cardPaymentProcessor, [payment]);
-        }
-
-        await checkCardPaymentProcessorState(fixture, [payment]);
-
-        setRefundAmount(payment, refundAmount);
-        const revocationCashbackAmount = calculateRefundCashbackDifference(payment);
-        const userSentAmount = refundAmount - revocationCashbackAmount;
-        let processorSentAmount = -(userSentAmount + revocationCashbackAmount);
-        let cashOutAccountSentAmount = 0;
-        if (tokenSourceAccount == cashOutAccount) {
-          cashOutAccountSentAmount = processorSentAmount;
-          processorSentAmount = 0;
-        }
-
-        const tx: TransactionResponse = await cardPaymentProcessor.connect(executor).refundPayment(
-          refundAmount,
-          payment.authorizationId,
-          PAYMENT_REFUNDING_CORRELATION_ID_STUB
-        );
-        await expect(tx).to.changeTokenBalances(
-          tokenMock,
-          [cardPaymentProcessor, payment.account, cashOutAccount, cashbackDistributorMock],
-          [processorSentAmount, userSentAmount, cashOutAccountSentAmount, +revocationCashbackAmount]
-        ).and.to.emit(
-          cardPaymentProcessor,
-          EVENT_NAME_REFUND_PAYMENT
-        ).withArgs(
-          payment.authorizationId,
-          PAYMENT_REFUNDING_CORRELATION_ID_STUB,
-          payment.account.address,
-          payment.refundAmount,
-          userSentAmount,
-          payment.status
-        );
-        await expect(tx).to.emit(
-          cashbackDistributorMock,
-          EVENT_NAME_REVOKE_CASHBACK_MOCK
-        ).withArgs(
-          cardPaymentProcessor.address,
-          payment.cashbackNonce || 0,
-          revocationCashbackAmount
-        );
-
-        await checkCardPaymentProcessorState(fixture, [payment]);
-      }
-
-      describe("Nonzero and the payment status is", async () => {
-        it("Uncleared", async () => {
-          await checkRefunding({ refundType: RefundType.Nonzero, paymentStatus: PaymentStatus.Uncleared });
+      describe("Nonzero and the new extra amount of the payment is", async () => {
+        describe("The same as the initial one and the payment status is", async () => {
+          it("Uncleared", async () => {
+            await checkRefunding(RefundType.Nonzero, NewExtraAmountType.Same, PaymentStatus.Uncleared);
+          });
         });
 
-        it("Cleared", async () => {
-          await checkRefunding({ refundType: RefundType.Nonzero, paymentStatus: PaymentStatus.Cleared });
+        describe("Less than the initial one and the payment status is", async () => {
+          it("Uncleared", async () => {
+            await checkRefunding(RefundType.Nonzero, NewExtraAmountType.Less, PaymentStatus.Uncleared);
+          });
+
+          it("Cleared", async () => {
+            await checkRefunding(RefundType.Nonzero, NewExtraAmountType.Less, PaymentStatus.Cleared);
+          });
+
+          it("Confirmed", async () => {
+            await checkRefunding(RefundType.Nonzero, NewExtraAmountType.Less, PaymentStatus.Confirmed);
+          });
         });
 
-        it("Confirmed", async () => {
-          await checkRefunding({ refundType: RefundType.Nonzero, paymentStatus: PaymentStatus.Confirmed });
-        })
-        ;
-      });
-
-      describe("Equals the payment amount and the payment status is", async () => {
-        it("Uncleared", async () => {
-          await checkRefunding({ refundType: RefundType.Full, paymentStatus: PaymentStatus.Uncleared });
-        });
-
-        it("Cleared", async () => {
-          await checkRefunding({ refundType: RefundType.Full, paymentStatus: PaymentStatus.Cleared });
-        });
-
-        it("Confirmed", async () => {
-          await checkRefunding({ refundType: RefundType.Full, paymentStatus: PaymentStatus.Confirmed });
+        describe("Zero and the payment status is", async () => {
+          it("Uncleared", async () => {
+            await checkRefunding(RefundType.Nonzero, NewExtraAmountType.Zero, PaymentStatus.Uncleared);
+          });
         });
       });
 
-      describe("Zero and the payment status is", async () => {
-        it("Uncleared", async () => {
-          await checkRefunding({ refundType: RefundType.Zero, paymentStatus: PaymentStatus.Cleared });
+      describe("Equals the base payment amount and the new extra amount of the payment is", async () => {
+        describe("The same as the initial one and the payment status is", async () => {
+          it("Uncleared", async () => {
+            await checkRefunding(RefundType.Full, NewExtraAmountType.Same, PaymentStatus.Uncleared);
+          });
         });
 
-        it("Cleared", async () => {
-          await checkRefunding({ refundType: RefundType.Zero, paymentStatus: PaymentStatus.Uncleared });
+        describe("Less than the initial one and the payment status is", async () => {
+          it("Uncleared", async () => {
+            await checkRefunding(RefundType.Full, NewExtraAmountType.Less, PaymentStatus.Uncleared);
+          });
+
+          it("Cleared", async () => {
+            await checkRefunding(RefundType.Full, NewExtraAmountType.Less, PaymentStatus.Cleared);
+          });
+
+          it("Confirmed", async () => {
+            await checkRefunding(RefundType.Full, NewExtraAmountType.Less, PaymentStatus.Confirmed);
+          });
         });
 
-        it("Confirmed", async () => {
-          await checkRefunding({ refundType: RefundType.Zero, paymentStatus: PaymentStatus.Confirmed });
+        describe("Zero and the payment status is", async () => {
+          it("Uncleared", async () => {
+            await checkRefunding(RefundType.Full, NewExtraAmountType.Zero, PaymentStatus.Uncleared);
+          });
+        });
+      });
+
+      describe("Zero and the new extra amount of the payment is", async () => {
+        describe("The same as the initial one and the payment status is", async () => {
+          it("Uncleared", async () => {
+            await checkRefunding(RefundType.Zero, NewExtraAmountType.Same, PaymentStatus.Uncleared);
+          });
+        });
+
+        describe("Less than the initial one and the payment status is", async () => {
+          it("Uncleared", async () => {
+            await checkRefunding(RefundType.Zero, NewExtraAmountType.Less, PaymentStatus.Uncleared);
+          });
+
+          it("Cleared", async () => {
+            await checkRefunding(RefundType.Zero, NewExtraAmountType.Less, PaymentStatus.Cleared);
+          });
+
+          it("Confirmed", async () => {
+            await checkRefunding(RefundType.Zero, NewExtraAmountType.Less, PaymentStatus.Confirmed);
+          });
+        });
+
+        describe("Zero and the payment status is", async () => {
+          it("Uncleared", async () => {
+            await checkRefunding(RefundType.Zero, NewExtraAmountType.Zero, PaymentStatus.Uncleared);
+          });
         });
       });
     });
 
     describe("Is reverted if", async () => {
       it("The contract is paused", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
-        await pauseContract(cardPaymentProcessor);
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+        await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessor.connect(executor).refundPayment(
-            payment.refundAmount,
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT](
+            payment.baseAmount,
+            payment.extraAmount,
             payment.authorizationId,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
           )
@@ -2827,10 +3801,13 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       });
 
       it("The caller does not have the executor role", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(deployer).refundPayment(
-            payment.refundAmount,
+          cardPaymentProcessorShell.contract.connect(deployer).functions[FUNCTION_REFUND_PAYMENT](
+            payment.baseAmount,
+            payment.extraAmount,
             payment.authorizationId,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
           )
@@ -2838,119 +3815,141 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       });
 
       it("The payment authorization ID is zero", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(executor).refundPayment(
-            payment.refundAmount,
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT](
+            payment.baseAmount,
+            payment.extraAmount,
             ZERO_AUTHORIZATION_ID,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO);
+        ).to.be.revertedWithCustomError(
+          cardPaymentProcessorShell.contract,
+          REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
+        );
       });
 
       it("The payment with the provided authorization ID does not exist", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await prepareForSinglePayment();
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
         await expect(
-          cardPaymentProcessor.connect(executor).refundPayment(
-            payment.refundAmount,
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT](
+            payment.baseAmount,
+            payment.extraAmount,
             payment.authorizationId,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
           )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
+        ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
       });
 
-      it("The refund amount exceeds the payment amount", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
-        await makePayments(cardPaymentProcessor, [payment]);
-        setRefundAmount(payment, payment.amount + 1);
+      it("The refund amount exceeds the base payment amount", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+        await cardPaymentProcessorShell.makePayments([payment]);
+        const refundAmount = payment.baseAmount + 1;
 
         await expect(
-          cardPaymentProcessor.connect(executor).refundPayment(
-            payment.refundAmount,
-            payment.authorizationId,
-            PAYMENT_REFUNDING_CORRELATION_ID_STUB
-          )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_REFUND_AMOUNT_IS_INAPPROPRIATE);
-      });
-
-      it("The payment is confirmed, but the cash-out amount address is zero", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
-        await makePayments(cardPaymentProcessor, [payment]);
-        await clearPayments(cardPaymentProcessor, [payment]);
-        await confirmPayments(cardPaymentProcessor, [payment]);
-        await proveTx(cardPaymentProcessor.setCashOutAccount(ZERO_ADDRESS));
-
-        await expect(
-          cardPaymentProcessor.connect(executor).refundPayment(
-            payment.refundAmount,
-            payment.authorizationId,
-            PAYMENT_REFUNDING_CORRELATION_ID_STUB
-          )
-        ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO);
-      });
-
-      it("The payment status is 'Revoked'", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
-        await makePayments(cardPaymentProcessor, [payment]);
-        await proveTx(cardPaymentProcessor.connect(executor).revokePayment(
-          payment.authorizationId,
-          PAYMENT_REVOKING_CORRELATION_ID_STUB,
-          payment.parentTxHash
-        ));
-
-        await expect(
-          cardPaymentProcessor.connect(executor).refundPayment(
-            payment.refundAmount,
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT](
+            refundAmount,
+            payment.extraAmount,
             payment.authorizationId,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
           )
         ).to.be.revertedWithCustomError(
-          cardPaymentProcessor,
+          cardPaymentProcessorShell.contract,
+          REVERT_ERROR_IF_REFUND_AMOUNT_IS_INAPPROPRIATE
+        );
+      });
+
+      it("The payment is confirmed, but the cash-out amount address is zero", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+        await cardPaymentProcessorShell.makePayments([payment]);
+        await cardPaymentProcessorShell.clearPayments([payment]);
+        await cardPaymentProcessorShell.confirmPayments([payment]);
+
+        await proveTx(cardPaymentProcessorShell.contract.setCashOutAccount(ZERO_ADDRESS));
+
+        await expect(
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT](
+            payment.baseAmount,
+            payment.extraAmount,
+            payment.authorizationId,
+            PAYMENT_REFUNDING_CORRELATION_ID_STUB
+          )
+        ).to.be.revertedWithCustomError(
+          cardPaymentProcessorShell.contract,
+          REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO
+        );
+      });
+
+      it("The payment status is 'Revoked'", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+        await cardPaymentProcessorShell.makePayments([payment]);
+        await cardPaymentProcessorShell.revokePayment(payment);
+
+        await expect(
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT](
+            payment.baseAmount,
+            payment.extraAmount,
+            payment.authorizationId,
+            PAYMENT_REFUNDING_CORRELATION_ID_STUB
+          )
+        ).to.be.revertedWithCustomError(
+          cardPaymentProcessorShell.contract,
           REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
         ).withArgs(PaymentStatus.Revoked);
       });
 
       it("The payment status is 'Reversed'", async () => {
-        const { fixture: { cardPaymentProcessor }, payment } = await beforeMakingPayment();
-        await makePayments(cardPaymentProcessor, [payment]);
-        await proveTx(cardPaymentProcessor.connect(executor).reversePayment(
-          payment.authorizationId,
-          PAYMENT_REVERSING_CORRELATION_ID_STUB,
-          payment.parentTxHash
-        ));
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+        await cardPaymentProcessorShell.makePayments([payment]);
+        await cardPaymentProcessorShell.reversePayment(payment);
 
         await expect(
-          cardPaymentProcessor.connect(executor).refundPayment(
-            payment.refundAmount,
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT](
+            payment.baseAmount,
+            payment.extraAmount,
             payment.authorizationId,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
           )
         ).to.be.revertedWithCustomError(
-          cardPaymentProcessor,
+          cardPaymentProcessorShell.contract,
           REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
         ).withArgs(PaymentStatus.Reversed);
+      });
+
+      it("The new extra amount exceeds the old one of the payment", async () => {
+        const context = await beforeMakingPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+        await cardPaymentProcessorShell.makePayments([payment]);
+        payment.extraAmount += 1;
+
+        await expect(
+          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT](
+            payment.baseAmount,
+            payment.extraAmount,
+            payment.authorizationId,
+            PAYMENT_REFUNDING_CORRELATION_ID_STUB
+          )
+        ).to.be.revertedWithCustomError(
+          cardPaymentProcessorShell.contract,
+          REVERT_ERROR_IF_NEW_EXTRA_PAYMENT_AMOUNT_IS_INAPPROPRIATE
+        );
       });
     });
   });
 
   describe("Complex scenarios without cashback", async () => {
-    async function beforeMakingPayments(): Promise<{
-      fixture: Fixture,
-      payments: TestPayment[],
-    }> {
-      const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
-      const payments: TestPayment[] = createTestPayments().slice(0, 2);
-      await setUpContractsForPayments(fixture, payments);
-
-      return {
-        fixture,
-        payments,
-      };
-    }
-
     async function checkRevertingOfAllPaymentProcessingFunctionsExceptMaking(
       cardPaymentProcessor: Contract,
-      payments: TestPayment[]
+      payments: TestPayment[],
+      status: PaymentStatus
     ) {
       const authorizationIds = payments.map(payment => payment.authorizationId);
       await expect(
@@ -2958,28 +3957,28 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       ).to.be.revertedWithCustomError(
         cardPaymentProcessor,
         REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
-      ).withArgs(payments[0].status);
+      ).withArgs(status);
 
       await expect(
         cardPaymentProcessor.connect(executor).clearPayments(authorizationIds)
       ).to.be.revertedWithCustomError(
         cardPaymentProcessor,
         REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
-      ).withArgs(payments[0].status);
+      ).withArgs(status);
 
       await expect(
         cardPaymentProcessor.connect(executor).unclearPayment(authorizationIds[0])
       ).to.be.revertedWithCustomError(
         cardPaymentProcessor,
         REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
-      ).withArgs(payments[0].status);
+      ).withArgs(status);
 
       await expect(
         cardPaymentProcessor.connect(executor).unclearPayments(authorizationIds)
       ).to.be.revertedWithCustomError(
         cardPaymentProcessor,
         REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
-      ).withArgs(payments[0].status);
+      ).withArgs(status);
 
       await expect(
         cardPaymentProcessor.connect(executor).revokePayment(
@@ -2990,7 +3989,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       ).to.be.revertedWithCustomError(
         cardPaymentProcessor,
         REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
-      ).withArgs(payments[0].status);
+      ).withArgs(status);
 
       await expect(
         cardPaymentProcessor.connect(executor).reversePayment(
@@ -3001,331 +4000,253 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       ).to.be.revertedWithCustomError(
         cardPaymentProcessor,
         REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
-      ).withArgs(payments[0].status);
+      ).withArgs(status);
 
       await expect(
         cardPaymentProcessor.connect(executor).confirmPayment(authorizationIds[0])
       ).to.be.revertedWithCustomError(
         cardPaymentProcessor,
         REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
-      ).withArgs(payments[0].status);
+      ).withArgs(status);
 
       await expect(
         cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds)
       ).to.be.revertedWithCustomError(
         cardPaymentProcessor,
         REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
-      ).withArgs(payments[0].status);
+      ).withArgs(status);
 
       await expect(
-        cardPaymentProcessor.connect(executor).updatePaymentAmount(
-          payments[0].amount,
+        cardPaymentProcessor.connect(executor).functions[FUNCTION_UPDATE_PAYMENT_AMOUNT](
+          payments[0].baseAmount,
+          payments[0].extraAmount,
           authorizationIds[0],
           PAYMENT_UPDATING_CORRELATION_ID_STUB)
       ).to.be.revertedWithCustomError(
         cardPaymentProcessor,
         REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
-      ).withArgs(payments[0].status);
+      ).withArgs(status);
     }
 
     it("All payment processing functions except making are reverted if a payment was revoked", async () => {
-      const { fixture, payments } = await beforeMakingPayments();
-      const { cardPaymentProcessor, tokenMock } = fixture;
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
 
-      await makePayments(cardPaymentProcessor, payments);
+      await cardPaymentProcessorShell.makePayments(payments);
+      await cardPaymentProcessorShell.revokePayment(payments[0]);
 
-      await proveTx(
-        cardPaymentProcessor.connect(executor).revokePayment(
-          payments[0].authorizationId,
-          PAYMENT_REVOKING_CORRELATION_ID_STUB,
-          payments[0].parentTxHash
-        )
+      await context.checkCardPaymentProcessorState();
+      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking(
+        cardPaymentProcessorShell.contract,
+        payments,
+        PaymentStatus.Revoked
       );
-      payments[0].status = PaymentStatus.Revoked;
-      payments[0].revocationCounter = 1;
 
-      await checkCardPaymentProcessorState(fixture, payments);
-      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking(cardPaymentProcessor, payments);
-
-      await expect(
-        cardPaymentProcessor.connect(payments[0].account).makePayment(
-          payments[0].amount,
-          payments[0].authorizationId,
-          payments[0].correlationId,
-        )
-      ).to.changeTokenBalances(
-        tokenMock,
-        [cardPaymentProcessor, payments[0].account],
-        [+payments[0].amount, -payments[0].amount]
-      ).and.to.emit(
-        cardPaymentProcessor,
-        EVENT_NAME_MAKE_PAYMENT
-      ).withArgs(
-        payments[0].authorizationId,
-        payments[0].correlationId,
+      cardPaymentProcessorShell.model.makePayment(payments[0], executor);
+      const tx = cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_MAKE_PAYMENT_FROM](
         payments[0].account.address,
-        payments[0].amount,
-        payments[0].revocationCounter || 0,
-        payments[0].account.address
+        payments[0].baseAmount,
+        payments[0].extraAmount,
+        payments[0].authorizationId,
+        payments[0].correlationId
       );
-
-      payments[0].status = PaymentStatus.Uncleared;
-      payments[0].parentTxHash = increaseBytesString(payments[0].parentTxHash, BYTES32_LENGTH);
-      await checkCardPaymentProcessorState(fixture, payments);
+      await context.checkPaymentOperationsForTx(tx);
+      await context.checkCardPaymentProcessorState();
     });
 
     it("All payment processing functions are reverted if a payment was reversed", async () => {
-      const { fixture, payments } = await beforeMakingPayments();
-      const { cardPaymentProcessor } = fixture;
-      await makePayments(cardPaymentProcessor, payments);
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
 
-      await proveTx(
-        cardPaymentProcessor.connect(executor).reversePayment(
-          payments[0].authorizationId,
-          PAYMENT_REVERSING_CORRELATION_ID_STUB,
-          payments[0].parentTxHash
-        )
-      );
-      payments[0].status = PaymentStatus.Reversed;
+      await cardPaymentProcessorShell.makePayments(payments);
+      await cardPaymentProcessorShell.reversePayment(payments[0]);
 
       await expect(
-        cardPaymentProcessor.makePayment(
-          payments[0].amount,
+        cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_MAKE_PAYMENT_FROM](
+          payments[0].account.address,
+          payments[0].baseAmount,
+          payments[0].extraAmount,
           payments[0].authorizationId,
           payments[0].correlationId
         )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
+      ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
 
-      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking(cardPaymentProcessor, payments);
-      await checkCardPaymentProcessorState(fixture, payments);
+      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking(
+        cardPaymentProcessorShell.contract,
+        payments,
+        PaymentStatus.Reversed
+      );
+      await context.checkCardPaymentProcessorState();
     });
 
     it("All payment processing functions are reverted if a payment was confirmed", async () => {
-      const { fixture, payments } = await beforeMakingPayments();
-      const { cardPaymentProcessor } = fixture;
-      await makePayments(cardPaymentProcessor, payments);
-      await clearPayments(cardPaymentProcessor, payments);
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, payments } = context;
 
-      await confirmPayments(cardPaymentProcessor, [payments[0]]);
+      await cardPaymentProcessorShell.makePayments(payments);
+      await cardPaymentProcessorShell.clearPayments(payments);
+      await cardPaymentProcessorShell.confirmPayments([payments[0]]);
 
       await expect(
-        cardPaymentProcessor.makePayment(
-          payments[0].amount,
+        cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_MAKE_PAYMENT_FROM](
+          payments[0].account.address,
+          payments[0].baseAmount,
+          payments[0].extraAmount,
           payments[0].authorizationId,
           payments[0].correlationId
         )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
+      ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
 
-      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking(cardPaymentProcessor, payments);
-      await checkCardPaymentProcessorState(fixture, payments);
+      await checkRevertingOfAllPaymentProcessingFunctionsExceptMaking(
+        cardPaymentProcessorShell.contract,
+        payments,
+        PaymentStatus.Confirmed
+      );
+      await context.checkCardPaymentProcessorState();
     });
 
     it("Making payment function is reverted if the payment has the 'Cleared' status", async () => {
-      const { fixture, payments } = await beforeMakingPayments();
-      const { cardPaymentProcessor } = fixture;
-      await makePayments(cardPaymentProcessor, [payments[0]]);
-      await clearPayments(cardPaymentProcessor, [payments[0]]);
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments } = context;
+
+      await cardPaymentProcessorShell.makePayments(payments);
+      await cardPaymentProcessorShell.clearPayments(payments);
 
       await expect(
-        cardPaymentProcessor.connect(payments[0].account).makePayment(
-          payments[0].amount,
+        cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_MAKE_PAYMENT_FROM](
+          payments[0].account.address,
+          payments[0].baseAmount,
+          payments[0].extraAmount,
           payments[0].authorizationId,
-          payments[0].correlationId,
+          payments[0].correlationId
         )
-      ).to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
+      ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_ALREADY_EXISTS);
     });
 
     it("Making payment function is reverted if the revocation counter has reached the limit", async () => {
-      const { fixture, payments } = await beforeMakingPayments();
-      const { cardPaymentProcessor } = fixture;
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments } = context;
       const revocationCounterMax: number = 1;
 
-      await proveTx(cardPaymentProcessor.setRevocationLimit(revocationCounterMax));
-      expect(await cardPaymentProcessor.revocationLimit()).to.equal(revocationCounterMax);
+      await proveTx(cardPaymentProcessorShell.contract.setRevocationLimit(revocationCounterMax));
+      expect(await cardPaymentProcessorShell.contract.revocationLimit()).to.equal(revocationCounterMax);
 
       for (let relocationCounter = 0; relocationCounter < revocationCounterMax; ++relocationCounter) {
-        await makePayments(cardPaymentProcessor, [payments[0]]);
-        await proveTx(
-          cardPaymentProcessor.connect(executor).revokePayment(
-            payments[0].authorizationId,
-            PAYMENT_REVOKING_CORRELATION_ID_STUB,
-            payments[0].parentTxHash
-          )
-        );
-        payments[0].status = PaymentStatus.Revoked;
-        payments[0].revocationCounter = relocationCounter + 1;
-        await checkCardPaymentProcessorState(fixture, payments);
+        await cardPaymentProcessorShell.makePayments([payments[0]]);
+        await cardPaymentProcessorShell.revokePayment(payments[0]);
       }
+      await context.checkCardPaymentProcessorState();
 
       await expect(
-        cardPaymentProcessor.connect(payments[0].account).makePayment(
-          payments[0].amount,
+        cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_MAKE_PAYMENT_FROM](
+          payments[0].account.address,
+          payments[0].baseAmount,
+          payments[0].extraAmount,
           payments[0].authorizationId,
-          payments[0].correlationId,
+          payments[0].correlationId
         )
       ).to.be.revertedWithCustomError(
-        cardPaymentProcessor,
+        cardPaymentProcessorShell.contract,
         REVERT_ERROR_IF_PAYMENT_REVOCATION_COUNTER_REACHED_LIMIT
       );
     });
 
-    it("All payment processing functions execute successfully if the payment amount is zero", async () => {
-      const { fixture, payments } = await beforeMakingPayments();
-      const { cardPaymentProcessor, tokenMock } = fixture;
-      payments.forEach(payment => payment.amount = 0);
+    it("All payment processing functions execute successfully if both base and extra amounts are zero", async () => {
+      const context = await beforeMakingPayments({ paymentNumber: 2 });
+      const { cardPaymentProcessorShell, tokenMock, payments } = context;
+      payments.forEach(payment => {
+        payment.baseAmount = 0;
+        payment.extraAmount = 0;
+      });
 
-      await makePayments(cardPaymentProcessor, payments);
-      await checkCardPaymentProcessorState(fixture, payments);
+      await cardPaymentProcessorShell.makePayments(payments);
+      await context.checkCardPaymentProcessorState();
 
-      await clearPayments(cardPaymentProcessor, payments);
-      await checkCardPaymentProcessorState(fixture, payments);
+      await cardPaymentProcessorShell.clearPayments(payments);
+      await context.checkCardPaymentProcessorState();
 
-      await unclearPayments(cardPaymentProcessor, payments);
-      await checkCardPaymentProcessorState(fixture, payments);
+      await cardPaymentProcessorShell.unclearPayments(payments);
+      await context.checkCardPaymentProcessorState();
 
-      await proveTx(
-        cardPaymentProcessor.connect(executor).revokePayment(
-          payments[0].authorizationId,
-          PAYMENT_REVOKING_CORRELATION_ID_STUB,
-          payments[0].parentTxHash
-        )
-      );
-      payments[0].status = PaymentStatus.Revoked;
-      payments[0].revocationCounter = 1;
+      await cardPaymentProcessorShell.revokePayment(payments[0]);
+      await context.checkCardPaymentProcessorState();
 
-      await checkCardPaymentProcessorState(fixture, payments);
+      await cardPaymentProcessorShell.reversePayment(payments[1]);
+      await context.checkCardPaymentProcessorState();
 
-      await proveTx(
-        cardPaymentProcessor.connect(executor).reversePayment(
-          payments[1].authorizationId,
-          PAYMENT_REVERSING_CORRELATION_ID_STUB,
-          payments[1].parentTxHash
-        )
-      );
-      payments[1].status = PaymentStatus.Reversed;
-      await checkCardPaymentProcessorState(fixture, payments);
-
-      await makePayments(cardPaymentProcessor, [payments[0]]);
-      await clearPayments(cardPaymentProcessor, [payments[0]]);
+      await cardPaymentProcessorShell.makePayments([payments[0]]);
+      await cardPaymentProcessorShell.clearPayments([payments[0]]);
 
       const cashOutAccountBalanceBefore: BigNumber = await tokenMock.balanceOf(cashOutAccount.address);
-      await confirmPayments(cardPaymentProcessor, [payments[0]]);
+      await cardPaymentProcessorShell.confirmPayments([payments[0]]);
       const cashOutAccountBalanceAfter: BigNumber = await tokenMock.balanceOf(cashOutAccount.address);
-      await checkCardPaymentProcessorState(fixture, payments);
+      await context.checkCardPaymentProcessorState();
       expect(cashOutAccountBalanceBefore).to.equal(cashOutAccountBalanceAfter);
     });
   });
 
   describe("Complex scenarios with cashback", async () => {
+    it("Several refund and payment updating operations execute as expected if cashback is enabled", async () => {
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+      expect(payment).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
-    it("No cashback distributor contract's function are called if the cashback operations are disabled", async () => {
-      const { fixture: { cardPaymentProcessor, cashbackDistributorMock }, payment } = await beforeMakingPayment();
-      await expect(
-        cardPaymentProcessor.connect(executor).makePaymentFrom(
-          payment.account.address,
-          payment.amount,
-          payment.authorizationId,
-          payment.correlationId
-        )
-      ).not.to.emit(
-        cashbackDistributorMock,
-        EVENT_NAME_SEND_CASHBACK_MOCK
+      await cardPaymentProcessorShell.enableCashback();
+      await cardPaymentProcessorShell.makePayments([payment]);
+
+      await context.checkCardPaymentProcessorState();
+
+      await cardPaymentProcessorShell.updatePaymentAmount(payment, Math.floor(payment.baseAmount * 2));
+      await cardPaymentProcessorShell.refundPayment(payment, Math.floor(payment.baseAmount * 0.1));
+      await cardPaymentProcessorShell.updatePaymentAmount(
+        payment,
+        Math.floor(payment.baseAmount * 0.9),
+        Math.floor(payment.extraAmount * 1.1),
       );
-      await expect(
-        cardPaymentProcessor.connect(executor).revokePayment(
-          payment.authorizationId,
-          PAYMENT_REVOKING_CORRELATION_ID_STUB,
-          payment.parentTxHash
-        )
-      ).not.to.emit(
-        cashbackDistributorMock,
-        EVENT_NAME_REVOKE_CASHBACK_MOCK
+      await cardPaymentProcessorShell.refundPayment(
+        payment,
+        Math.floor(payment.baseAmount * 0.2),
+        Math.floor(payment.extraAmount * 0.1),
       );
-      payment.revocationCounter = 1;
-      await expect(
-        cardPaymentProcessor.connect(executor).makePaymentFrom(
-          payment.account.address,
-          payment.amount,
-          payment.authorizationId,
-          payment.correlationId
-        )
-      ).not.to.emit(
-        cashbackDistributorMock,
-        EVENT_NAME_SEND_CASHBACK_MOCK
+      await cardPaymentProcessorShell.updatePaymentAmount(payment, Math.floor(payment.baseAmount * 1.5));
+      await context.checkCardPaymentProcessorState();
+
+      await cardPaymentProcessorShell.clearPayments([payment]);
+      await context.checkCardPaymentProcessorState();
+
+      await cardPaymentProcessorShell.refundPayment(payment, Math.floor(payment.baseAmount * 0.3));
+      await context.checkCardPaymentProcessorState();
+
+      const [operationResult] = await cardPaymentProcessorShell.confirmPayments([payment]);
+      await context.checkPaymentOperationsForTx(operationResult.tx);
+      await context.checkCardPaymentProcessorState();
+
+      await cardPaymentProcessorShell.refundPayment(payment, Math.floor(payment.baseAmount * 0.4));
+      const paymentModel = cardPaymentProcessorShell.model.getPaymentByAuthorizationId(payment.authorizationId);
+      await cardPaymentProcessorShell.refundPayment(
+        payment,
+        paymentModel.baseAmount - paymentModel.refundAmount,
+        0
       );
-      payment.parentTxHash = increaseBytesString(payment.parentTxHash, BYTES32_LENGTH);
-      await expect(
-        cardPaymentProcessor.connect(executor).reversePayment(
-          payment.authorizationId,
-          PAYMENT_REVERSING_CORRELATION_ID_STUB,
-          payment.parentTxHash
-        )
-      ).not.to.emit(
-        cashbackDistributorMock,
-        EVENT_NAME_REVOKE_CASHBACK_MOCK
-      );
+      await context.checkCardPaymentProcessorState();
     });
 
-    it("Several refund and payment updating operations execute as expected if cashback is enabled", async () => {
-      const { fixture, payment } = await prepareForSinglePayment();
-      const { cardPaymentProcessor, tokenMock } = fixture;
-      await proveTx(tokenMock.mint(payment.account.address, MAX_INT256));
-      await proveTx(tokenMock.connect(payment.account).approve(cardPaymentProcessor.address, MAX_UINT256));
-      await proveTx(cardPaymentProcessor.enableCashback());
-      setCashback(payment, fixture);
-      await makePayments(cardPaymentProcessor, [payment]);
+    it("Several revocation execute as expected with and without the payment extra amount and cashback", async () => {
+      const context = await beforeMakingPayments();
+      const { cardPaymentProcessorShell, payments: [payment] } = context;
+      expect(payment).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
-      async function updatePaymentAmount(newPaymentAmount: number) {
-        await proveTx(
-          await cardPaymentProcessor.connect(executor).updatePaymentAmount(
-            newPaymentAmount,
-            payment.authorizationId,
-            PAYMENT_UPDATING_CORRELATION_ID_STUB
-          )
-        );
-        setNewAmount(payment, newPaymentAmount);
-      }
+      await cardPaymentProcessorShell.enableCashback();
+      await cardPaymentProcessorShell.makePayments([payment]);
+      await cardPaymentProcessorShell.revokePayment(payment);
+      await context.checkCardPaymentProcessorState();
 
-      async function refundPayment(refundAmount: number) {
-        await proveTx(
-          await cardPaymentProcessor.connect(executor).refundPayment(
-            refundAmount,
-            payment.authorizationId,
-            PAYMENT_REFUNDING_CORRELATION_ID_STUB
-          )
-        );
-        setRefundAmount(payment, (payment.refundAmount || 0) + refundAmount);
-      }
-
-      async function checkCashOutAccountBalance() {
-        expect(
-          await tokenMock.balanceOf(cashOutAccount.address)
-        ).to.equal(payment.amount - (payment.refundAmount || 0));
-      }
-
-      await checkCardPaymentProcessorState(fixture, [payment]);
-
-      await updatePaymentAmount(Math.floor(payment.amount * 2));
-      await refundPayment(Math.floor(payment.amount * 0.1));
-      await updatePaymentAmount(Math.floor(payment.amount * 0.9));
-      await refundPayment(Math.floor(payment.amount * 0.2));
-      await updatePaymentAmount(Math.floor(payment.amount * 1.5));
-      await checkCardPaymentProcessorState(fixture, [payment]);
-
-      await clearPayments(cardPaymentProcessor, [payment]);
-      await checkCardPaymentProcessorState(fixture, [payment]);
-
-      await refundPayment(Math.floor(payment.amount * 0.3));
-      await checkCardPaymentProcessorState(fixture, [payment]);
-
-      await confirmPayments(cardPaymentProcessor, [payment]);
-      await checkCardPaymentProcessorState(fixture, [payment]);
-      await checkCashOutAccountBalance();
-
-      await refundPayment(Math.floor(payment.amount * 0.4));
-      await refundPayment(payment.amount - (payment.refundAmount || 0));
-      await checkCardPaymentProcessorState(fixture, [payment]);
-      await checkCashOutAccountBalance();
+      payment.extraAmount = 0;
+      await cardPaymentProcessorShell.disableCashback();
+      await cardPaymentProcessorShell.makePayments([payment]);
+      await context.checkCardPaymentProcessorState();
+      await cardPaymentProcessorShell.revokePayment(payment);
+      await context.checkCardPaymentProcessorState();
     });
   });
 });


### PR DESCRIPTION
### Abbreviations
1. CPP stands for the CardPaymentProcessor contract.
2. CD stands for the CashbackDistributor contract.

### Description
1. The ability to specify an extra payment amount in CPP has been provided.
2. The extra payment amount is excluded from the cashback calculation.
3. The payment amount that is used in the cashback calculation is now called the "base amount".
4. The following relations are assumed for a CPP payment:
    * `sumAmount = baseAmount + extraAmount`;
    * `totalAmount = sumAmount - refundAmount = baseAmount + extraAmount - refundAmount`.
5. The logic of interactions CPP with CD have also been updated accordingly.

### Main changes
1. A new field in the `Payment` structure has been added: `Payment.extraAmount`.
2. An existing field of the `Payment` structure has been renamed : `Payment.amount` => `Payment.baseAmount`.
3. Functions `makePayment()`, `makePaymentFrom()`, `updatePaymentAmount()`, `refundPayment()` have been redefined in the part of the following:
    * `makePayment(.... uint256 amount, ....)` => `makePayment(.... uint256 baseAmount, uint256 extraAmount, ....)`.
    * `makePaymentFrom(.... uint256 amount, ....)` => `makePaymentFrom(.... uint256 baseAmount, uint256 extraAmount, ....)`. 
    * `updatePaymentAmount(.... uint256 newAmount, ....)` => `updatePaymentAmount(.... uint256 newBaseAmount, uint256 newExtraAmount, ....)`.
    * `refundPayment(.... uint256 amount, ....)` => `refundPayment(.... uint256 refundAmount, uint256 newExtraAmount, ....)`.

    NOTE: a new value of `extraAmount` must be provided each time during the `updatePaymentAmount()` and `refundPayment()` calls, not the difference between a new value and the old one.
4. Some fields of the existing events have been renamed:
    * `MakePayment(.... uint256 amount, ....)` => `MakePayment(.... uint256 sumAmount, ....)`.
    * `UpdatePaymentAmount(.... uint256 oldAmount, uint256 newAmount ....)` => `UpdatePaymentAmount(.... uint256 oldSumAmount, uint256 newSumAmount ....)`.
    * `ClearPayment(.... uint256 amount, ....)` => `ClearPayment(.... uint256 totalAmount, ....)`.
    * `UnclearPayment(.... uint256 amount, ....)` => `UnclearPayment(.... uint256 totalAmount, ....)`.
    * `RevokePayment(.... uint256 amount, ....)` => `RevokePayment(.... uint256 sentAmount, ....)`.
    * `ReversePayment(.... uint256 amount, ....)` => `ReversePayment(.... uint256 sentAmount, ....)`.
    * `ConfirmPayment(.... uint256 amount, ....)` => `ConfirmPayment(.... uint256 totalAmount, ....)`.

    NOTES:
    * The renaming will not change the method ID of the events in the blockchain and Blockscout database.
    * `sentAmount` refers to tokens that were sent to a user.
5. A new event related to `extraAmount` has been added:
```solidity
    event PaymentExtraAmountChanged(
        bytes16 indexed authorizationId,
        address indexed account,
        uint256 sumAmount,
        uint256 newExtraAmount,
        uint256 oldExtraAmount
    );
```
6. The new event will be emitted in the following cases:
   * A payment is made with non-zero value of the `extraAmount` field.
   * The `extraAmount` field of a payment is changed during some operation (e.g. during the `refundPayment()` function call).
7. The `extraAmount` value has been included to cleared and uncleared balances of payments like:
    ```solidity
    _unclearedBalances[authorizationId] = baseAmount + extraAmount - refundAmount`;
    ```
    or
    ```solidity
    _totalClearedBalance -= payment.baseAmount + payment.extraAmount - payment.refundAmount`
    ```
8. Functions `makePayment()`, `makePaymentFrom()`, `updatePaymentAmount()`, `refundPayment()` without the `extraAmount` parameter has been kept for backward compatibility. All of them or several can be removed later.

### Test coverage
![image](https://user-images.githubusercontent.com/97302011/232452900-7849080c-254b-41d4-8e0f-434f55a5c0a4.png)
