### PR TITLE
PIX. Tracking cash-in operations to prevent `txId` reusage

### DIFF
--- a/contracts/PixCashierStorage.sol
+++ b/contracts/PixCashierStorage.sol
@@ -26,6 +26,14 @@ abstract contract PixCashierStorageV1 is IPixCashierTypes {
 }
 
 /**
+ * @title PixCashier storage version 2
+ */
+abstract contract PixCashierStorageV2 is IPixCashierTypes {
+    /// @dev The mapping of a cash-out operation structure for a given off-chain transaction identifier.
+    mapping(bytes32 => CashInOperation) internal _cashIns;
+}
+
+/**
  * @title PixCashier storage
  * @dev Contains storage variables of the {PixCashier} contract.
  *
@@ -35,6 +43,6 @@ abstract contract PixCashierStorageV1 is IPixCashierTypes {
  * e.g. PixCashierStorage<versionNumber>, so finally it would look like
  * "contract PixCashierStorage is PixCashierStorageV1, PixCashierStorageV2".
  */
-abstract contract PixCashierStorage is PixCashierStorageV1 {
+abstract contract PixCashierStorage is PixCashierStorageV1, PixCashierStorageV2 {
 
 }

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -7,6 +7,18 @@ pragma solidity 0.8.16;
  */
 interface IPixCashierTypes {
     /**
+     * @dev Possible statuses of a cash-in operation as an enum.
+     *
+     * The possible values:
+     * - Nonexistent - The operation does not exist (the default value).
+     * - Executed ---- The operations was executed.
+     */
+    enum CashInStatus {
+        Nonexistent, // 0
+        Executed     // 1
+    }
+
+    /**
      * @dev Possible statuses of a cash-out operation as an enum.
      *
      * The possible values:
@@ -22,7 +34,14 @@ interface IPixCashierTypes {
         Confirmed    // 3
     }
 
-    /// @dev Structure with data of a single cash-out operation.
+    /// @dev Structure with data of a single cash-in operation.
+    struct CashInOperation {
+        CashInStatus status;  // The status of the cash-in operation according to the {CashInStatus} enum.
+        address account;      // The owner of tokens to cash-in.
+        uint256 amount;       // The amount of tokens to cash-in.
+    }
+
+    /// @dev Structure with data of a single cash-in operation.
     struct CashOut {
         address account;      // The owner of tokens to cash-out.
         uint256 amount;       // The amount of tokens to cash-out.
@@ -71,6 +90,18 @@ interface IPixCashier is IPixCashierTypes {
      * @dev Returns the address of the underlying token.
      */
     function underlyingToken() external view returns (address);
+
+    /**
+     * @dev Returns the data of a single cash-in operation.
+     * @param txId The off-chain transaction identifier of the operation.
+     */
+    function getCashIn(bytes32 txId) external view returns (CashInOperation memory);
+
+    /**
+     * @dev Returns the data of multiple cash-out operations.
+     * @param txIds The off-chain transaction identifiers of the operations.
+     */
+    function getCashIns(bytes32[] memory txIds) external view returns (CashInOperation[] memory cashIns);
 
     /**
      * @dev Returns the pending cash-out balance for an account.


### PR DESCRIPTION
### Main changes

1. Each time a cash-in operation with a given off-chain transaction identifier `txId` is executed the information about it stored on the `PixCashier` contract using the following code entities:
    ```solidity
    enum CashInStatus {
        Nonexistent, // 0
        Executed     // 1
    }

    struct CashInOperation {
        CashInStatus status;  // The status of the cash-in operation according to the {CashInStatus} enum.
        address account;      // The owner of tokens to cash-in.
        uint256 amount;       // The amount of tokens to cash-in.
    }
    
    // The mapping of a cash-out operation structure for a given off-chain transaction identifier (`txId`).
    mapping(bytes32 => CashInOperation) internal _cashIns;
    ```
2. Each time a cash-in operation is executed (through the `cashIn()` or `cashInBatch()` function call) it is checked whether an operation with the same `txId` was executed already or not. If ""yes" the transaction will be reverted with the following custom error:
    ```solidity
    /**
     * @dev The cash-in operation with the provided off-chain transaction is already executed.
     * @param txId The off-chain transaction identifiers of the operation.
     */
    error CashInAlreadyExecuted(bytes32 txId);
    ```
3. To fetch the stored data of  cash-in operations from the `PixCashier` contract the following new functions have been implemented:
    * for a single operation: `function getCashIn(bytes32 txIds) external view returns (CashInOperation memory)`;
    * for several operations: `function getCashIns(bytes32[] memory txIds) external view returns (CashInOperation[] memory)`.
4. Gas usage for a single cash-in operation increased from ~85k to ~130k, i.e. on about 53%.

### Test coverage

| Folder or File                              | % Stmts | % Branch | % Funcs | % Lines |
|:--------------------------------------------|--------:|---------:|--------:|--------:|
| contracts/                                  |     100 |    98.33 |     100 |     100 |
| &nbsp;&nbsp;CardPaymentProcessor.sol        |     100 |     99.3 |     100 |     100 |
| &nbsp;&nbsp;CardPaymentProcessorStorage.sol |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;CashbackDistributor.sol         |     100 |    97.62 |     100 |     100 |
| &nbsp;&nbsp;CashbackDistributorStorage.sol  |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;PixCashier.sol                  |     100 |    97.78 |     100 |     100 |
| &nbsp;&nbsp;PixCashierStorage.sol           |     100 |      100 |     100 |     100 |
| &nbsp;&nbsp;TokenDistributor.sol            |     100 |       90 |     100 |     100 |
| contracts/interfaces/                       |     100 |      100 |     100 |     100 |
| contracts/mocks/                            |     100 |      100 |     100 |     100 |
| contracts/mocks/tokens/                     |     100 |       50 |     100 |     100 |
| ------------------------------------------- | ------- | -------- | ------- | ------- |
| All files                                   |     100 |    98.17 |     100 |     100 |
