### PR TITLE
Prevent txId reusing in the PixCashier contract

### DIFF
--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -72,12 +72,11 @@ contract PixCashier is
     error InappropriateCashOutStatus(bytes32 txId, CashOutStatus status);
 
     /**
-     * @dev The cash-out operation with the provided off-chain transaction identifier cannot be reused.
+     * @dev The cash-out operation with the provided txId cannot executed for the given account.
      * @param txId The off-chain transaction identifiers of the operation.
-     * @param status The current status of the operation.
-     * @param account The previous account on that behalf the operation was made.
+     * @param account The account that must be used for the operation.
      */
-    error WrongCashOutReusing(bytes32 txId, CashOutStatus status, address account);
+    error InappropriateCashOutAccount(bytes32 txId, address account);
 
     // -------------------- Functions --------------------------------
 
@@ -398,7 +397,7 @@ contract PixCashier is
         if (status == CashOutStatus.Pending || status == CashOutStatus.Confirmed) {
             revert InappropriateCashOutStatus(txId, status);
         } else if (status == CashOutStatus.Reversed && operation.account != account) {
-            revert WrongCashOutReusing(txId, status, operation.account);
+            revert InappropriateCashOutAccount(txId, operation.account);
         }
 
         operation.account = account;

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -71,6 +71,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
     /// @dev Emitted when the extra amount of a payment is changed or set as non-zero during payment making.
     event PaymentExtraAmountChanged(
         bytes16 indexed authorizationId,
+        bytes16 indexed correlationId,
         address indexed account,
         uint256 sumAmount,
         uint256 newExtraAmount,
@@ -93,7 +94,9 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
         bytes16 indexed correlationId,
         address indexed account,
         uint256 oldSumAmount,
-        uint256 newSumAmount
+        uint256 newSumAmount,
+        uint256 oldBaseAmount,
+        uint256 newBaseAmount
     );
 
     /// @dev Emitted along with the {UpdatePaymentAmount} event when the amount of a subsidized payment is updated.

--- a/contracts/interfaces/ICashbackDistributor.sol
+++ b/contracts/interfaces/ICashbackDistributor.sol
@@ -140,6 +140,7 @@ interface ICashbackDistributor is ICashbackDistributorTypes {
      * @param externalId The external identifier of the initial cashback operation.
      * @param recipient The account that received the cashback.
      * @param amount The requested amount of cashback to revoke.
+     * @param totalAmount The total amount of cashback that the recipient has after this operation.
      * @param sender The account that initiated the cashback revocation operation.
      * @param nonce The nonce of the initial cashback operation.
      */
@@ -151,6 +152,7 @@ interface ICashbackDistributor is ICashbackDistributorTypes {
         bytes32 indexed externalId,
         address indexed recipient,
         uint256 amount,
+        uint256 totalAmount,
         address sender,
         uint256 nonce
     );
@@ -169,6 +171,7 @@ interface ICashbackDistributor is ICashbackDistributorTypes {
      * @param externalId The external identifier of the initial cashback operation.
      * @param recipient The account that received the cashback.
      * @param amount The requested or actual amount of cashback increase (see the note above).
+     * @param totalAmount The total amount of cashback that the recipient has after this operation.
      * @param sender The account that initiated the cashback increase operation.
      * @param nonce The nonce of the initial cashback operation.
      */
@@ -180,6 +183,7 @@ interface ICashbackDistributor is ICashbackDistributorTypes {
         bytes32 indexed externalId,
         address indexed recipient,
         uint256 amount,
+        uint256 totalAmount,
         address sender,
         uint256 nonce
     );

--- a/test-utils/checkers.ts
+++ b/test-utils/checkers.ts
@@ -12,6 +12,19 @@ function checkEventField(fieldName: string, expectedValue: any): (value: any) =>
   return f;
 }
 
+function checkEventFieldNotEqual(fieldName: string, notExpectedValue: any): (value: any) => boolean {
+  const f = function (value: any): boolean {
+    expect(value).not.to.equal(
+      notExpectedValue,
+      `The "${fieldName}" field of the event is wrong because it is equal ${notExpectedValue} but should not`
+    );
+    return true;
+  };
+  Object.defineProperty(f, "name", { value: `checkEventFieldNot_${fieldName}`, writable: false });
+  return f;
+}
+
 export {
   checkEventField,
+  checkEventFieldNotEqual
 };

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1245,6 +1245,7 @@ class TestContext {
           EVENT_NAME_PAYMENT_EXTRA_AMOUNT_CHANGED
         ).withArgs(
           checkEventField("authorizationId", operation.authorizationId),
+          checkEventField("correlationId", operation.correlationId),
           checkEventField("account", operation.account.address),
           checkEventField("sumAmount", operation.newBaseAmount + operation.newExtraAmount),
           checkEventField("newExtraAmount", operation.newExtraAmount),
@@ -1550,6 +1551,8 @@ class TestContext {
       checkEventField("account", operation.account.address),
       checkEventField("oldSumAmount", operation.oldBaseAmount + operation.oldExtraAmount),
       checkEventField("newSumAmount", operation.newBaseAmount + operation.newExtraAmount),
+      checkEventField("oldBaseAmount", operation.oldBaseAmount),
+      checkEventField("newBaseAmount", operation.newBaseAmount),
     );
 
     if (!!operation.sponsor) {

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -75,6 +75,7 @@ describe("Contract 'PixCashier'", async () => {
   const REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO = "ZeroTxId";
   const REVERT_ERROR_IF_TOKEN_MINTING_FAILURE = "TokenMintingFailure";
   const REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS = "InappropriateCashOutStatus";
+  const REVERT_ERROR_IF_WRONG_CASH_OUT_REUSING = "WrongCashOutReusing";
   const REVERT_ERROR_IF_EMPTY_TRANSACTION_IDS_ARRAY = "EmptyTransactionIdsArray";
   const REVERT_ERROR_IF_BATCH_TRANSACTION_DIFFERENT = "InvalidBatchArrays";
 
@@ -546,6 +547,30 @@ describe("Contract 'PixCashier'", async () => {
         pixCashier,
         REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
       ).withArgs(cashOut.txId, CashOutStatus.Pending);
+    });
+
+    it("Is reverted if the cash-out with the provided txId is already confirmed", async () => {
+      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
+      await pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId);
+      await pixCashier.connect(cashier).confirmCashOut(cashOut.txId);
+      expect(
+        pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId)
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS
+      ).withArgs(cashOut.txId, CashOutStatus.Confirmed);
+    });
+
+    it("Is reverted if the cash-out with the provided txId is reused for another account", async () => {
+      await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
+      await pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId);
+      await pixCashier.connect(cashier).reverseCashOut(cashOut.txId);
+      expect(
+        pixCashier.connect(cashier).requestCashOutFrom(deployer.address, cashOut.amount, cashOut.txId)
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_WRONG_CASH_OUT_REUSING
+      ).withArgs(cashOut.txId, CashOutStatus.Reversed, cashOut.account.address);
     });
 
     it("Is reverted if the user has not enough tokens", async () => {
@@ -1194,13 +1219,6 @@ describe("Contract 'PixCashier'", async () => {
       ).withArgs(cashOut.txId, CashOutStatus.Confirmed);
 
       expect(await tokenMock.balanceOf(cashOut.account.address)).to.equal(cashInTokenAmount - cashOut.amount);
-
-      // After confirming a cash-out with the same txId can be requested again.
-      cashOut.amount = cashInTokenAmount - cashOut.amount;
-      await requestCashOuts([cashOut]);
-      cashOut.status = CashOutStatus.Pending;
-      await checkPixCashierState([cashOut], 1);
-      expect(await tokenMock.balanceOf(cashOut.account.address)).to.equal(0);
     });
   });
 });

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -74,8 +74,8 @@ describe("Contract 'PixCashier'", async () => {
   const REVERT_ERROR_IF_AMOUNT_IS_ZERO = "ZeroAmount";
   const REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO = "ZeroTxId";
   const REVERT_ERROR_IF_TOKEN_MINTING_FAILURE = "TokenMintingFailure";
+  const REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_ACCOUNT = "InappropriateCashOutAccount";
   const REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_STATUS = "InappropriateCashOutStatus";
-  const REVERT_ERROR_IF_WRONG_CASH_OUT_REUSING = "WrongCashOutReusing";
   const REVERT_ERROR_IF_EMPTY_TRANSACTION_IDS_ARRAY = "EmptyTransactionIdsArray";
   const REVERT_ERROR_IF_BATCH_TRANSACTION_DIFFERENT = "InvalidBatchArrays";
 
@@ -561,7 +561,7 @@ describe("Contract 'PixCashier'", async () => {
       ).withArgs(cashOut.txId, CashOutStatus.Confirmed);
     });
 
-    it("Is reverted if the cash-out with the provided txId is reused for another account", async () => {
+    it("Is reverted if txId of a reversed cash-out operation is reused for another account", async () => {
       await proveTx(tokenMock.mint(cashOut.account.address, cashOut.amount));
       await pixCashier.connect(cashier).requestCashOutFrom(cashOut.account.address, cashOut.amount, cashOut.txId);
       await pixCashier.connect(cashier).reverseCashOut(cashOut.txId);
@@ -569,8 +569,8 @@ describe("Contract 'PixCashier'", async () => {
         pixCashier.connect(cashier).requestCashOutFrom(deployer.address, cashOut.amount, cashOut.txId)
       ).to.be.revertedWithCustomError(
         pixCashier,
-        REVERT_ERROR_IF_WRONG_CASH_OUT_REUSING
-      ).withArgs(cashOut.txId, CashOutStatus.Reversed, cashOut.account.address);
+        REVERT_ERROR_IF_INAPPROPRIATE_CASH_OUT_ACCOUNT
+      ).withArgs(cashOut.txId, cashOut.account.address);
     });
 
     it("Is reverted if the user has not enough tokens", async () => {


### PR DESCRIPTION
### Description

There was a possibility to widely reuse the same `txId` value for a new PIX cash-out requests in the `PixCashier` smart-contract.
Now reuse `txId` is allowed only if the previous cash-out operation has the `Reversed` status and the account addresses of the previous and new operation are the same.
If an operation with the provided `txId` does not exist no restrictions are applied for the new cash-out requests.

The full list of restrictions for cash-out request transactions related to `txId`:
1. `TxId` of a confirmed cash-out operation cannot be used again.
2. `TxId` of a pending cash-out operation cannot be used again.
3. `TxId` of a reversed cash-out operation cannot be used again for a different account.

### Main changes
1. New logic for checking cash-out request has been introduced:
```solidity
        if (status == CashOutStatus.Pending || status == CashOutStatus.Confirmed) {
            revert InappropriateCashOutStatus(txId, status);
        } else if (status == CashOutStatus.Reversed && operation.account != account) {
            revert InappropriateCashOutAccount(txId, operation.account);
        }
```
2. A new error has been added:
```solidity
    /**
     * @dev The cash-out operation with the provided txId cannot executed for the given account.
     * @param txId The off-chain transaction identifiers of the operation.
     * @param account The account that must be used for the operation.
     */
    error InappropriateCashOutAccount(bytes32 txId, address account);
``` 

Test coverage
| File                                        | % Stmts | % Branch | % Funcs | % Lines |
|:--------------------------------------------|--------:|---------:|--------:|--------:|
| contracts/                                  |     100 |    98.27 |     100 |     100 |
| &nbsp;&nbsp;CardPaymentProcessor.sol        |     100 |    99.26 |     100 |     100 |
| &nbsp;&nbsp;CardPaymentProcessorStorage.sol |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;CashbackDistributor.sol         |     100 |    97.62 |     100 |     100 |
| &nbsp;&nbsp;CashbackDistributorStorage.sol  |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;PixCashier.sol                  |     100 |    97.73 |     100 |     100 |
| &nbsp;&nbsp;PixCashierStorage.sol           |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;TokenDistributor.sol            |     100 |       90 |     100 |     100 |
| contracts/interfaces/                       |     100 |      100 |     100 |     100 |
| contracts/mocks/                            |     100 |      100 |     100 |     100 |
| contracts/mocks/tokens/                     |     100 |       50 |     100 |     100 |
| ------------------------------------------- | ------- | -------- | ------- | ------- |
| All files                                   |     100 |     98.1 |     100 |     100 |