### PR TITLE
Improve cash-in batch operations 

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -12073,6 +12073,376 @@
           }
         }
       }
+    },
+    "b60ba51314d499c3c8f460a316b6f4747adcc7940cd0b81fe62c3240e463f1d7": {
+      "address": "0x34c8BB4119cCA33399B2022acd9d4a2968723C31",
+      "txHash": "0x3fc0954849456b8c9e2e07fb81496aaaa268dbd8d332c8b3dc87a934002c7335",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)469_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:21"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:139"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\PausableExtUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\RescuableUpgradeable.sol:71"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_token",
+            "offset": 0,
+            "slot": "551",
+            "type": "t_address",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:13"
+          },
+          {
+            "label": "_cashOutBalances",
+            "offset": 0,
+            "slot": "552",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:16"
+          },
+          {
+            "label": "_cashOuts",
+            "offset": 0,
+            "slot": "553",
+            "type": "t_mapping(t_bytes32,t_struct(CashOut)11365_storage)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:19"
+          },
+          {
+            "label": "_pendingCashOutTxIds",
+            "offset": 0,
+            "slot": "554",
+            "type": "t_struct(Bytes32Set)2928_storage",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:22"
+          },
+          {
+            "label": "_processedCashOutCounter",
+            "offset": 0,
+            "slot": "556",
+            "type": "t_uint256",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:25"
+          },
+          {
+            "label": "_cashIns",
+            "offset": 0,
+            "slot": "557",
+            "type": "t_mapping(t_bytes32,t_struct(CashInOperation)11353_storage)",
+            "contract": "PixCashierStorageV2",
+            "src": "contracts\\PixCashierStorage.sol:33"
+          },
+          {
+            "label": "_cashInBatches",
+            "offset": 0,
+            "slot": "558",
+            "type": "t_mapping(t_bytes32,t_struct(CashInBatchOperation)11357_storage)",
+            "contract": "PixCashierStorageV3",
+            "src": "contracts\\PixCashierStorage.sol:41"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(CashInBatchStatus)11334": {
+            "label": "enum IPixCashierTypes.CashInBatchStatus",
+            "members": [
+              "Nonexistent",
+              "Executed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashInStatus)11331": {
+            "label": "enum IPixCashierTypes.CashInStatus",
+            "members": [
+              "Nonexistent",
+              "Executed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashOutStatus)11345": {
+            "label": "enum IPixCashierTypes.CashOutStatus",
+            "members": [
+              "Nonexistent",
+              "Pending",
+              "Reversed",
+              "Confirmed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInBatchOperation)11357_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInBatchOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInOperation)11353_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashOut)11365_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashOut)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)469_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Bytes32Set)2928_storage": {
+            "label": "struct EnumerableSetUpgradeable.Bytes32Set",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)2734_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashInBatchOperation)11357_storage": {
+            "label": "struct IPixCashierTypes.CashInBatchOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInBatchStatus)11334",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(CashInOperation)11353_storage": {
+            "label": "struct IPixCashierTypes.CashInOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInStatus)11331",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashOut)11365_storage": {
+            "label": "struct IPixCashierTypes.CashOut",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(CashOutStatus)11345",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(RoleData)469_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Set)2734_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -11703,6 +11703,376 @@
           }
         }
       }
+    },
+    "b56007d4de229d7d85bf3bf298287a46372d09e04112083c8c17e33c6c73fd0d": {
+      "address": "0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8",
+      "txHash": "0xb3349123b940793a25be7adbdaa670a76ea0973b38dd48504fa61053c997e962",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)469_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:21"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:139"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\PausableExtUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\RescuableUpgradeable.sol:71"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_token",
+            "offset": 0,
+            "slot": "551",
+            "type": "t_address",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:13"
+          },
+          {
+            "label": "_cashOutBalances",
+            "offset": 0,
+            "slot": "552",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:16"
+          },
+          {
+            "label": "_cashOuts",
+            "offset": 0,
+            "slot": "553",
+            "type": "t_mapping(t_bytes32,t_struct(CashOut)4082_storage)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:19"
+          },
+          {
+            "label": "_pendingCashOutTxIds",
+            "offset": 0,
+            "slot": "554",
+            "type": "t_struct(Bytes32Set)2292_storage",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:22"
+          },
+          {
+            "label": "_processedCashOutCounter",
+            "offset": 0,
+            "slot": "556",
+            "type": "t_uint256",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:25"
+          },
+          {
+            "label": "_cashIns",
+            "offset": 0,
+            "slot": "557",
+            "type": "t_mapping(t_bytes32,t_struct(CashInOperation)4070_storage)",
+            "contract": "PixCashierStorageV2",
+            "src": "contracts\\PixCashierStorage.sol:33"
+          },
+          {
+            "label": "_cashInBatches",
+            "offset": 0,
+            "slot": "558",
+            "type": "t_mapping(t_bytes32,t_struct(CashInBatchOperation)4074_storage)",
+            "contract": "PixCashierStorageV3",
+            "src": "contracts\\PixCashierStorage.sol:41"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(CashInBatchStatus)4057": {
+            "label": "enum IPixCashierTypes.CashInBatchStatus",
+            "members": [
+              "Nonexistent",
+              "Executed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashInStatus)4054": {
+            "label": "enum IPixCashierTypes.CashInStatus",
+            "members": [
+              "Nonexistent",
+              "Executed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashOutStatus)4062": {
+            "label": "enum IPixCashierTypes.CashOutStatus",
+            "members": [
+              "Nonexistent",
+              "Pending",
+              "Reversed",
+              "Confirmed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInBatchOperation)4074_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInBatchOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInOperation)4070_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashOut)4082_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashOut)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)469_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Bytes32Set)2292_storage": {
+            "label": "struct EnumerableSetUpgradeable.Bytes32Set",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)2098_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashInBatchOperation)4074_storage": {
+            "label": "struct IPixCashierTypes.CashInBatchOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInBatchStatus)4057",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(CashInOperation)4070_storage": {
+            "label": "struct IPixCashierTypes.CashInOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInStatus)4054",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashOut)4082_storage": {
+            "label": "struct IPixCashierTypes.CashOut",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(CashOutStatus)4062",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(RoleData)469_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Set)2098_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -11704,6 +11704,364 @@
         }
       }
     },
+    "e563e80b94285180065008693efe5ee9eb1a26a99628011f044a1b7fcc410f0c": {
+      "address": "0xdCbDAcce467D18aD39c6378403A2DC71e125Fd96",
+      "txHash": "0x65f5b67634eb1fcad004ca521c7fc3bd42a79e501c1d95421813f31bea3fa5d6",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)469_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:21"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:139"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\PausableExtUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\RescuableUpgradeable.sol:71"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_enabled",
+            "offset": 0,
+            "slot": "551",
+            "type": "t_bool",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:13"
+          },
+          {
+            "label": "_nextNonce",
+            "offset": 0,
+            "slot": "552",
+            "type": "t_uint256",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:16"
+          },
+          {
+            "label": "_cashbacks",
+            "offset": 0,
+            "slot": "553",
+            "type": "t_mapping(t_uint256,t_struct(Cashback)10907_storage)",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:19"
+          },
+          {
+            "label": "_nonceCollectionByExternalId",
+            "offset": 0,
+            "slot": "554",
+            "type": "t_mapping(t_bytes32,t_array(t_uint256)dyn_storage)",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:22"
+          },
+          {
+            "label": "_totalAmountByExternalId",
+            "offset": 0,
+            "slot": "555",
+            "type": "t_mapping(t_bytes32,t_uint256)",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:25"
+          },
+          {
+            "label": "_totalAmountByRecipient",
+            "offset": 0,
+            "slot": "556",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:28"
+          },
+          {
+            "label": "_totalCashbackByTokenAndExternalId",
+            "offset": 0,
+            "slot": "557",
+            "type": "t_mapping(t_address,t_mapping(t_bytes32,t_uint256))",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:31"
+          },
+          {
+            "label": "_totalCashbackByTokenAndRecipient",
+            "offset": 0,
+            "slot": "558",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:34"
+          },
+          {
+            "label": "_cashbackLastTimeReset",
+            "offset": 0,
+            "slot": "559",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "CashbackDistributorStorageV2",
+            "src": "contracts\\CashbackDistributorStorage.sol:45"
+          },
+          {
+            "label": "_cashbackSinceLastReset",
+            "offset": 0,
+            "slot": "560",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "CashbackDistributorStorageV2",
+            "src": "contracts\\CashbackDistributorStorage.sol:47"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(CashbackKind)10863": {
+            "label": "enum ICashbackDistributorTypes.CashbackKind",
+            "members": [
+              "Manual",
+              "CardPayment"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashbackStatus)10872": {
+            "label": "enum ICashbackDistributorTypes.CashbackStatus",
+            "members": [
+              "Nonexistent",
+              "Success",
+              "Blacklisted",
+              "OutOfFunds",
+              "Disabled",
+              "Revoked",
+              "Capped",
+              "Partial"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_uint256))": {
+            "label": "mapping(address => mapping(bytes32 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_array(t_uint256)dyn_storage)": {
+            "label": "mapping(bytes32 => uint256[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)469_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Cashback)10907_storage)": {
+            "label": "mapping(uint256 => struct ICashbackDistributorTypes.Cashback)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Cashback)10907_storage": {
+            "label": "struct ICashbackDistributorTypes.Cashback",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "kind",
+                "type": "t_enum(CashbackKind)10863",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(CashbackStatus)10872",
+                "offset": 21,
+                "slot": "0"
+              },
+              {
+                "label": "externalId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "recipient",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "sender",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "revokedAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              }
+            ],
+            "numberOfBytes": "192"
+          },
+          "t_struct(RoleData)469_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
     "b56007d4de229d7d85bf3bf298287a46372d09e04112083c8c17e33c6c73fd0d": {
       "address": "0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8",
       "txHash": "0xb3349123b940793a25be7adbdaa670a76ea0973b38dd48504fa61053c997e962",
@@ -12391,6 +12749,376 @@
               {
                 "label": "status",
                 "type": "t_enum(CashOutStatus)11345",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(RoleData)469_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Set)2734_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "333181ff241ab85299a3b57fabca0cc6dae9ad1d56434a17a7528247a59bdbad": {
+      "address": "0x1497D1a06f6449108a40fB8C4A67eF6eDE13EbBd",
+      "txHash": "0xcaf39b5a471d01c52be5fd87322ee9ccec7e733326538273d85905a87fe35711",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)469_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:21"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:139"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\PausableExtUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\RescuableUpgradeable.sol:71"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_token",
+            "offset": 0,
+            "slot": "551",
+            "type": "t_address",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:13"
+          },
+          {
+            "label": "_cashOutBalances",
+            "offset": 0,
+            "slot": "552",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:16"
+          },
+          {
+            "label": "_cashOuts",
+            "offset": 0,
+            "slot": "553",
+            "type": "t_mapping(t_bytes32,t_struct(CashOut)11366_storage)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:19"
+          },
+          {
+            "label": "_pendingCashOutTxIds",
+            "offset": 0,
+            "slot": "554",
+            "type": "t_struct(Bytes32Set)2928_storage",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:22"
+          },
+          {
+            "label": "_processedCashOutCounter",
+            "offset": 0,
+            "slot": "556",
+            "type": "t_uint256",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:25"
+          },
+          {
+            "label": "_cashIns",
+            "offset": 0,
+            "slot": "557",
+            "type": "t_mapping(t_bytes32,t_struct(CashInOperation)11354_storage)",
+            "contract": "PixCashierStorageV2",
+            "src": "contracts\\PixCashierStorage.sol:33"
+          },
+          {
+            "label": "_cashInBatches",
+            "offset": 0,
+            "slot": "558",
+            "type": "t_mapping(t_bytes32,t_struct(CashInBatchOperation)11358_storage)",
+            "contract": "PixCashierStorageV3",
+            "src": "contracts\\PixCashierStorage.sol:41"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(CashInBatchStatus)11335": {
+            "label": "enum IPixCashierTypes.CashInBatchStatus",
+            "members": [
+              "Nonexistent",
+              "Executed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashInStatus)11332": {
+            "label": "enum IPixCashierTypes.CashInStatus",
+            "members": [
+              "Nonexistent",
+              "Executed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashOutStatus)11346": {
+            "label": "enum IPixCashierTypes.CashOutStatus",
+            "members": [
+              "Nonexistent",
+              "Pending",
+              "Reversed",
+              "Confirmed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInBatchOperation)11358_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInBatchOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInOperation)11354_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashOut)11366_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashOut)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)469_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Bytes32Set)2928_storage": {
+            "label": "struct EnumerableSetUpgradeable.Bytes32Set",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)2734_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashInBatchOperation)11358_storage": {
+            "label": "struct IPixCashierTypes.CashInBatchOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInBatchStatus)11335",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(CashInOperation)11354_storage": {
+            "label": "struct IPixCashierTypes.CashInOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInStatus)11332",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashOut)11366_storage": {
+            "label": "struct IPixCashierTypes.CashOut",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(CashOutStatus)11346",
                 "offset": 0,
                 "slot": "2"
               }

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -185,8 +185,8 @@ contract PixCashier is
     /**
      * @dev See {IPixCashier-getCashIn}.
      */
-    function getCashIn(bytes32 txIds) external view returns (CashInOperation memory) {
-        return _cashIns[txIds];
+    function getCashIn(bytes32 txId) external view returns (CashInOperation memory) {
+        return _cashIns[txId];
     }
 
     /**
@@ -197,6 +197,26 @@ contract PixCashier is
         cashIns = new CashInOperation[](len);
         for (uint256 i = 0; i < len; i++) {
             cashIns[i] = _cashIns[txIds[i]];
+        }
+    }
+
+    /**
+     * @dev See {IPixCashier-getCashInBatch}.
+     */
+    function getCashInBatch(bytes32 batchId) external view returns (CashInBatchOperation memory) {
+        return _cashInBatches[batchId];
+    }
+
+    /**
+     * @dev See {IPixCashier-getCashInBatches}.
+     */
+    function getCashInBatches(
+        bytes32[] memory batchIds
+    ) external view returns (CashInBatchOperation[] memory cashInBatches) {
+        uint256 len = batchIds.length;
+        cashInBatches = new CashInBatchOperation[](len);
+        for (uint256 i = 0; i < len; i++) {
+            cashInBatches[i] = _cashInBatches[batchIds[i]];
         }
     }
 
@@ -254,7 +274,7 @@ contract PixCashier is
         if (accounts.length == 0 || accounts.length != amounts.length || accounts.length != txIds.length) {
             revert InvalidBatchArrays();
         }
-        if (_cashInBatches[batchId]) {
+        if (_cashInBatches[batchId].status == CashInBatchStatus.Executed) {
             revert CashInBatchAlreadyExecuted(batchId);
         }
         if (batchId == 0) {
@@ -265,7 +285,7 @@ contract PixCashier is
             _cashIn(accounts[i], amounts[i], txIds[i]);
         }
 
-        _cashInBatches[batchId] = true;
+        _cashInBatches[batchId].status = CashInBatchStatus.Executed;
 
         emit CashInBatch(batchId);
     }

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -294,7 +294,7 @@ contract PixCashier is
 
         _cashInBatches[batchId].status = CashInBatchStatus.Executed;
 
-        emit CashInBatch(batchId, executionResults);
+        emit CashInBatch(batchId, txIds, executionResults);
     }
 
     /**

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -246,6 +246,7 @@ contract PixCashier is
      * - The contract must not be paused.
      * - The caller must have the {CASHIER_ROLE} role.
      * - The provided `account`, `amount`, and `txId` values must not be zero.
+     * - The cash-in operation with the provided `txId` must not be already executed.
      */
     function cashIn(
         address account,
@@ -264,6 +265,10 @@ contract PixCashier is
      * - The contract must not be paused.
      * - The caller must have the {CASHIER_ROLE} role.
      * - The provided `account`, `amount`, and `txId` values must not be zero.
+     * - The provided `accounts`, `amounts`, `txIds` arrays must not be empty and must have the same length.
+     * - The provided `batchId` must not be zero
+     * - The cash-in batch operation with the provided `batchId` must not be already executed.
+     * - Each cash-in operation with the provided identifier from the `txIds` array must not be already executed.
      */
     function cashInBatch(
         address[] memory accounts,

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -254,7 +254,7 @@ contract PixCashier is
         if (accounts.length == 0 || accounts.length != amounts.length || accounts.length != txIds.length) {
             revert InvalidBatchArrays();
         }
-        if (_chashInBatches[batchId]) {
+        if (_cashInBatches[batchId]) {
             revert CashInBatchAlreadyExecuted(batchId);
         }
         if (batchId == 0) {
@@ -265,7 +265,7 @@ contract PixCashier is
             _cashIn(accounts[i], amounts[i], txIds[i]);
         }
 
-        _chashInBatches[batchId] = true;
+        _cashInBatches[batchId] = true;
 
         emit CashInBatch(batchId);
     }

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -436,12 +436,11 @@ contract PixCashier is
         }
 
         if (_cashIns[txId].status != CashInStatus.Nonexistent) {
-            if (policy == CashInExecutionPolicy.Revert) {
-                revert CashInAlreadyExecuted(txId);
-            } else if (policy == CashInExecutionPolicy.Skip) {
+            if (policy == CashInExecutionPolicy.Skip) {
                 return CashInExecutionResult.AlreadyExecuted;
+            } else {
+                revert CashInAlreadyExecuted(txId);
             }
-            assert(false);
         }
 
         _cashIns[txId] = CashInOperation({

--- a/contracts/PixCashierStorage.sol
+++ b/contracts/PixCashierStorage.sol
@@ -19,7 +19,7 @@ abstract contract PixCashierStorageV1 is IPixCashierTypes {
     mapping(bytes32 => CashOut) internal _cashOuts;
 
     /// @dev The set of off-chain transaction identifiers that correspond the pending cash-out operations.
-    EnumerableSetUpgradeable.Bytes32Set _pendingCashOutTxIds;
+    EnumerableSetUpgradeable.Bytes32Set internal _pendingCashOutTxIds;
 
     /// @dev The processed cash-out operation counter that includes number of reversed and confirmed operations.
     uint256 internal _processedCashOutCounter;

--- a/contracts/PixCashierStorage.sol
+++ b/contracts/PixCashierStorage.sol
@@ -36,9 +36,9 @@ abstract contract PixCashierStorageV2 is IPixCashierTypes {
 /**
  * @title PixCashier storage version 3
  */
-abstract contract PixCashierStorageV3 {
-    /// @dev The mapping of a cash-in batch identifier to a boolean value that indicates whether the batch was processed.
-    mapping(bytes32 => bool) internal _cashInBatches;
+abstract contract PixCashierStorageV3 is IPixCashierTypes {
+    /// @dev The mapping of a cash-in batch operation structure for a given off-chain identifier.
+    mapping(bytes32 => CashInBatchOperation) internal _cashInBatches;
 }
 
 /**

--- a/contracts/PixCashierStorage.sol
+++ b/contracts/PixCashierStorage.sol
@@ -29,7 +29,7 @@ abstract contract PixCashierStorageV1 is IPixCashierTypes {
  * @title PixCashier storage version 2
  */
 abstract contract PixCashierStorageV2 is IPixCashierTypes {
-    /// @dev The mapping of a cash-out operation structure for a given off-chain transaction identifier.
+    /// @dev The mapping of a cash-in operation structure for a given off-chain transaction identifier.
     mapping(bytes32 => CashInOperation) internal _cashIns;
 }
 
@@ -37,8 +37,8 @@ abstract contract PixCashierStorageV2 is IPixCashierTypes {
  * @title PixCashier storage version 3
  */
 abstract contract PixCashierStorageV3 {
-    /// @dev The mapping of a chahi-in batch identifier to a boolean value that indicates whether the batch was processed.
-    mapping(bytes32 => bool) internal _chashInBatches;
+    /// @dev The mapping of a cash-in batch identifier to a boolean value that indicates whether the batch was processed.
+    mapping(bytes32 => bool) internal _cashInBatches;
 }
 
 /**

--- a/contracts/PixCashierStorage.sol
+++ b/contracts/PixCashierStorage.sol
@@ -34,6 +34,14 @@ abstract contract PixCashierStorageV2 is IPixCashierTypes {
 }
 
 /**
+ * @title PixCashier storage version 3
+ */
+abstract contract PixCashierStorageV3 {
+    /// @dev The mapping of a chahi-in batch identifier to a boolean value that indicates whether the batch was processed.
+    mapping(bytes32 => bool) internal _chashInBatches;
+}
+
+/**
  * @title PixCashier storage
  * @dev Contains storage variables of the {PixCashier} contract.
  *
@@ -43,6 +51,6 @@ abstract contract PixCashierStorageV2 is IPixCashierTypes {
  * e.g. PixCashierStorage<versionNumber>, so finally it would look like
  * "contract PixCashierStorage is PixCashierStorageV1, PixCashierStorageV2".
  */
-abstract contract PixCashierStorage is PixCashierStorageV1, PixCashierStorageV2 {
+abstract contract PixCashierStorage is PixCashierStorageV1, PixCashierStorageV2, PixCashierStorageV3 {
 
 }

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -19,6 +19,18 @@ interface IPixCashierTypes {
     }
 
     /**
+     * @dev Possible statuses of a cash-in batch operation as an enum.
+     *
+     * The possible values:
+     * - Nonexistent - The operation does not exist (the default value).
+     * - Executed ---- The operations was executed.
+     */
+    enum CashInBatchStatus {
+        Nonexistent, // 0
+        Executed     // 1
+    }
+
+    /**
      * @dev Possible statuses of a cash-out operation as an enum.
      *
      * The possible values:
@@ -39,6 +51,11 @@ interface IPixCashierTypes {
         CashInStatus status;  // The status of the cash-in operation according to the {CashInStatus} enum.
         address account;      // The owner of tokens to cash-in.
         uint256 amount;       // The amount of tokens to cash-in.
+    }
+
+    /// @dev Structure with data of a batch cash-in operation.
+    struct CashInBatchOperation {
+        CashInBatchStatus status;  // The status of the cash-in batch operation according to the {CashInBatchStatus}.
     }
 
     /// @dev Structure with data of a single cash-in operation.
@@ -103,10 +120,24 @@ interface IPixCashier is IPixCashierTypes {
     function getCashIn(bytes32 txId) external view returns (CashInOperation memory);
 
     /**
-     * @dev Returns the data of multiple cash-out operations.
+     * @dev Returns the data of multiple cash-in operations.
      * @param txIds The off-chain transaction identifiers of the operations.
      */
     function getCashIns(bytes32[] memory txIds) external view returns (CashInOperation[] memory cashIns);
+
+    /**
+     * @dev Returns the data of a cash-in batch operation.
+     * @param batchId The off-chain identifier of the cash-in batch operation.
+     */
+    function getCashInBatch(bytes32 batchId) external view returns (CashInBatchOperation memory);
+
+    /**
+     * @dev Returns the data of multiple cash-in batch operations.
+     * @param batchIds The off-chain identifiers of the cash-in batch operations.
+     */
+    function getCashInBatches(
+        bytes32[] memory batchIds
+    ) external view returns (CashInBatchOperation[] memory cashInBatches);
 
     /**
      * @dev Returns the pending cash-out balance for an account.

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -61,6 +61,11 @@ interface IPixCashier is IPixCashierTypes {
         bytes32 indexed txId     // The off-chain transaction identifier.
     );
 
+    /// @dev Emitted when a new batch of cash-in operations is executed.
+    event CashInBatch(
+        bytes32 indexed batchId // The off-chain batch identifier.
+    );
+
     /// @dev Emitted when a new cash-out operation is initiated.
     event RequestCashOut(
         address indexed account, // The account that owns the tokens to cash-out.
@@ -173,16 +178,19 @@ interface IPixCashier is IPixCashierTypes {
      * This function is expected to be called by a limited number of accounts
      * that are allowed to execute cash-in operations.
      *
-     * Emits {CashIn} events.
+     * Emits a {CashInBatch} event.
+     * Emits a {CashIn} events.
      *
      * @param accounts The array of the addresses of the tokens recipient.
      * @param amounts The array of the token amounts to be received.
      * @param txIds The array of the off-chain transaction identifiers of the operation.
+     * @param batchId The off-chain batch identifier.
      */
     function cashInBatch(
         address[] memory accounts,
         uint256[] memory amounts,
-        bytes32[] memory txIds
+        bytes32[] memory txIds,
+        bytes32 batchId
     ) external;
 
     /**

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -11,7 +11,7 @@ interface IPixCashierTypes {
      *
      * The possible values:
      * - Nonexistent - The operation does not exist (the default value).
-     * - Executed ---- The operations was executed.
+     * - Executed ---- The operation was executed.
      */
     enum CashInStatus {
         Nonexistent, // 0
@@ -23,11 +23,35 @@ interface IPixCashierTypes {
      *
      * The possible values:
      * - Nonexistent - The operation does not exist (the default value).
-     * - Executed ---- The operations was executed.
+     * - Executed ---- The operation was executed.
      */
     enum CashInBatchStatus {
         Nonexistent, // 0
         Executed     // 1
+    }
+
+    /**
+     * @dev Possible result statuses of a cash-in operation as an enum.
+     *
+     * The possible values:
+     * - Success --------- The operation was executed successfully.
+     * - AlreadyExecuted - The operation was already executed.
+     */
+    enum CashInExecutionResult {
+        Success,        // 0
+        AlreadyExecuted // 1
+    }
+
+    /**
+     * @dev Possible execution policies of a cash-in operation as an enum.
+     *
+     * The possible values:
+     * - Revert - In case of failure the operation will be reverted.
+     * - Skip --- In case of failure the operation will be skipped.
+     */
+    enum CashInExecutionPolicy {
+        Revert, // 0
+        Skip    // 1
     }
 
     /**
@@ -37,7 +61,7 @@ interface IPixCashierTypes {
      * - Nonexistent - The operation does not exist (the default value).
      * - Pending ----- The status immediately after the operation requesting.
      * - Reversed ---- The operation was reversed.
-     * - Confirmed --- The operations was confirmed.
+     * - Confirmed --- The operation was confirmed.
      */
     enum CashOutStatus {
         Nonexistent, // 0
@@ -80,7 +104,8 @@ interface IPixCashier is IPixCashierTypes {
 
     /// @dev Emitted when a new batch of cash-in operations is executed.
     event CashInBatch(
-        bytes32 indexed batchId // The off-chain batch identifier.
+        bytes32 indexed batchId,                 // The off-chain batch identifier.
+        CashInExecutionResult[] executionResults // The array of execution results for each operation.
     );
 
     /// @dev Emitted when a new cash-out operation is initiated.

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -105,7 +105,8 @@ interface IPixCashier is IPixCashierTypes {
     /// @dev Emitted when a new batch of cash-in operations is executed.
     event CashInBatch(
         bytes32 indexed batchId,                 // The off-chain batch identifier.
-        CashInExecutionResult[] executionResults // The array of execution results for each operation.
+        bytes32[] txIds,                         // The array of off-chain identifiers for each operation in the batch.
+        CashInExecutionResult[] executionResults // The array of execution results for each operation in the batch.
     );
 
     /// @dev Emitted when a new cash-out operation is initiated.

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -15,7 +15,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A](https://explorer.testnet.cloudwalk.io/address/0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x3181Ab023a4D4788754258BE5A3b8cf3D8276B98](https://explorer.testnet.cloudwalk.io/address/0x3181Ab023a4D4788754258BE5A3b8cf3D8276B98) |
-| 3 | PixCashier | Proxy implementation | [0xc0e7D7F54072F7c61924063e8198039Ec98b838c](https://explorer.testnet.cloudwalk.io/address/0xc0e7D7F54072F7c61924063e8198039Ec98b838c) |
+| 3 | PixCashier | Proxy implementation | [0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8](https://explorer.testnet.cloudwalk.io/address/0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8) |
+|||| <strike>[0xc0e7D7F54072F7c61924063e8198039Ec98b838c](https://explorer.testnet.cloudwalk.io/address/0xc0e7D7F54072F7c61924063e8198039Ec98b838c)</strike> |
 |||| <strike>[0x85Ec19fDfcf32E2733339FB27e55146f7e539dDd](https://explorer.testnet.cloudwalk.io/address/0x85Ec19fDfcf32E2733339FB27e55146f7e539dDd)</strike> |
 |||| <strike>[0x29bda6192283E3FB70f8B507877BC5e3036F1B93](https://explorer.testnet.cloudwalk.io/address/0x29bda6192283E3FB70f8B507877BC5e3036F1B93)</strike> |
 |||| <strike>[0x4E6dDB0A2F44273863Fb36F05501223A53989DA9](https://explorer.testnet.cloudwalk.io/address/0x4E6dDB0A2F44273863Fb36F05501223A53989DA9)</strike> |
@@ -34,7 +35,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A](https://explorer.testnet.cloudwalk.io/address/0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xd1476a75a3F4e700AEbcB8804d0A74A8bAcc303c](https://explorer.testnet.cloudwalk.io/address/0xd1476a75a3F4e700AEbcB8804d0A74A8bAcc303c) |
-| 3 | PixCashier | Proxy implementation | [0xc0e7D7F54072F7c61924063e8198039Ec98b838c](https://explorer.testnet.cloudwalk.io/address/0xc0e7D7F54072F7c61924063e8198039Ec98b838c) |
+| 3 | PixCashier | Proxy implementation | [0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8](https://explorer.testnet.cloudwalk.io/address/0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8) |
+|||| <strike>[0xc0e7D7F54072F7c61924063e8198039Ec98b838c](https://explorer.testnet.cloudwalk.io/address/0xc0e7D7F54072F7c61924063e8198039Ec98b838c)</strike> |
 
 # CardPaymentProcessor (BRLC)
 

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -15,7 +15,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A](https://explorer.testnet.cloudwalk.io/address/0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x3181Ab023a4D4788754258BE5A3b8cf3D8276B98](https://explorer.testnet.cloudwalk.io/address/0x3181Ab023a4D4788754258BE5A3b8cf3D8276B98) |
-| 3 | PixCashier | Proxy implementation | [0x34c8BB4119cCA33399B2022acd9d4a2968723C31](https://explorer.testnet.cloudwalk.io/address/0x34c8BB4119cCA33399B2022acd9d4a2968723C31) |
+| 3 | PixCashier | Proxy implementation | [0x1497D1a06f6449108a40fB8C4A67eF6eDE13EbBd](https://explorer.testnet.cloudwalk.io/address/0x1497D1a06f6449108a40fB8C4A67eF6eDE13EbBd) |
+|||| <strike>[0x34c8BB4119cCA33399B2022acd9d4a2968723C31](https://explorer.testnet.cloudwalk.io/address/0x34c8BB4119cCA33399B2022acd9d4a2968723C31)</strike> |
 |||| <strike>[0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8](https://explorer.testnet.cloudwalk.io/address/0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8)</strike> |
 |||| <strike>[0xc0e7D7F54072F7c61924063e8198039Ec98b838c](https://explorer.testnet.cloudwalk.io/address/0xc0e7D7F54072F7c61924063e8198039Ec98b838c)</strike> |
 |||| <strike>[0x85Ec19fDfcf32E2733339FB27e55146f7e539dDd](https://explorer.testnet.cloudwalk.io/address/0x85Ec19fDfcf32E2733339FB27e55146f7e539dDd)</strike> |
@@ -36,7 +37,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A](https://explorer.testnet.cloudwalk.io/address/0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xd1476a75a3F4e700AEbcB8804d0A74A8bAcc303c](https://explorer.testnet.cloudwalk.io/address/0xd1476a75a3F4e700AEbcB8804d0A74A8bAcc303c) |
-| 3 | PixCashier | Proxy implementation | [0x34c8BB4119cCA33399B2022acd9d4a2968723C31](https://explorer.testnet.cloudwalk.io/address/0x34c8BB4119cCA33399B2022acd9d4a2968723C31) |
+| 3 | PixCashier | Proxy implementation | [0x1497D1a06f6449108a40fB8C4A67eF6eDE13EbBd](https://explorer.testnet.cloudwalk.io/address/0x1497D1a06f6449108a40fB8C4A67eF6eDE13EbBd) |
+|||| <strike>[0x34c8BB4119cCA33399B2022acd9d4a2968723C31](https://explorer.testnet.cloudwalk.io/address/0x34c8BB4119cCA33399B2022acd9d4a2968723C31)</strike> |
 |||| <strike>[0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8](https://explorer.testnet.cloudwalk.io/address/0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8)</strike> |
 |||| <strike>[0xc0e7D7F54072F7c61924063e8198039Ec98b838c](https://explorer.testnet.cloudwalk.io/address/0xc0e7D7F54072F7c61924063e8198039Ec98b838c)</strike> |
 

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -15,7 +15,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A](https://explorer.testnet.cloudwalk.io/address/0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x3181Ab023a4D4788754258BE5A3b8cf3D8276B98](https://explorer.testnet.cloudwalk.io/address/0x3181Ab023a4D4788754258BE5A3b8cf3D8276B98) |
-| 3 | PixCashier | Proxy implementation | [0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8](https://explorer.testnet.cloudwalk.io/address/0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8) |
+| 3 | PixCashier | Proxy implementation | [0x34c8BB4119cCA33399B2022acd9d4a2968723C31](https://explorer.testnet.cloudwalk.io/address/0x34c8BB4119cCA33399B2022acd9d4a2968723C31) |
+|||| <strike>[0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8](https://explorer.testnet.cloudwalk.io/address/0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8)</strike> |
 |||| <strike>[0xc0e7D7F54072F7c61924063e8198039Ec98b838c](https://explorer.testnet.cloudwalk.io/address/0xc0e7D7F54072F7c61924063e8198039Ec98b838c)</strike> |
 |||| <strike>[0x85Ec19fDfcf32E2733339FB27e55146f7e539dDd](https://explorer.testnet.cloudwalk.io/address/0x85Ec19fDfcf32E2733339FB27e55146f7e539dDd)</strike> |
 |||| <strike>[0x29bda6192283E3FB70f8B507877BC5e3036F1B93](https://explorer.testnet.cloudwalk.io/address/0x29bda6192283E3FB70f8B507877BC5e3036F1B93)</strike> |
@@ -35,7 +36,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A](https://explorer.testnet.cloudwalk.io/address/0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xd1476a75a3F4e700AEbcB8804d0A74A8bAcc303c](https://explorer.testnet.cloudwalk.io/address/0xd1476a75a3F4e700AEbcB8804d0A74A8bAcc303c) |
-| 3 | PixCashier | Proxy implementation | [0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8](https://explorer.testnet.cloudwalk.io/address/0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8) |
+| 3 | PixCashier | Proxy implementation | [0x34c8BB4119cCA33399B2022acd9d4a2968723C31](https://explorer.testnet.cloudwalk.io/address/0x34c8BB4119cCA33399B2022acd9d4a2968723C31) |
+|||| <strike>[0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8](https://explorer.testnet.cloudwalk.io/address/0x8474a120b9e253D0E03DAd5F7B8c7f6b803217F8)</strike> |
 |||| <strike>[0xc0e7D7F54072F7c61924063e8198039Ec98b838c](https://explorer.testnet.cloudwalk.io/address/0xc0e7D7F54072F7c61924063e8198039Ec98b838c)</strike> |
 
 # CardPaymentProcessor (BRLC)

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -511,6 +511,7 @@ describe("Contract 'PixCashier'", async () => {
         "CashInBatch"
       ).withArgs(
         BATCH_ID_STUB1,
+        TRANSACTIONS_ARRAY,
         expectedExecutionResults
       );
       await expect(tx).to.emit(

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -12,6 +12,11 @@ enum CashInStatus {
   Executed = 1,
 }
 
+enum CashInBatchStatus {
+  Nonexistent = 0,
+  Executed = 1,
+}
+
 enum CashOutStatus {
   Nonexistent = 0,
   Pending = 1,
@@ -24,6 +29,11 @@ interface TestCashIn {
   amount: number;
   txId: string;
   status: CashInStatus;
+}
+
+interface TestCashInBatch {
+  batchId: string;
+  status: CashInBatchStatus;
 }
 
 interface TestCashOut {
@@ -109,13 +119,25 @@ function checkCashInEquality(
   }
 }
 
+function checkCashInBatchEquality(
+  actualOnChainCashInBatch: any,
+  expectedCashInBatch: TestCashInBatch,
+  cashInBatchIndex: number
+) {
+  expect(actualOnChainCashInBatch.status).to.equal(
+    expectedCashInBatch.status,
+    `cashInBatches[${cashInBatchIndex}].status is incorrect`
+  );
+}
+
 describe("Contract 'PixCashier'", async () => {
   const TRANSACTION_ID1 = ethers.utils.formatBytes32String("MOCK_TRANSACTION_ID1");
   const TRANSACTION_ID2 = ethers.utils.formatBytes32String("MOCK_TRANSACTION_ID2");
   const TRANSACTION_ID3 = ethers.utils.formatBytes32String("MOCK_TRANSACTION_ID3");
   const TRANSACTIONS_ARRAY: string[] = [TRANSACTION_ID1, TRANSACTION_ID2, TRANSACTION_ID3];
   const TOKEN_AMOUNTS: number[] = [100, 200, 300];
-  const BATCH_ID_STUB = ethers.utils.formatBytes32String("MOCK_BATCH_ID");
+  const BATCH_ID_STUB1 = ethers.utils.formatBytes32String("MOCK_BATCH_ID1");
+  const BATCH_ID_STUB2 = ethers.utils.formatBytes32String("MOCK_BATCH_ID2");
   const BATCH_ID_ZERO = ethers.constants.HashZero;
 
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
@@ -240,6 +262,17 @@ describe("Contract 'PixCashier'", async () => {
       const actualCashIn: any = await pixCashier.getCashIn(cashIn.txId);
       checkCashInEquality(actualCashIn, cashIn, i);
       checkCashInEquality(actualCashIns[i], cashIn, i);
+    }
+  }
+
+  async function checkCashInBatchStructuresOnBlockchain(cashInBatches: TestCashInBatch[]) {
+    const batchIds: string[] = cashInBatches.map(cashInBatch => cashInBatch.batchId);
+    const actualCashInBatches: any[] = await pixCashier.getCashInBatches(batchIds);
+    for (let i = 0; i < cashInBatches.length; ++i) {
+      const cashInBatch: TestCashInBatch = cashInBatches[i];
+      const actualCashInBatch: any = await pixCashier.getCashInBatch(cashInBatch.batchId);
+      checkCashInBatchEquality(actualCashInBatch, cashInBatch, i);
+      checkCashInBatchEquality(actualCashInBatches[i], cashInBatch, i);
     }
   }
 
@@ -454,7 +487,7 @@ describe("Contract 'PixCashier'", async () => {
 
     it("Executes as expected", async () => {
       const tx: TransactionResponse =
-        await pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB);
+        await pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1);
       await expect(tx).to.changeTokenBalances(
         tokenMock,
         [user, secondUser, thirdUser, pixCashier],
@@ -463,7 +496,7 @@ describe("Contract 'PixCashier'", async () => {
       await expect(tx).to.emit(
         pixCashier,
         "CashInBatch"
-      ).withArgs(BATCH_ID_STUB);
+      ).withArgs(BATCH_ID_STUB1);
       await expect(tx).to.emit(
         pixCashier,
         "CashIn"
@@ -489,7 +522,13 @@ describe("Contract 'PixCashier'", async () => {
         expectedCashIns[2].txId
       );
 
+      const expectedCashInBatches: TestCashInBatch[] = [
+        { batchId: BATCH_ID_STUB1, status: CashInBatchStatus.Executed },
+        { batchId: BATCH_ID_STUB2, status: CashInBatchStatus.Nonexistent },
+      ];
+
       await checkCashInStructuresOnBlockchain(expectedCashIns);
+      await checkCashInBatchStructuresOnBlockchain(expectedCashInBatches);
     });
 
     it("Is reverted if the contract is paused", async () => {
@@ -497,20 +536,20 @@ describe("Contract 'PixCashier'", async () => {
       await proveTx(pixCashier.pause());
       const users = [user.address, secondUser.address, thirdUser.address];
       await expect(
-        pixCashier.connect(cashier).cashInBatch(users, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB)
+        pixCashier.connect(cashier).cashInBatch(users, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
     it("Is reverted if the caller does not have the cashier role", async () => {
       await expect(
-        pixCashier.connect(deployer).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB)
+        pixCashier.connect(deployer).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
     });
 
     it("Is reverted if one of the account addresses is zero", async () => {
       const zeroAccountArray = [user.address, ethers.constants.AddressZero, user.address];
       await expect(
-        pixCashier.connect(cashier).cashInBatch(zeroAccountArray, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB)
+        pixCashier.connect(cashier).cashInBatch(zeroAccountArray, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_ZERO);
     });
 
@@ -518,21 +557,21 @@ describe("Contract 'PixCashier'", async () => {
       await proveTx(pixCashier.grantRole(blacklisterRole, deployer.address));
       await proveTx(pixCashier.blacklist(secondUser.address));
       await expect(
-        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB)
+        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
     });
 
     it("Is reverted if one of the token amounts is zero", async () => {
       const zeroAmountArray = [100, 200, 0];
       await expect(
-        pixCashier.connect(cashier).cashInBatch(userAddresses, zeroAmountArray, TRANSACTIONS_ARRAY, BATCH_ID_STUB)
+        pixCashier.connect(cashier).cashInBatch(userAddresses, zeroAmountArray, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_AMOUNT_IS_ZERO);
     });
 
     it("Is reverted if one of the off-chain transaction IDs is zero", async () => {
       const zeroTransactionIdArray = [TRANSACTION_ID1, ethers.constants.HashZero, TRANSACTION_ID3];
       await expect(
-        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, zeroTransactionIdArray, BATCH_ID_STUB)
+        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, zeroTransactionIdArray, BATCH_ID_STUB1)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TRANSACTION_ID_IS_ZERO);
     });
 
@@ -540,7 +579,7 @@ describe("Contract 'PixCashier'", async () => {
       const noUsers: string[] = [];
 
       await expect(
-        pixCashier.connect(cashier).cashInBatch(noUsers, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB)
+        pixCashier.connect(cashier).cashInBatch(noUsers, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_INVALID_BATCH_ARRAYS);
     });
 
@@ -550,22 +589,22 @@ describe("Contract 'PixCashier'", async () => {
       const moreTransactions = [TRANSACTION_ID1, TRANSACTION_ID2, TRANSACTION_ID3, TRANSACTION_ID1];
 
       await expect(
-        pixCashier.connect(cashier).cashInBatch(moreUsers, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB)
+        pixCashier.connect(cashier).cashInBatch(moreUsers, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_INVALID_BATCH_ARRAYS);
 
       await expect(
-        pixCashier.connect(cashier).cashInBatch(userAddresses, moreAmounts, TRANSACTIONS_ARRAY, BATCH_ID_STUB)
+        pixCashier.connect(cashier).cashInBatch(userAddresses, moreAmounts, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_INVALID_BATCH_ARRAYS);
 
       await expect(
-        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, moreTransactions, BATCH_ID_STUB)
+        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, moreTransactions, BATCH_ID_STUB1)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_INVALID_BATCH_ARRAYS);
     });
 
     it("Is reverted if minting function returns 'false'", async () => {
       await proveTx(tokenMock.setMintResult(false));
       await expect(
-        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB)
+        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       ).to.be.revertedWithCustomError(pixCashier, REVERT_ERROR_IF_TOKEN_MINTING_FAILURE);
     });
 
@@ -573,7 +612,7 @@ describe("Contract 'PixCashier'", async () => {
       const lastTxId: string = TRANSACTIONS_ARRAY.slice(-1)[0];
       await proveTx(pixCashier.connect(cashier).cashIn(deployer.address, 1, lastTxId));
       await expect(
-        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB)
+        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       ).to.be.revertedWithCustomError(
         pixCashier,
         REVERT_ERROR_IF_CASH_IN_ALREADY_EXECUTED
@@ -591,14 +630,14 @@ describe("Contract 'PixCashier'", async () => {
 
     it("Is reverted if a cash-in batch with the provided ID is already executed", async () => {
       await proveTx(
-        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB)
+        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       );
       await expect(
-        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB)
+        pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       ).to.be.revertedWithCustomError(
         pixCashier,
         REVERT_ERROR_IF_CASH_IN_BATCH_ALREADY_EXECUTED
-      ).withArgs(BATCH_ID_STUB);
+      ).withArgs(BATCH_ID_STUB1);
     });
   });
 


### PR DESCRIPTION
closes cloudwalk/product-blockchain/issues/134

### Main changes
1.  The `batchId` parameter has been appended to the function for executing batch cash-in operations. The new function definition:
    ```solidity
    function cashInBatch(
        address[] memory accounts,
        uint256[] memory amounts,
        bytes32[] memory txIds,
        bytes32 batchId
    ) external whenNotPaused onlyRole(CASHIER_ROLE) {}
    ```
2. Now, the `cashInBatch()` function along with the `CashIn` events for each cash-in operation in the batch emits a new `CashInBatch` event corresponding the batch operation as a whole. The definition of the new event:
    ```solidity
    /**
     * @dev Possible result statuses of a cash-in operation as an enum.
     *
     * The possible values:
     * - Success --------- The operation was executed successfully.
     * - AlreadyExecuted - The operation was already executed.
     */
    enum CashInExecutionResult {
        Success,        // 0
        AlreadyExecuted // 1
    }
    
    /// @dev Emitted when a new batch of cash-in operations is executed.
    event CashInBatch(
        bytes32 indexed batchId,                 // The off-chain batch identifier.
        bytes32[] txIds,                         // The array of off-chain identifiers for each operation in the batch.
        CashInExecutionResult[] executionResults // The array of execution results for each operation in the batch.
    );
    ```
    The new event can be listened to on the backend side and when it occurs, the hash of the corresponding transaction can be determined. Then all individual `CashIn` events related to the batch operation can be matched with it using the obtained transaction hash.
    The `executionResults` array of the new event can be used to define skipped cash-in operations that have been already executed before the batch is submitted.

3. The `cashInBatch()` function is not reverted if some of the individual cash-in operations that form the batch are already executed. Already executed operations will be skipped and got the appropriate status in the `executionResults` array of the `CashInBatch` event.

4. The following additional requirements for the `cashInBatch()` function have been added:
    * The provided `batchId` must not be zero
    * The cash-in batch operation with the provided `batchId` must not be already executed.

5. To store the state of cash-in batch operations a new enumeration and structure have been introduced:
    ```solidity
    enum CashInBatchStatus {
        Nonexistent, // 0
        Executed     // 1
    }
    
    /// @dev Structure with data of a batch cash-in operation.
    struct CashInBatchOperation {
        CashInBatchStatus status;  // The status of the cash-in batch operation according to the {CashInBatchStatus}.
    }
    ```

6.  To check the state of a single batch operation the following function have been added:
    ```solidity
    function getCashInBatch(bytes32 batchId) external view returns (CashInBatchOperation memory){}
    ```
7.  To check the state of multiple batch operations the following function have been added:
    ```solidity
    function getCashInBatches(
        bytes32[] memory batchIds
    ) external view returns (CashInBatchOperation[] memory cashInBatches) {}
    ```

*Note:* Related changes in the token contract to provide minting for blocked accounts are described [in this PR](https://github.com/cloudwalk/brlc-token/pull/48).


### Test coverage

| Folder or File                              | % Stmts | % Branch | % Funcs | % Lines |
|:--------------------------------------------|--------:|---------:|--------:|--------:|
| contracts/                                  |  100.00 |    98.33 |  100.00 |  100.00 |
| &nbsp;&nbsp;CardPaymentProcessor.sol        |  100.00 |    99.28 |  100.00 |  100.00 |
| &nbsp;&nbsp;CardPaymentProcessorStorage.sol |  100.00 |   100.00 |  100.00 |  100.00 |
| &nbsp;&nbsp;CashbackDistributor.sol         |  100.00 |    97.62 |  100.00 |  100.00 |
| &nbsp;&nbsp;CashbackDistributorStorage.sol  |  100.00 |   100.00 |  100.00 |  100.00 |
| &nbsp;&nbsp;PixCashier.sol                  |  100.00 |    97.96 |  100.00 |  100.00 |
| &nbsp;&nbsp;PixCashierStorage.sol           |  100.00 |   100.00 |  100.00 |  100.00 |
| &nbsp;&nbsp;TokenDistributor.sol            |  100.00 |       90 |  100.00 |  100.00 |
| contracts/interfaces/                       |  100.00 |   100.00 |  100.00 |  100.00 |
| contracts/mocks/                            |  100.00 |   100.00 |  100.00 |  100.00 |
| contracts/mocks/tokens/                     |  100.00 |       50 |  100.00 |  100.00 |
| ------------------------------------------- | ------- | -------- | ------- | ------- |
| All files                                   |  100.00 |    98.16 |  100.00 |  100.00 |
