### PR TITLE
Introduce subsidized payments and cashback control to the CardPaymentProcessor contract

### DIFF
--- a/contracts/interfaces/ICashbackDistributor.sol
+++ b/contracts/interfaces/ICashbackDistributor.sol
@@ -140,6 +140,7 @@ interface ICashbackDistributor is ICashbackDistributorTypes {
      * @param externalId The external identifier of the initial cashback operation.
      * @param recipient The account that received the cashback.
      * @param amount The requested amount of cashback to revoke.
+     * @param totalAmount The total amount of cashback that the recipient has after this operation.
      * @param sender The account that initiated the cashback revocation operation.
      * @param nonce The nonce of the initial cashback operation.
      */
@@ -151,6 +152,7 @@ interface ICashbackDistributor is ICashbackDistributorTypes {
         bytes32 indexed externalId,
         address indexed recipient,
         uint256 amount,
+        uint256 totalAmount,
         address sender,
         uint256 nonce
     );
@@ -169,6 +171,7 @@ interface ICashbackDistributor is ICashbackDistributorTypes {
      * @param externalId The external identifier of the initial cashback operation.
      * @param recipient The account that received the cashback.
      * @param amount The requested or actual amount of cashback increase (see the note above).
+     * @param totalAmount The total amount of cashback that the recipient has after this operation.
      * @param sender The account that initiated the cashback increase operation.
      * @param nonce The nonce of the initial cashback operation.
      */
@@ -180,6 +183,7 @@ interface ICashbackDistributor is ICashbackDistributorTypes {
         bytes32 indexed externalId,
         address indexed recipient,
         uint256 amount,
+        uint256 totalAmount,
         address sender,
         uint256 nonce
     );

--- a/test-utils/checkers.ts
+++ b/test-utils/checkers.ts
@@ -12,6 +12,19 @@ function checkEventField(fieldName: string, expectedValue: any): (value: any) =>
   return f;
 }
 
+function checkEventFieldNotEqual(fieldName: string, notExpectedValue: any): (value: any) => boolean {
+  const f = function (value: any): boolean {
+    expect(value).not.to.equal(
+      notExpectedValue,
+      `The "${fieldName}" field of the event is wrong because it is equal ${notExpectedValue} but should not`
+    );
+    return true;
+  };
+  Object.defineProperty(f, "name", { value: `checkEventFieldNot_${fieldName}`, writable: false });
+  return f;
+}
+
 export {
   checkEventField,
+  checkEventFieldNotEqual
 };


### PR DESCRIPTION
### Abbreviations
1. CPP stands for the `CardPaymentProcessor` smart-contract.
2. CD stands for the `CashbackDistributor` smart-contract.

### Main changes in CPP related to subsidized payments

1. A new function to support subsidized payments and special cashback rate has been added:
```solidity
/**
 * @dev Makes a card payment for a given account initiated by a service account.
 *
 * The payment can be subsidized with full or partial reimbursement from a specified sponsor account.
 * The payment cashback rate can be taken from the contract settings or specified at the call.
 * If cashback is disabled in the contract it will not be sent in any case.
 *
 * Transfers the underlying tokens from the account and/or sponsor to this contract.
 * This function can be called by a limited number of accounts that are allowed to execute processing operations.
 *
 * Emits a {MakePayment} event.
 * Emits a {MakePaymentSubsidized} event if the payment is subsidized.
 * Emits a {PaymentExtraAmountChanged} event if `extraAmount` is not zero.
 *
 * @param account The account on that behalf the payment is made.
 * @param baseAmount The base amount of tokens to transfer because of the payment.
 * @param extraAmount The extra amount of tokens to transfer because of the payment. No cashback is applied.
 * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
 * @param correlationId The ID that is correlated to this function call in the off-chain card processing backend.
 * @param sponsor The address of a sponsor if the payment is subsidized, otherwise zero.
 * @param subsidyLimit The maximum amount of tokens that the sponsor is willing to compensate for the payment.
 * @param cashbackRateInPermil The cashback rate in permil for the payment or a negative value if
 *                             the contract settings are used to determine cashback. If zero cashback is not sent.
 */
function makePaymentFor(
    address account,
    uint256 baseAmount,
    uint256 extraAmount,
    bytes16 authorizationId,
    bytes16 correlationId,
    address sponsor,
    uint256 subsidyLimit,
    int16   cashbackRateInPermil
) external;
```
2. The new function can be called only by an account with the `EXECUTOR_ROLE` role.
3. A payment will be subsidized only if the `sponsor` parameter is non-zero address. Otherwise it will be a common payment.
4. Even if `subsidyLimit == 0` but `sponsor != address(0)` the related payment will be treated as subsidized.
5. The `subsidyLimit` argument can be specified more than `baseAmount + extraAmount`. It allows to update `baseAmount` and `extraAmount` of a payment in the future processing.
6. The `Payment` structure of CPP has been extended with two fields `sponsor` and `subsidyLimit` that correspond to the function parameters of the same name. The current structure definition:
```solidity
/// @dev Structure with data of a single payment.
struct Payment {
    address account;             // Account who made the payment.
    uint256 baseAmount;          // Base amount of tokens in the payment.
    PaymentStatus status;        // Current status of the payment.
    uint8 revocationCounter;     // Number of payment revocations.
    uint256 compensationAmount;  // The total amount of compensation to the account related to the payment (cashback + refunds).
    uint256 refundAmount;        // The total amount of all refunds related to the payment.
    uint16 cashbackRate;         // The rate of cashback of the payment.
    uint256 extraAmount;         // The extra amount of tokens in the payment, without a cashback.
    address sponsor;             // The sponsor of the payment if it is subsidized. Otherwise the zero address.
    uint256 subsidyLimit;        // The subsidy limit of the payment if it is subsidized. Otherwise zero.
}
```
7. The main logic of processing the subsidized payments can be described with the following Solidity snippet:
```solidity
// The base amount of a payment
uint256 paymentBaseAmount = baseAmount;

// The extra amount of a payment
uint256 paymentExtraAmount = extraAmount;

// The sum amount of a payment
uint256 paymentSumAmount = paymentBaseAmount + paymentExtraAmount;

// The cumulative refund amount of a payment
uint256 paymentRefundAmount = payment.refundAmount;

// The total amount of a payment
uint256 paymentTotalAmount = paymentSumAmount - paymentRefundAmount;

// The account (user) base amount that is taken from him during making or sent him back during cancellation
uint256 accountBaseAmount;

// The account (user) extra amount that is taken from him during making or sent him back during cancellation
uint256 accountExtraAmount;

// The sponsor base amount that is taken from him during making or sent him back during cancellation
uint256 sponsorBaseAmount;

// The sponsor extra amount that is taken from him during making or sent him back during cancellation
uint256 sponsorExtraAmount;

// The account (user) refund amount that is returned him back during refunding operations except revoked cashback
uint256 accountRefundAmount;

// The sponsor refund amount that is returned him back during refunding operations
uint256 sponsorRefundAmount;

// The account (user) cashback amount
uint256 cashbackAmount;


// Base amount parts calculation
if (subsidyLimit >= paymentBaseAmount) {
    accountBaseAmount = 0;
} else {
    accountBaseAmount = paymentBaseAmount - subsidyLimit;
}
sponsorBaseAmount = paymentBaseAmount - accountBaseAmount;

// Extra amount parts calculation
if (subsidyLimit > paymentBaseAmount) {
    if (subsidyLimit >= paymentSumAmount) {
        accountExtraAmount = 0;
    } else {
        accountExtraAmount = paymentSumAmount - subsidyLimit;
    }
} else {
    accountExtraAmount = paymentExtraAmount;
}
sponsorBaseAmount = paymentExtraAmount - accountExtraAmount;

// Refund amount parts calculation
if (subsidyLimit >= paymentBaseAmount) {
    sponsorRefundAmount = paymentRefundAmount;
} else {
    sponsorRefundAmount = paymentRefundAmount * subsidyLimit / paymentBaseAmount;
}
accountRefundAmount = paymentRefundAmount - sponsorRefundAmount;

// Cashback amount calculation
cashbackAmount = (accountBaseAmount - accountRefundAmount) * cashbackRateInPermil / 1000;
```
8. When some field of a payment structure changes the new values are calculated and the difference between new values and old values are sent to user and sponsor or taken from them. If there is nothing to send/take the appropriate token transfer operations are executed with zero amount.

9. The token transfer operations are not executed for a sponsor if the payment is not subsidized.

10. New events has been added to inform about subsidized payments. They are emitted if an appropriate operation is executed for a payment along with appropriate main events. The name of the new event is formed from the name of the main event by adding the word "Subsidized" to the end, for example `MakePayment` => `MakePaymentSubsidized`. The exception is the main event `UpdatePaymentAmount`. Its corresponding subsidized payment event is called `UpdatePaymentSubsidized`. The code of the new event definitions:
```solidity
/// @dev Emitted along with the {MakePayment} event when a subsidized payment is made.
event MakePaymentSubsidized(
    bytes16 indexed authorizationId,
    bytes16 indexed correlationId,
    address indexed sponsor,
    uint256 subsidyLimit,
    uint256 sponsorSumAmount,
    bytes addendum // Empty. Reserved for future possible additional information.
);

/// @dev Emitted along with the {UpdatePaymentAmount} event when the amount of a subsidized payment is updated.
event UpdatePaymentSubsidized(
    bytes16 indexed authorizationId,
    bytes16 indexed correlationId,
    address indexed sponsor,
    uint256 oldSponsorSumAmount,
    uint256 newSponsorSumAmount,
    bytes addendum // Empty. Reserved for future possible additional information.
);

/// @dev Emitted along with the {ClearPayment} event when a subsidized payment is cleared.
event ClearPaymentSubsidized(
    bytes16 indexed authorizationId,
    address indexed sponsor,
    bytes addendum // Empty. Reserved for future possible additional information.
);

/// @dev Emitted along with the {UnclearPayment} event when a subsidized payment is uncleared.
event UnclearPaymentSubsidized(
    bytes16 indexed authorizationId,
    address indexed sponsor,
    bytes addendum // Empty. Reserved for future possible additional information.
);

/// @dev Emitted along with the {RevokePayment} event when a subsidized payment is revoked.
event RevokePaymentSubsidized(
    bytes16 indexed authorizationId,
    bytes16 indexed correlationId,
    address indexed sponsor,
    uint256 sponsorSentAmount,
    bytes addendum // Empty. Reserved for future possible additional information.
);

/// @dev Emitted along with the {ReversePayment} event when a subsidized payment is reversed.
event ReversePaymentSubsidized(
    bytes16 indexed authorizationId,
    bytes16 indexed correlationId,
    address indexed sponsor,
    uint256 sponsorSentAmount,
    bytes addendum // Empty. Reserved for future possible additional information.
);

/// @dev Emitted along with the {ConfirmPayment} event when a subsidized payment is confirmed.
event ConfirmPaymentSubsidized(
    bytes16 indexed authorizationId,
    address indexed sponsor,
    bytes addendum // Empty. Reserved for future possible additional information.
);

/// @dev Emitted along with the {RefundPayment} event when a subsidized payment is refunded.
event RefundPaymentSubsidized(
    bytes16 indexed authorizationId,
    bytes16 indexed correlationId,
    address indexed sponsor,
    uint256 sponsorRefundAmount,
    uint256 sponsorSentAmount,
    bytes addendum // Empty. Reserved for future possible additional information.
);
```
11. The restrictions for subsidized payments:
* a. A subsidized payment cannot be updated through the `updatePaymentAmount()` function if its refund amount is not zero. The function will be reverted with the `SubsidizedPaymentWithNonZeroRefundAmount` error. It is done to avoid possible recalculating refund amount parts and resulting token transfers between the user and the sponsor. 
* b. There is no function to update the subsidy limit of a payment except revoking the payment and making it again.

### Main changes in CPP related to cashback control

1. The `cashbackRateInPermil` parameter has been added to the new `makePaymentFor()` function described in the previous section.
2. Possible values of parameter `cashbackRateInPermil` and their corresponding cashback logic:
* `cashbackRateInPermil < 0` -- the cashback rate configured in the CPP is used.
* `cashbackRateInPermil = 0` -- no cashback is given to the user. The corresponding CD function is not called too.
* `cashbackRateInPermil > 0` -- the provided rate is used to calculate cashback instead of one configured in the CPP.
3. Regardless of the `cashbackRateInPermil` parameter value, no cashback is given if it is disabled in the CPP (e.g., `disableCashback()` function was called earlier).
4. A new function to support payments without cashback that can be called from a user account has been introduced:
```solidity
    /**
     * @dev Makes a card payment without cashback.
     *
     * Transfers the underlying tokens from the payer (who is the caller of the function) to this contract.
     * This function is expected to be called by any account.
     *
     * Emits a {MakePayment} event.
     * Emits a {PaymentExtraAmountChanged} event if `extraAmount` is not zero.
     *
     * @param baseAmount The base amount of tokens to transfer because of the payment.
     * @param extraAmount The extra amount of tokens to transfer because of the payment. No cashback is applied.
     * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
     * @param correlationId The ID that is correlated to this function call in the off-chain card processing backend.
     */
    function makePaymentWithoutCashback(
        uint256 baseAmount,
        uint256 extraAmount,
        bytes16 authorizationId,
        bytes16 correlationId
    ) external;
```

### Test coverage
| File                                        | % Stmts | % Branch | % Funcs | % Lines |
|:--------------------------------------------|--------:|---------:|--------:|--------:|
| contracts/                                  |     100 |    98.25 |     100 |     100 |
| &nbsp;&nbsp;CardPaymentProcessor.sol        |     100 |    99.26 |     100 |     100 |
| &nbsp;&nbsp;CardPaymentProcessorStorage.sol |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;CashbackDistributor.sol         |     100 |    97.62 |     100 |     100 |
| &nbsp;&nbsp;CashbackDistributorStorage.sol  |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;PixCashier.sol                  |     100 |    97.62 |     100 |     100 |
| &nbsp;&nbsp;PixCashierStorage.sol           |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;TokenDistributor.sol            |     100 |       90 |     100 |     100 |
| contracts/interfaces/                       |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;ICardPaymentCashback.sol        |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;ICardPaymentProcessor.sol       |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;ICashbackDistributor.sol        |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;IERC20Mintable.sol              |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;IPixCashier.sol                 |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;ITokenDistributor.sol           |     100 |      100 |     100 |     100 |
| contracts/mocks/                            |     100 |      100 |     100 |     100 |
| contracts/mocks/tokens/                     |     100 |       50 |     100 |     100 |
| ------------------------------------------- | ------- | -------- | ------- | ------- |
| All files                                   |     100 |    98.09 |     100 |     100 |  

