### PR TITLE
Increase cashback ahead any other token transfers during payment updating operations in the CardPaymentProcessor (CPP) smart-contract. Add data about recent contract upgrades

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -13171,6 +13171,406 @@
           }
         }
       }
+    },
+    "a64ebbd1a65ebfe5b9b9dd988ff111a7c1940f6f78128e278b4fb556ec098b57": {
+      "address": "0x2F0C21388a7a6C616654135721c76413d7163bfF",
+      "txHash": "0x199f7e3b4ac968b3cb9c3ca7237e654b411761bf0fed02ad6826638cad47de08",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)469_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:21"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:139"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\PausableExtUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\RescuableUpgradeable.sol:71"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_token",
+            "offset": 0,
+            "slot": "551",
+            "type": "t_address",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:13"
+          },
+          {
+            "label": "_totalClearedBalance",
+            "offset": 0,
+            "slot": "552",
+            "type": "t_uint256",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:16"
+          },
+          {
+            "label": "_totalUnclearedBalance",
+            "offset": 0,
+            "slot": "553",
+            "type": "t_uint256",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:19"
+          },
+          {
+            "label": "_payments",
+            "offset": 0,
+            "slot": "554",
+            "type": "t_mapping(t_bytes16,t_struct(Payment)10537_storage)",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:22"
+          },
+          {
+            "label": "_unclearedBalances",
+            "offset": 0,
+            "slot": "555",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:25"
+          },
+          {
+            "label": "_clearedBalances",
+            "offset": 0,
+            "slot": "556",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:28"
+          },
+          {
+            "label": "_paymentRevocationFlags",
+            "offset": 0,
+            "slot": "557",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:31"
+          },
+          {
+            "label": "_paymentReversionFlags",
+            "offset": 0,
+            "slot": "558",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:34"
+          },
+          {
+            "label": "_revocationLimit",
+            "offset": 0,
+            "slot": "559",
+            "type": "t_uint8",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:37"
+          },
+          {
+            "label": "_cashOutAccount",
+            "offset": 1,
+            "slot": "559",
+            "type": "t_address",
+            "contract": "CardPaymentProcessorStorageV2",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:45"
+          },
+          {
+            "label": "_cashbackEnabled",
+            "offset": 21,
+            "slot": "559",
+            "type": "t_bool",
+            "contract": "CardPaymentProcessorStorageV3",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:53"
+          },
+          {
+            "label": "_cashbackDistributor",
+            "offset": 0,
+            "slot": "560",
+            "type": "t_address",
+            "contract": "CardPaymentProcessorStorageV3",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:56"
+          },
+          {
+            "label": "_cashbackRateInPermil",
+            "offset": 20,
+            "slot": "560",
+            "type": "t_uint16",
+            "contract": "CardPaymentProcessorStorageV3",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:59"
+          },
+          {
+            "label": "_cashbacks",
+            "offset": 0,
+            "slot": "561",
+            "type": "t_mapping(t_bytes16,t_struct(Cashback)10376_storage)",
+            "contract": "CardPaymentProcessorStorageV3",
+            "src": "contracts\\CardPaymentProcessorStorage.sol:62"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes16": {
+            "label": "bytes16",
+            "numberOfBytes": "16"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(PaymentStatus)10512": {
+            "label": "enum ICardPaymentProcessorTypes.PaymentStatus",
+            "members": [
+              "Nonexistent",
+              "Uncleared",
+              "Cleared",
+              "Revoked",
+              "Reversed",
+              "Confirmed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes16,t_struct(Cashback)10376_storage)": {
+            "label": "mapping(bytes16 => struct ICardPaymentCashbackTypes.Cashback)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes16,t_struct(Payment)10537_storage)": {
+            "label": "mapping(bytes16 => struct ICardPaymentProcessorTypes.Payment)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)469_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Cashback)10376_storage": {
+            "label": "struct ICardPaymentCashbackTypes.Cashback",
+            "members": [
+              {
+                "label": "lastCashbackNonce",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Payment)10537_storage": {
+            "label": "struct ICardPaymentProcessorTypes.Payment",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "baseAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(PaymentStatus)10512",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "revocationCounter",
+                "type": "t_uint8",
+                "offset": 1,
+                "slot": "2"
+              },
+              {
+                "label": "compensationAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "refundAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "cashbackRate",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "extraAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "sponsor",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "subsidyLimit",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              }
+            ],
+            "numberOfBytes": "288"
+          },
+          "t_struct(RoleData)469_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -10861,6 +10861,406 @@
           }
         }
       }
+    },
+    "a64ebbd1a65ebfe5b9b9dd988ff111a7c1940f6f78128e278b4fb556ec098b57": {
+      "address": "0x0697A9427F2f289D8230F98005F97106ECB43737",
+      "txHash": "0x8c9e21cf3d0d7727011e5c78c22b56272475e5ff97bd1b620da5a9a1ab91c161",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)469_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc/brlc-contracts/contracts/access-control/BlacklistableUpgradeable.sol:21"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc/brlc-contracts/contracts/access-control/BlacklistableUpgradeable.sol:139"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "@cloudwalkinc/brlc-contracts/contracts/access-control/PausableExtUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "@cloudwalkinc/brlc-contracts/contracts/access-control/RescuableUpgradeable.sol:71"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc/brlc-contracts/contracts/storage/StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_token",
+            "offset": 0,
+            "slot": "551",
+            "type": "t_address",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts/CardPaymentProcessorStorage.sol:13"
+          },
+          {
+            "label": "_totalClearedBalance",
+            "offset": 0,
+            "slot": "552",
+            "type": "t_uint256",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts/CardPaymentProcessorStorage.sol:16"
+          },
+          {
+            "label": "_totalUnclearedBalance",
+            "offset": 0,
+            "slot": "553",
+            "type": "t_uint256",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts/CardPaymentProcessorStorage.sol:19"
+          },
+          {
+            "label": "_payments",
+            "offset": 0,
+            "slot": "554",
+            "type": "t_mapping(t_bytes16,t_struct(Payment)10537_storage)",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts/CardPaymentProcessorStorage.sol:22"
+          },
+          {
+            "label": "_unclearedBalances",
+            "offset": 0,
+            "slot": "555",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts/CardPaymentProcessorStorage.sol:25"
+          },
+          {
+            "label": "_clearedBalances",
+            "offset": 0,
+            "slot": "556",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts/CardPaymentProcessorStorage.sol:28"
+          },
+          {
+            "label": "_paymentRevocationFlags",
+            "offset": 0,
+            "slot": "557",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts/CardPaymentProcessorStorage.sol:31"
+          },
+          {
+            "label": "_paymentReversionFlags",
+            "offset": 0,
+            "slot": "558",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts/CardPaymentProcessorStorage.sol:34"
+          },
+          {
+            "label": "_revocationLimit",
+            "offset": 0,
+            "slot": "559",
+            "type": "t_uint8",
+            "contract": "CardPaymentProcessorStorageV1",
+            "src": "contracts/CardPaymentProcessorStorage.sol:37"
+          },
+          {
+            "label": "_cashOutAccount",
+            "offset": 1,
+            "slot": "559",
+            "type": "t_address",
+            "contract": "CardPaymentProcessorStorageV2",
+            "src": "contracts/CardPaymentProcessorStorage.sol:45"
+          },
+          {
+            "label": "_cashbackEnabled",
+            "offset": 21,
+            "slot": "559",
+            "type": "t_bool",
+            "contract": "CardPaymentProcessorStorageV3",
+            "src": "contracts/CardPaymentProcessorStorage.sol:53"
+          },
+          {
+            "label": "_cashbackDistributor",
+            "offset": 0,
+            "slot": "560",
+            "type": "t_address",
+            "contract": "CardPaymentProcessorStorageV3",
+            "src": "contracts/CardPaymentProcessorStorage.sol:56"
+          },
+          {
+            "label": "_cashbackRateInPermil",
+            "offset": 20,
+            "slot": "560",
+            "type": "t_uint16",
+            "contract": "CardPaymentProcessorStorageV3",
+            "src": "contracts/CardPaymentProcessorStorage.sol:59"
+          },
+          {
+            "label": "_cashbacks",
+            "offset": 0,
+            "slot": "561",
+            "type": "t_mapping(t_bytes16,t_struct(Cashback)10376_storage)",
+            "contract": "CardPaymentProcessorStorageV3",
+            "src": "contracts/CardPaymentProcessorStorage.sol:62"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes16": {
+            "label": "bytes16",
+            "numberOfBytes": "16"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(PaymentStatus)10512": {
+            "label": "enum ICardPaymentProcessorTypes.PaymentStatus",
+            "members": [
+              "Nonexistent",
+              "Uncleared",
+              "Cleared",
+              "Revoked",
+              "Reversed",
+              "Confirmed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes16,t_struct(Cashback)10376_storage)": {
+            "label": "mapping(bytes16 => struct ICardPaymentCashbackTypes.Cashback)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes16,t_struct(Payment)10537_storage)": {
+            "label": "mapping(bytes16 => struct ICardPaymentProcessorTypes.Payment)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)469_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Cashback)10376_storage": {
+            "label": "struct ICardPaymentCashbackTypes.Cashback",
+            "members": [
+              {
+                "label": "lastCashbackNonce",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Payment)10537_storage": {
+            "label": "struct ICardPaymentProcessorTypes.Payment",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "baseAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(PaymentStatus)10512",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "revocationCounter",
+                "type": "t_uint8",
+                "offset": 1,
+                "slot": "2"
+              },
+              {
+                "label": "compensationAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "refundAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "cashbackRate",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "extraAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "sponsor",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "subsidyLimit",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              }
+            ],
+            "numberOfBytes": "288"
+          },
+          "t_struct(RoleData)469_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -10503,6 +10503,364 @@
           }
         }
       }
+    },
+    "e563e80b94285180065008693efe5ee9eb1a26a99628011f044a1b7fcc410f0c": {
+      "address": "0x1Fc18Da129de1cf54422C6C10a3b518cE3Cd1Fb7",
+      "txHash": "0x057227f67735d8bc26675f19cb7dc9f2533288b6fc8bb1ae9b4212a4b0754784",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)469_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:21"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:139"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\PausableExtUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\RescuableUpgradeable.sol:71"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_enabled",
+            "offset": 0,
+            "slot": "551",
+            "type": "t_bool",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:13"
+          },
+          {
+            "label": "_nextNonce",
+            "offset": 0,
+            "slot": "552",
+            "type": "t_uint256",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:16"
+          },
+          {
+            "label": "_cashbacks",
+            "offset": 0,
+            "slot": "553",
+            "type": "t_mapping(t_uint256,t_struct(Cashback)11071_storage)",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:19"
+          },
+          {
+            "label": "_nonceCollectionByExternalId",
+            "offset": 0,
+            "slot": "554",
+            "type": "t_mapping(t_bytes32,t_array(t_uint256)dyn_storage)",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:22"
+          },
+          {
+            "label": "_totalAmountByExternalId",
+            "offset": 0,
+            "slot": "555",
+            "type": "t_mapping(t_bytes32,t_uint256)",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:25"
+          },
+          {
+            "label": "_totalAmountByRecipient",
+            "offset": 0,
+            "slot": "556",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:28"
+          },
+          {
+            "label": "_totalCashbackByTokenAndExternalId",
+            "offset": 0,
+            "slot": "557",
+            "type": "t_mapping(t_address,t_mapping(t_bytes32,t_uint256))",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:31"
+          },
+          {
+            "label": "_totalCashbackByTokenAndRecipient",
+            "offset": 0,
+            "slot": "558",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "CashbackDistributorStorageV1",
+            "src": "contracts\\CashbackDistributorStorage.sol:34"
+          },
+          {
+            "label": "_cashbackLastTimeReset",
+            "offset": 0,
+            "slot": "559",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "CashbackDistributorStorageV2",
+            "src": "contracts\\CashbackDistributorStorage.sol:45"
+          },
+          {
+            "label": "_cashbackSinceLastReset",
+            "offset": 0,
+            "slot": "560",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "CashbackDistributorStorageV2",
+            "src": "contracts\\CashbackDistributorStorage.sol:47"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(CashbackKind)11027": {
+            "label": "enum ICashbackDistributorTypes.CashbackKind",
+            "members": [
+              "Manual",
+              "CardPayment"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashbackStatus)11036": {
+            "label": "enum ICashbackDistributorTypes.CashbackStatus",
+            "members": [
+              "Nonexistent",
+              "Success",
+              "Blacklisted",
+              "OutOfFunds",
+              "Disabled",
+              "Revoked",
+              "Capped",
+              "Partial"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_uint256))": {
+            "label": "mapping(address => mapping(bytes32 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_array(t_uint256)dyn_storage)": {
+            "label": "mapping(bytes32 => uint256[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)469_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Cashback)11071_storage)": {
+            "label": "mapping(uint256 => struct ICashbackDistributorTypes.Cashback)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Cashback)11071_storage": {
+            "label": "struct ICashbackDistributorTypes.Cashback",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "kind",
+                "type": "t_enum(CashbackKind)11027",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(CashbackStatus)11036",
+                "offset": 21,
+                "slot": "0"
+              },
+              {
+                "label": "externalId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "recipient",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "sender",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "revokedAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              }
+            ],
+            "numberOfBytes": "192"
+          },
+          "t_struct(RoleData)469_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -1021,6 +1021,13 @@ contract CardPaymentProcessor is
                 bytes("")
             );
         }
+
+        // Increase cashback ahead any other token transfers to avoid conner cases with lack of customer balance
+        if (!operation.cashbackDecreased) {
+            uint256 cashbackIncreaseAmount = increaseCashbackInternal(authorizationId, operation.cashbackAmountChange);
+            payment.compensationAmount = operation.oldCompensationAmount + cashbackIncreaseAmount;
+        }
+
         updateExtraAmountInternal(
             authorizationId,
             correlationId,
@@ -1048,9 +1055,6 @@ contract CardPaymentProcessor is
         if (operation.cashbackDecreased) {
             revokeCashbackInternal(authorizationId, operation.cashbackAmountChange);
             payment.compensationAmount = operation.oldCompensationAmount - operation.cashbackAmountChange;
-        } else {
-            uint256 cashbackIncreaseAmount = increaseCashbackInternal(authorizationId, operation.cashbackAmountChange);
-            payment.compensationAmount = operation.oldCompensationAmount + cashbackIncreaseAmount;
         }
     }
 

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -6,6 +6,7 @@
 | 1 | ProxyAdmin | Proxy admin | [0x71Bb3b173De088f34609e33A4B3E39EE8dd57A95](https://explorer.mainnet.cloudwalk.io/address/0x71Bb3b173De088f34609e33A4B3E39EE8dd57A95) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x1F94A163C329bEc14C73Ca46c66150E3c47dbEDC](https://explorer.mainnet.cloudwalk.io/address/0x1F94A163C329bEc14C73Ca46c66150E3c47dbEDC) |
 | 3 | PixCashier | Proxy implementation | [0x49E61dd2Bb79E9993CcB5Abb7f936f8c6D97df1c](https://explorer.mainnet.cloudwalk.io/address/0x49E61dd2Bb79E9993CcB5Abb7f936f8c6D97df1c) |
+|||| <strike>[0xaA886ADfa5809B17FAb19331B07e4F90f51ebD44](https://explorer.mainnet.cloudwalk.io/address/0xaA886ADfa5809B17FAb19331B07e4F90f51ebD44)</strike> |
 |||| <strike>[0x5A987e235D225Ab15bf0daeFC7f82a56FBDD9870](https://explorer.mainnet.cloudwalk.io/address/0x5A987e235D225Ab15bf0daeFC7f82a56FBDD9870)</strike> |
 |||| <strike>[0x01F8907E37AE91A6Ecd264A409ca6DEDcEF692Bc](https://explorer.mainnet.cloudwalk.io/address/0x01F8907E37AE91A6Ecd264A409ca6DEDcEF692Bc)</strike> |
 |||| <strike>[0x8B69294E72b0f026f1E4176d92F667dd6f0AAa06](https://explorer.mainnet.cloudwalk.io/address/0x8B69294E72b0f026f1E4176d92F667dd6f0AAa06)</strike> |
@@ -32,6 +33,7 @@
 | 1 | ProxyAdmin | Proxy admin | [0x71Bb3b173De088f34609e33A4B3E39EE8dd57A95](https://explorer.mainnet.cloudwalk.io/address/0x71Bb3b173De088f34609e33A4B3E39EE8dd57A95) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xB2aEa43F8aEfc78A2eb558118F8A606d6d9073D8](https://explorer.mainnet.cloudwalk.io/address/0xB2aEa43F8aEfc78A2eb558118F8A606d6d9073D8) |
 | 3 | PixCashier | Proxy implementation | [0x49E61dd2Bb79E9993CcB5Abb7f936f8c6D97df1c](https://explorer.mainnet.cloudwalk.io/address/0x49E61dd2Bb79E9993CcB5Abb7f936f8c6D97df1c) |
+|||| <strike>[0xaA886ADfa5809B17FAb19331B07e4F90f51ebD44](https://explorer.mainnet.cloudwalk.io/address/0xaA886ADfa5809B17FAb19331B07e4F90f51ebD44)</strike> |
 |||| <strike>[0x5A987e235D225Ab15bf0daeFC7f82a56FBDD9870](https://explorer.mainnet.cloudwalk.io/address/0x5A987e235D225Ab15bf0daeFC7f82a56FBDD9870)</strike> |
 
 ### CloudWalk (Testnet)
@@ -51,7 +53,9 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0x71Bb3b173De088f34609e33A4B3E39EE8dd57A95](https://explorer.mainnet.cloudwalk.io/address/0x71Bb3b173De088f34609e33A4B3E39EE8dd57A95) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xc10dB4941fB486b2d88839775802FA03BAc6dE31](https://explorer.mainnet.cloudwalk.io/address/0xc10dB4941fB486b2d88839775802FA03BAc6dE31) |
-| 3 | CardPaymentProcessor | Proxy implementation | [0x1487c7A58a889f4aE5F47231c5e65308ebF67f36](https://explorer.mainnet.cloudwalk.io/address/0x1487c7A58a889f4aE5F47231c5e65308ebF67f36) |
+| 3 | CardPaymentProcessor | Proxy implementation | [0x0697a9427f2f289d8230f98005f97106ecb43737](https://explorer.mainnet.cloudwalk.io/address/0x0697a9427f2f289d8230f98005f97106ecb43737) |
+|||| <strike>[0x4dfbb30dE477FC97546c551fBfa1c3898b594Ef0](https://explorer.mainnet.cloudwalk.io/address/0x4dfbb30dE477FC97546c551fBfa1c3898b594Ef0)</strike> |
+|||| <strike>[0x1487c7A58a889f4aE5F47231c5e65308ebF67f36](https://explorer.mainnet.cloudwalk.io/address/0x1487c7A58a889f4aE5F47231c5e65308ebF67f36)</strike> |
 |||| <strike>[0x4FD4eD690f886555838C6ff7817569228666b37c](https://explorer.mainnet.cloudwalk.io/address/0x4FD4eD690f886555838C6ff7817569228666b37c)</strike> |
 |||| <strike>[0x94468CED5411D9394dea234F27E1ff82B6Be7c67](https://explorer.mainnet.cloudwalk.io/address/0x94468CED5411D9394dea234F27E1ff82B6Be7c67)</strike> |
 |||| <strike>[0x1462E6237E7eF6668E544B4368199A71832Dbb53](https://explorer.mainnet.cloudwalk.io/address/0x1462E6237E7eF6668E544B4368199A71832Dbb53)</strike> |
@@ -69,7 +73,9 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A](https://explorer.testnet.cloudwalk.io/address/0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xe938b69d9AFA593FFE55CF01738AbfD62466DEa7](https://explorer.testnet.cloudwalk.io/address/0xe938b69d9AFA593FFE55CF01738AbfD62466DEa7) |
-| 3 | CardPaymentProcessor | Proxy implementation | [0xd539c1683D5115EdC40a4ecD8E65DFaB0b3E8110](https://explorer.testnet.cloudwalk.io/address/0xd539c1683D5115EdC40a4ecD8E65DFaB0b3E8110) |
+| 3 | CardPaymentProcessor | Proxy implementation | [0x2F0C21388a7a6C616654135721c76413d7163bfF](https://explorer.testnet.cloudwalk.io/address/0x2F0C21388a7a6C616654135721c76413d7163bfF) |
+|||| <strike>[0x4049059E17574C02Dc3dda68DeABC6a29C3d0470](https://explorer.testnet.cloudwalk.io/address/0x4049059E17574C02Dc3dda68DeABC6a29C3d0470)</strike> |
+|||| <strike>[0xd539c1683D5115EdC40a4ecD8E65DFaB0b3E8110](https://explorer.testnet.cloudwalk.io/address/0xd539c1683D5115EdC40a4ecD8E65DFaB0b3E8110)</strike> |
 |||| <strike>[0x1A17724b8B14cf35024Ab7EC7aaaaAE0a70FA004](https://explorer.testnet.cloudwalk.io/address/0x1A17724b8B14cf35024Ab7EC7aaaaAE0a70FA004)</strike> |
 |||| <strike>[0x7097c58298baF94b8bC0724FeF217b73ee2CAD01](https://explorer.testnet.cloudwalk.io/address/0x7097c58298baF94b8bC0724FeF217b73ee2CAD01)</strike> |
 |||| <strike>[0x6E8b29d87692a965fb62c527523a3f690b06e4D5](https://explorer.testnet.cloudwalk.io/address/0x6E8b29d87692a965fb62c527523a3f690b06e4D5)</strike> |
@@ -93,7 +99,9 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0x71Bb3b173De088f34609e33A4B3E39EE8dd57A95](https://explorer.mainnet.cloudwalk.io/address/0x71Bb3b173De088f34609e33A4B3E39EE8dd57A95) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x06aAAACCE7E224b402E749135C1dF616435BBb9E](https://explorer.mainnet.cloudwalk.io/address/0x06aAAACCE7E224b402E749135C1dF616435BBb9E) |
-| 3 | CardPaymentProcessor | Proxy implementation | [0x1487c7A58a889f4aE5F47231c5e65308ebF67f36](https://explorer.mainnet.cloudwalk.io/address/0x1487c7A58a889f4aE5F47231c5e65308ebF67f36) |
+| 3 | CardPaymentProcessor | Proxy implementation | [0x0697a9427f2f289d8230f98005f97106ecb43737](https://explorer.mainnet.cloudwalk.io/address/0x0697a9427f2f289d8230f98005f97106ecb43737) |
+|||| <strike>[0x4dfbb30dE477FC97546c551fBfa1c3898b594Ef0](https://explorer.mainnet.cloudwalk.io/address/0x4dfbb30dE477FC97546c551fBfa1c3898b594Ef0)</strike> |
+|||| <strike>[0x1487c7A58a889f4aE5F47231c5e65308ebF67f36](https://explorer.mainnet.cloudwalk.io/address/0x1487c7A58a889f4aE5F47231c5e65308ebF67f36)</strike> |
 |||| <strike>[0x4FD4eD690f886555838C6ff7817569228666b37c](https://explorer.mainnet.cloudwalk.io/address/0x4FD4eD690f886555838C6ff7817569228666b37c)</strike> |
 
 ### CloudWalk (Testnet)
@@ -101,7 +109,9 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A](https://explorer.testnet.cloudwalk.io/address/0xDb25bd42B55468B6CeF2097C65cE7AcF4f8aaE8A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x160e794bAd1503968D316A8300D2a4E8F435Bf3e](https://explorer.testnet.cloudwalk.io/address/0x160e794bAd1503968D316A8300D2a4E8F435Bf3e) |
-| 3 | CardPaymentProcessor | Proxy implementation | [0xd539c1683D5115EdC40a4ecD8E65DFaB0b3E8110](https://explorer.testnet.cloudwalk.io/address/0xd539c1683D5115EdC40a4ecD8E65DFaB0b3E8110) |
+| 3 | CardPaymentProcessor | Proxy implementation | [0x2F0C21388a7a6C616654135721c76413d7163bfF](https://explorer.testnet.cloudwalk.io/address/0x2F0C21388a7a6C616654135721c76413d7163bfF) |
+|||| <strike>[0x4049059E17574C02Dc3dda68DeABC6a29C3d0470](https://explorer.testnet.cloudwalk.io/address/0x4049059E17574C02Dc3dda68DeABC6a29C3d0470)</strike> |
+|||| <strike>[0xd539c1683D5115EdC40a4ecD8E65DFaB0b3E8110](https://explorer.testnet.cloudwalk.io/address/0xd539c1683D5115EdC40a4ecD8E65DFaB0b3E8110)</strike> |
 |||| <strike>[0x1A17724b8B14cf35024Ab7EC7aaaaAE0a70FA004](https://explorer.testnet.cloudwalk.io/address/0x1A17724b8B14cf35024Ab7EC7aaaaAE0a70FA004)</strike> |
 
 # CashbackDistributor (BRLC)
@@ -111,7 +121,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0x71Bb3b173De088f34609e33A4B3E39EE8dd57A95](https://explorer.mainnet.cloudwalk.io/address/0x71Bb3b173De088f34609e33A4B3E39EE8dd57A95) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xE3845d98DFb62172B0C8E49BfCc3290890e40a05](https://explorer.mainnet.cloudwalk.io/address/0xE3845d98DFb62172B0C8E49BfCc3290890e40a05) |
-| 3 | CashbackDistributor | Proxy implementation | [0x333FcF25979CE31F7ff4Da54d20fAB6D79B6AA20](https://explorer.mainnet.cloudwalk.io/address/0x333FcF25979CE31F7ff4Da54d20fAB6D79B6AA20) |
+| 3 | CashbackDistributor | Proxy implementation | [0x1Fc18Da129de1cf54422C6C10a3b518cE3Cd1Fb7](https://explorer.mainnet.cloudwalk.io/address/0x1Fc18Da129de1cf54422C6C10a3b518cE3Cd1Fb7) |
+|||| <strike>[0x333FcF25979CE31F7ff4Da54d20fAB6D79B6AA20](https://explorer.mainnet.cloudwalk.io/address/0x333FcF25979CE31F7ff4Da54d20fAB6D79B6AA20)</strike> |
 |||| <strike>[0x9Cd0528914fA328A977f24238B94730650eD8707](https://explorer.mainnet.cloudwalk.io/address/0x9Cd0528914fA328A977f24238B94730650eD8707)</strike> |
 |||| <strike>[0x5e56fa08AD3EDA581CbA31f28c495C990Eadc019](https://explorer.mainnet.cloudwalk.io/address/0x5e56fa08AD3EDA581CbA31f28c495C990Eadc019)</strike> |
 |||| <strike>[0x87C747e61FdD1991CAFD0e0fC834B17B28640f5e](https://explorer.mainnet.cloudwalk.io/address/0x87C747e61FdD1991CAFD0e0fC834B17B28640f5e)</strike> |


### PR DESCRIPTION
### Main changes
Previously cashback changes happen after any other token transfers during payment updating operations of CPP.
Now if cashback is increased it happens prior any other token transfers during an update.
It is needed to avoid rare corner cases related to lack of customer's balance for a payment updating operation.

### Auxiliary changes
The data about recent contract upgrades in our mainnet and testnet has also been changed in this PR. The data includes new implementation addresses and changed `.openzeppelin` files.

### Test coverage

| Folder or File                              | % Stmts | % Branch | % Funcs | % Lines |
|:--------------------------------------------|--------:|---------:|--------:|--------:|
| contracts/                                  |  100.00 |    98.34 |  100.00 |  100.00 |
| &nbsp;&nbsp;CardPaymentProcessor.sol        |  100.00 |    99.28 |  100.00 |  100.00 |
| &nbsp;&nbsp;CardPaymentProcessorStorage.sol |  100.00 |   100.00 |  100.00 |  100.00 |
| &nbsp;&nbsp;CashbackDistributor.sol         |  100.00 |    97.67 |  100.00 |  100.00 |
| &nbsp;&nbsp;CashbackDistributorStorage.sol  |  100.00 |   100.00 |  100.00 |  100.00 |
| &nbsp;&nbsp;PixCashier.sol                  |  100.00 |    97.96 |  100.00 |  100.00 |
| &nbsp;&nbsp;PixCashierStorage.sol           |  100.00 |   100.00 |  100.00 |  100.00 |
| &nbsp;&nbsp;TokenDistributor.sol            |  100.00 |       90 |  100.00 |  100.00 |
| contracts/interfaces/                       |  100.00 |   100.00 |  100.00 |  100.00 |
| contracts/mocks/                            |  100.00 |   100.00 |  100.00 |  100.00 |
| contracts/mocks/tokens/                     |  100.00 |       50 |  100.00 |  100.00 |
| ------------------------------------------- | ------- | -------- | ------- | ------- |
| All files                                   |  100.00 |    98.18 |  100.00 |  100.00 |
