### PR TITLE
Extend the CashbackDistributor contract events with a new field of cashback total amount

### DIFF
--- a/contracts/interfaces/ICashbackDistributor.sol
+++ b/contracts/interfaces/ICashbackDistributor.sol
@@ -140,6 +140,7 @@ interface ICashbackDistributor is ICashbackDistributorTypes {
      * @param externalId The external identifier of the initial cashback operation.
      * @param recipient The account that received the cashback.
      * @param amount The requested amount of cashback to revoke.
+     * @param totalAmount The total amount of cashback that the recipient has after this operation.
      * @param sender The account that initiated the cashback revocation operation.
      * @param nonce The nonce of the initial cashback operation.
      */
@@ -151,6 +152,7 @@ interface ICashbackDistributor is ICashbackDistributorTypes {
         bytes32 indexed externalId,
         address indexed recipient,
         uint256 amount,
+        uint256 totalAmount,
         address sender,
         uint256 nonce
     );
@@ -169,6 +171,7 @@ interface ICashbackDistributor is ICashbackDistributorTypes {
      * @param externalId The external identifier of the initial cashback operation.
      * @param recipient The account that received the cashback.
      * @param amount The requested or actual amount of cashback increase (see the note above).
+     * @param totalAmount The total amount of cashback that the recipient has after this operation.
      * @param sender The account that initiated the cashback increase operation.
      * @param nonce The nonce of the initial cashback operation.
      */
@@ -180,6 +183,7 @@ interface ICashbackDistributor is ICashbackDistributorTypes {
         bytes32 indexed externalId,
         address indexed recipient,
         uint256 amount,
+        uint256 totalAmount,
         address sender,
         uint256 nonce
     );


### PR DESCRIPTION
### Main changes
1. Event `IncreaseCashback` of the `CashbackDistributor` smart-contract. A new field `totalAmount` has been added. It corresponds to the result amount of cashback that the recipient has after the increase operation. The new event definition:
```solidity
    event IncreaseCashback(
        address token,
        CashbackKind cashbackKind,
        CashbackStatus cashbackStatus,
        IncreaseStatus indexed status,
        bytes32 indexed externalId,
        address indexed recipient,
        uint256 amount,
        uint256 totalAmount,
        address sender,
        uint256 nonce
    );
```
2. Event `RevokeCashback` of the `CashbackDistributor` smart-contract.  A new field `totalAmount` has been added. It corresponds to the result amount of cashback that the recipient has after the revocation operation. The new event definition:
```solidity
    event RevokeCashback(
        address token,
        CashbackKind cashbackKind,
        CashbackStatus cashbackStatus,
        RevocationStatus indexed status,
        bytes32 indexed externalId,
        address indexed recipient,
        uint256 amount,
        uint256 totalAmount,
        address sender,
        uint256 nonce
    );
```
**IMPROTANT**. Due to changes in the set of event fields the first topics of the events mentioned above have been changes:

| Event name       | Old first topic                                                    | New first topic                                                    |
|:-----------------|:-------------------------------------------------------------------|:-------------------------------------------------------------------|
| IncreaseCashback | 0x52a4c747a7e4e19336de6715f24690181f302cc6d72e6aa062c99cc868f33faf | 0xa4c44ce71737d7bf7bb8906bd53397ff15f6bbcfdee02d9b4d5fc410dc245084 |
| RevokeCashback   | 0xa9246589b9d1c7f3eb5bcf0c5a1fe8dc6224070e93c019427c0657ebc4408429 | 0x768f6f47ddc0c4c2c84a1d875f2f27598f49562d44daad5f4bb7bcc0432112cf |

### Test coverage
| File                                        | % Stmts | % Branch | % Funcs | % Lines |
|:--------------------------------------------|--------:|---------:|--------:|--------:|
| contracts/                                  |     100 |    97.95 |     100 |     100 |
| &nbsp;&nbsp;CardPaymentProcessor.sol        |     100 |    99.01 |     100 |     100 |
| &nbsp;&nbsp;CardPaymentProcessorStorage.sol |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;CashbackDistributor.sol         |     100 |    97.62 |     100 |     100 |
| &nbsp;&nbsp;CashbackDistributorStorage.sol  |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;PixCashier.sol                  |     100 |    97.62 |     100 |     100 |
| &nbsp;&nbsp;PixCashierStorage.sol           |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;TokenDistributor.sol            |     100 |       90 |     100 |     100 |
| contracts/interfaces/                       |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;ICardPaymentCashback.sol        |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;ICardPaymentProcessor.sol       |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;ICashbackDistributor.sol        |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;IERC20Mintable.sol              |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;IPixCashier.sol                 |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;ITokenDistributor.sol           |     100 |      100 |     100 |     100 |
| contracts/mocks/                            |     100 |      100 |     100 |     100 |
| contracts/mocks/tokens/                     |     100 |      50 |     100 |     100 |
| ------------------------------------------- | ------- | -------- | ------- | ------- |
| All files                                   |     100 |    97.76 |     100 |     100 |  