### PR TITLE
Unite clearing and confirmation operations for a payment in the CardPaymentProcessor contract

### DIFF
--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -440,10 +440,10 @@ contract CardPaymentProcessor is
      * - The payment linked with the authorization ID must have the "uncleared" status.
      */
     function clearPayment(bytes16 authorizationId) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
-        uint256 totalAmount = clearPaymentInternal(authorizationId);
+        uint256 amount = clearPaymentInternal(authorizationId);
 
-        _totalUnclearedBalance = _totalUnclearedBalance - totalAmount;
-        _totalClearedBalance = _totalClearedBalance + totalAmount;
+        _totalUnclearedBalance -= amount;
+        _totalClearedBalance += amount;
     }
 
     /**
@@ -462,14 +462,14 @@ contract CardPaymentProcessor is
             revert EmptyAuthorizationIdsArray();
         }
 
-        uint256 cumulativeTotalAmount = 0;
+        uint256 cumulativeAmount = 0;
         uint256 len = authorizationIds.length;
         for (uint256 i = 0; i < len; i++) {
-            cumulativeTotalAmount += clearPaymentInternal(authorizationIds[i]);
+            cumulativeAmount += clearPaymentInternal(authorizationIds[i]);
         }
 
-        _totalUnclearedBalance = _totalUnclearedBalance - cumulativeTotalAmount;
-        _totalClearedBalance = _totalClearedBalance + cumulativeTotalAmount;
+        _totalUnclearedBalance -= cumulativeAmount;
+        _totalClearedBalance += cumulativeAmount;
     }
 
     /**
@@ -483,10 +483,10 @@ contract CardPaymentProcessor is
      * - The payment linked with the authorization ID must have the "cleared" status.
      */
     function unclearPayment(bytes16 authorizationId) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
-        uint256 totalAmount = unclearPaymentInternal(authorizationId);
+        uint256 amount = unclearPaymentInternal(authorizationId);
 
-        _totalClearedBalance = _totalClearedBalance - totalAmount;
-        _totalUnclearedBalance = _totalUnclearedBalance + totalAmount;
+        _totalClearedBalance -=amount;
+        _totalUnclearedBalance += amount;
     }
 
     /**
@@ -505,14 +505,14 @@ contract CardPaymentProcessor is
             revert EmptyAuthorizationIdsArray();
         }
 
-        uint256 cumulativeTotalAmount = 0;
+        uint256 cumulativeAmount = 0;
         uint256 len = authorizationIds.length;
         for (uint256 i = 0; i < len; i++) {
-            cumulativeTotalAmount += unclearPaymentInternal(authorizationIds[i]);
+            cumulativeAmount += unclearPaymentInternal(authorizationIds[i]);
         }
 
-        _totalClearedBalance = _totalClearedBalance - cumulativeTotalAmount;
-        _totalUnclearedBalance = _totalUnclearedBalance + cumulativeTotalAmount;
+        _totalClearedBalance -= cumulativeAmount;
+        _totalUnclearedBalance += cumulativeAmount;
     }
 
     /**
@@ -598,13 +598,13 @@ contract CardPaymentProcessor is
             revert EmptyAuthorizationIdsArray();
         }
 
-        uint256 totalAmount = 0;
+        uint256 cumulativeAmount = 0;
         for (uint256 i = 0; i < authorizationIds.length; i++) {
-            totalAmount += confirmPaymentInternal(authorizationIds[i]);
+            cumulativeAmount += confirmPaymentInternal(authorizationIds[i]);
         }
 
-        _totalClearedBalance -= totalAmount;
-        IERC20Upgradeable(_token).safeTransfer(requireCashOutAccount(), totalAmount);
+        _totalClearedBalance -= cumulativeAmount;
+        IERC20Upgradeable(_token).safeTransfer(requireCashOutAccount(), cumulativeAmount);
     }
 
     /**

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -523,6 +523,34 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
     function confirmPayments(bytes16[] memory authorizationIds) external;
 
     /**
+     * @dev Executes clearing and confirmation operations for a single previously made card payment.
+     *
+     * This function can be called by a limited number of accounts that are allowed to execute processing operations.
+     *
+     * Emits a {ClearPayment} event.
+     * Emits a {ClearPaymentSubsidized} event if the payment is subsidized.
+     * Emits a {ConfirmPayment} event.
+     * Emits a {ConfirmPaymentSubsidized} event if the payment is subsidized.
+     *
+     * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
+     */
+    function clearAndConfirmPayment(bytes16 authorizationId) external;
+
+    /**
+     * @dev Executes clearing and confirmation operations for several previously made card payments.
+     *
+     * This function can be called by a limited number of accounts that are allowed to execute processing operations.
+     *
+     * Emits a {ClearPayment} event for each payment.
+     * Emits a {ClearPaymentSubsidized} event for each subsidized payment.
+     * Emits a {ConfirmPayment} event for each payment.
+     * Emits a {ConfirmPaymentSubsidized} for each subsidized payment.
+     *
+     * @param authorizationIds The card transaction authorization IDs from the off-chain card processing backend.
+     */
+    function clearAndConfirmPayments(bytes16[] memory authorizationIds) external;
+
+    /**
      * @dev Makes a refund for a previously made card payment.
      *
      * Emits a {RefundPayment} event.


### PR DESCRIPTION
### Main changes
1. Two new functions have been added to the CardPaymentProcessor contract (CPP): `clearAndConfirmPayment(bytes16 authorizationId)` and `clearAndConfirmPayments(bytes16[] memory authorizationIds)`
2. Function `clearAndConfirmPayment()` executes consequently clearing and confirm operations for a single payment by its authorization ID.
3. Function `clearAndConfirmPayments()` does the same as the function above but for several payments by their authorization IDs.

### Test coverage

| Folder or File                              | % Stmts | % Branch | % Funcs | % Lines |
|:--------------------------------------------|--------:|---------:|--------:|--------:|
| contracts/                                  |     100 |    98.33 |     100 |     100 |
| &nbsp;&nbsp;CardPaymentProcessor.sol        |     100 |     99.3 |     100 |     100 |
| &nbsp;&nbsp;CardPaymentProcessorStorage.sol |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;CashbackDistributor.sol         |     100 |    97.62 |     100 |     100 |
| &nbsp;&nbsp;CashbackDistributorStorage.sol  |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;PixCashier.sol                  |     100 |    97.73 |     100 |     100 |
| &nbsp;&nbsp;PixCashierStorage.sol           |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;TokenDistributor.sol            |     100 |       90 |     100 |     100 |
| contracts/interfaces/                       |     100 |      100 |     100 |     100 |
| contracts/mocks/                            |     100 |      100 |     100 |     100 |
| contracts/mocks/tokens/                     |     100 |       50 |     100 |     100 |
| ------------------------------------------- | ------- | -------- | ------- | ------- |
| All files                                   |     100 |    98.16 |     100 |     100 |

