### PR TITLE
Improve cashback changes handling in CardPaymentProcessor contract

### DIFF
--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -41,6 +41,13 @@ contract CardPaymentProcessor is
     /// @dev The maximum allowable cashback rate in permil (1 permil = 0.1 %).
     uint16 public constant MAX_CASHBACK_RATE_IN_PERMIL = 250;
 
+    /**
+     * @dev The coefficient used to round the cashback according to the formula:
+     *      `roundedCashback = [(cashback + coef / 2) / coef] * coef`.
+     * Currently, it can only be changed by deploying a new implementation of the contract.
+     */
+    uint16 public constant CASHBACK_ROUNDING_COEF = 10000;
+
     // -------------------- Events -----------------------------------
 
     /**
@@ -1612,7 +1619,8 @@ contract CardPaymentProcessor is
 
     /// @dev Calculates cashback according to the amount and the rate.
     function calculateCashback(uint256 amount, uint256 cashbackRateInPermil) internal pure returns (uint256) {
-        return amount * cashbackRateInPermil / 1000;
+        uint256 cashback = amount * cashbackRateInPermil / 1000;
+        return ((cashback + CASHBACK_ROUNDING_COEF / 2) / CASHBACK_ROUNDING_COEF) * CASHBACK_ROUNDING_COEF;
     }
 
     /// @dev Update the extra amount of a payment and emits the related event.


### PR DESCRIPTION
### Description

The improvements eliminate a handling bug when the initial cashback is capped.

The following rules have been applied to cashback changes:
1. If the base amount of a payment decreases (in the `updatePaymentAmount()` function) or a payment is refunding the new cashback amount cannot be higher than the old cashback amount if the old cashback was capped.
2. If the base amount of a payment increases (in the `updatePaymentAmount()` function) the new cashback amount can be higher than the old cashback amount even if the old cashback amount was capped.
3. Calling functions of the `CashbackDistributor` contract when the cashback amount change is zero. If the new base amount of a payment is greater than the old one the `increaseCashback()` function of the `CashbackDistributor` contract will be called (with zero amount parameter). Otherwise the `revokeCashback()` function of the `CashbackDistributor` contract will be called (with zero amount parameter).

Example for rule 1:
* `payment.baseAmount = 1000 BRLC`;
* `payment.extraAmount = 0;
* `cashbackRate = 1.5%`;
* `oldExpectedCashbackAmount = 15 BRLC`;
* `oldActualCashbackAmount = 6 BRLC` -- due to the cashback cap;
* Execute refunding operation with `refundAmount = 200 BRLC`;
* `newExpectedCashbackAmount = 12 BRLC` -- after refunding;
* `newActualCashbackAmount = ?`;
* Because `newExpectedCashbackAmount > oldActualCashbackAmount` then `newActualCashbackAmount = 6 BRLC`;
* `cashbackChange = 0`.

Another example for rule 1:
* `payment.baseAmount = 1000 BRLC`;
* `payment.extraAmount = 0;
* `cashbackRate = 1.5%`;
* `oldExpectedCashbackAmount = 15 BRLC`;
* `oldActualCashbackAmount = 6 BRLC` -- due to the cashback cap;
* Execute updating operation with `newBaseAmount = 600 BRLC`;
* `newExpectedCashbackAmount = 9 BRLC` -- after updating;
* `newActualCashbackAmount = ?`;
* Because `newExpectedCashbackAmount > oldActualCashbackAmount` then `newActualCashbackAmount = 6 BRLC`;
* `cashbackChange = 0`.

Example for rule 2:
* `payment.baseAmount = 1000 BRLC`;
* `payment.extraAmount = 0;
* `cashbackRate = 1.5%`;
* `oldExpectedCashbackAmount = 15 BRLC`;
* `oldActualCashbackAmount = 6 BRLC` -- due to the cashback cap;
* The cashback cap reset for the account.
* Execute updating operation with `newBaseAmount = 1200 BRLC`;
* `newActualCashbackAmount = 18 BRLC`;
* `cashbackChange = +12 BRLC`.

Another example for rule 2:
* `payment.baseAmount = 1000 BRLC`;
* `payment.extraAmount = 0;
* `cashbackRate = 1.5%`;
* `oldExpectedCashbackAmount = 15 BRLC`;
* `oldActualCashbackAmount = 6 BRLC` -- due to the cashback cap;
* The cashback cap did not reset for the account.
* Execute updating operation with `newBaseAmount = 1200 BRLC`;
* `newExpectedCashbackAmount = 18 BRLC`;
* `newActualCashbackAmount = 0 BRLC` -- due to the cap has not reset yet;
* `cashbackChange = 0`.

Examples for rule 3:
* `payment.baseAmount = 1000 BRLC`;
* `payment.extraAmount = 0;
* The payment is subsidized with `subsidyLimit = 2000 BRLC`;
* If an updating operation is executed with `newBaseAmount = 1200 BRLC`, the cashback changes is zero and the `increaseCashback()` function of the `CashbackDistributor` contract will be called`;
* If an updating operation is executed with `newBaseAmount = 800 BRLC`, the cashback changes is zero and the `revokeCashback()` function of the `CashbackDistributor` contract will be called`.

### Test coverage

| Folder or File                              | % Stmts | % Branch | % Funcs | % Lines |
|:--------------------------------------------|--------:|---------:|--------:|--------:|
| contracts/                                  |     100 |    98.29 |     100 |     100 |
| &nbsp;&nbsp;CardPaymentProcessor.sol        |     100 |    99.28 |     100 |     100 |
| &nbsp;&nbsp;CardPaymentProcessorStorage.sol |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;CashbackDistributor.sol         |     100 |    97.62 |     100 |     100 |
| &nbsp;&nbsp;CashbackDistributorStorage.sol  |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;PixCashier.sol                  |     100 |    97.73 |     100 |     100 |
| &nbsp;&nbsp;PixCashierStorage.sol           |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;TokenDistributor.sol            |     100 |       90 |     100 |     100 |
| contracts/interfaces/                       |     100 |      100 |     100 |     100 |
| contracts/mocks/                            |     100 |      100 |     100 |     100 |
| contracts/mocks/tokens/                     |     100 |       50 |     100 |     100 |
| ------------------------------------------- | ------- | -------- | ------- | ------- |
| All files                                   |     100 |    98.13 |     100 |     100 |  