### PR TITLE
Override AccessControlUpgradeable contract

### DIFF
--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -163,6 +163,7 @@ contract CardPaymentProcessor is
         __Context_init_unchained();
         __ERC165_init_unchained();
         __AccessControl_init_unchained();
+        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
         __Blacklistable_init_unchained(OWNER_ROLE);
         __Pausable_init_unchained();
         __PausableExt_init_unchained(OWNER_ROLE);

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -163,7 +163,7 @@ contract CardPaymentProcessor is
         __Context_init_unchained();
         __ERC165_init_unchained();
         __AccessControl_init_unchained();
-        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
+        __AccessControlExt_init_unchained();
         __Blacklistable_init_unchained(OWNER_ROLE);
         __Pausable_init_unchained();
         __PausableExt_init_unchained(OWNER_ROLE);

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -4,12 +4,12 @@ pragma solidity 0.8.16;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
-import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 
 import { BlacklistableUpgradeable } from "./base/BlacklistableUpgradeable.sol";
 import { PausableExtUpgradeable } from "./base/PausableExtUpgradeable.sol";
 import { RescuableUpgradeable } from "./base/RescuableUpgradeable.sol";
 import { StoragePlaceholder200 } from "./base/StoragePlaceholder200.sol";
+import { AccessControlExtUpgradeable } from "./base/AccessControlExtUpgradeable.sol";
 
 import { CardPaymentProcessorStorage } from "./CardPaymentProcessorStorage.sol";
 import { ICardPaymentProcessor } from "./interfaces/ICardPaymentProcessor.sol";
@@ -21,7 +21,7 @@ import { ICashbackDistributor, ICashbackDistributorTypes } from "./interfaces/IC
  * @dev Wrapper contract for the card payment operations.
  */
 contract CardPaymentProcessor is
-    AccessControlUpgradeable,
+    AccessControlExtUpgradeable,
     BlacklistableUpgradeable,
     PausableExtUpgradeable,
     RescuableUpgradeable,

--- a/contracts/CashbackDistributor.sol
+++ b/contracts/CashbackDistributor.sol
@@ -79,6 +79,7 @@ contract CashbackDistributor is
         __Context_init_unchained();
         __ERC165_init_unchained();
         __AccessControl_init_unchained();
+        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
         __Blacklistable_init_unchained(OWNER_ROLE);
         __Pausable_init_unchained();
         __PausableExt_init_unchained(OWNER_ROLE);

--- a/contracts/CashbackDistributor.sol
+++ b/contracts/CashbackDistributor.sol
@@ -5,12 +5,12 @@ pragma solidity 0.8.16;
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { EnumerableSetUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/structs/EnumerableSetUpgradeable.sol";
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
-import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 
 import { BlacklistableUpgradeable } from "./base/BlacklistableUpgradeable.sol";
 import { PausableExtUpgradeable } from "./base/PausableExtUpgradeable.sol";
 import { RescuableUpgradeable } from "./base/RescuableUpgradeable.sol";
 import { StoragePlaceholder200 } from "./base/StoragePlaceholder200.sol";
+import { AccessControlExtUpgradeable } from "./base/AccessControlExtUpgradeable.sol";
 
 import { CashbackDistributorStorage } from "./CashbackDistributorStorage.sol";
 import { ICashbackDistributor } from "./interfaces/ICashbackDistributor.sol";
@@ -20,7 +20,7 @@ import { ICashbackDistributor } from "./interfaces/ICashbackDistributor.sol";
  * @dev Wrapper contract for the cashback operations.
  */
 contract CashbackDistributor is
-    AccessControlUpgradeable,
+    AccessControlExtUpgradeable,
     BlacklistableUpgradeable,
     PausableExtUpgradeable,
     RescuableUpgradeable,

--- a/contracts/CashbackDistributor.sol
+++ b/contracts/CashbackDistributor.sol
@@ -79,7 +79,7 @@ contract CashbackDistributor is
         __Context_init_unchained();
         __ERC165_init_unchained();
         __AccessControl_init_unchained();
-        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
+        __AccessControlExt_init_unchained();
         __Blacklistable_init_unchained(OWNER_ROLE);
         __Pausable_init_unchained();
         __PausableExt_init_unchained(OWNER_ROLE);

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -113,6 +113,7 @@ contract PixCashier is
         __Context_init_unchained();
         __ERC165_init_unchained();
         __AccessControl_init_unchained();
+        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
         __Blacklistable_init_unchained(OWNER_ROLE);
         __Pausable_init_unchained();
         __PausableExt_init_unchained(OWNER_ROLE);

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -5,12 +5,12 @@ pragma solidity 0.8.16;
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import { EnumerableSetUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/structs/EnumerableSetUpgradeable.sol";
-import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 
 import { BlacklistableUpgradeable } from "./base/BlacklistableUpgradeable.sol";
 import { PausableExtUpgradeable } from "./base/PausableExtUpgradeable.sol";
 import { RescuableUpgradeable } from "./base/RescuableUpgradeable.sol";
 import { StoragePlaceholder200 } from "./base/StoragePlaceholder200.sol";
+import { AccessControlExtUpgradeable } from "./base/AccessControlExtUpgradeable.sol";
 
 import { PixCashierStorage } from "./PixCashierStorage.sol";
 import { IPixCashier } from "./interfaces/IPixCashier.sol";
@@ -24,7 +24,7 @@ import { IERC20Mintable } from "./interfaces/IERC20Mintable.sol";
  * About roles see https://docs.openzeppelin.com/contracts/4.x/api/access#AccessControl.
  */
 contract PixCashier is
-    AccessControlUpgradeable,
+    AccessControlExtUpgradeable,
     BlacklistableUpgradeable,
     PausableExtUpgradeable,
     RescuableUpgradeable,

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -113,7 +113,7 @@ contract PixCashier is
         __Context_init_unchained();
         __ERC165_init_unchained();
         __AccessControl_init_unchained();
-        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
+        __AccessControlExt_init_unchained();
         __Blacklistable_init_unchained(OWNER_ROLE);
         __Pausable_init_unchained();
         __PausableExt_init_unchained(OWNER_ROLE);

--- a/contracts/TokenDistributor.sol
+++ b/contracts/TokenDistributor.sol
@@ -63,6 +63,7 @@ contract TokenDistributor is
 
     function __TokenDistributor_init() internal onlyInitializing {
         __AccessControl_init_unchained();
+        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
         __Context_init_unchained();
         __ERC165_init_unchained();
         __Pausable_init_unchained();

--- a/contracts/TokenDistributor.sol
+++ b/contracts/TokenDistributor.sol
@@ -4,11 +4,11 @@ pragma solidity 0.8.16;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
-import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 
 import { PausableExtUpgradeable } from "./base/PausableExtUpgradeable.sol";
 import { RescuableUpgradeable } from "./base/RescuableUpgradeable.sol";
 import { StoragePlaceholder200 } from "./base/StoragePlaceholder200.sol";
+import { AccessControlExtUpgradeable } from "./base/AccessControlExtUpgradeable.sol";
 
 import { ITokenDistributor } from "./interfaces/ITokenDistributor.sol";
 
@@ -20,7 +20,7 @@ import { ITokenDistributor } from "./interfaces/ITokenDistributor.sol";
  * About roles see https://docs.openzeppelin.com/contracts/4.x/api/access#AccessControl.
  */
 contract TokenDistributor is
-    AccessControlUpgradeable,
+    AccessControlExtUpgradeable,
     PausableExtUpgradeable,
     RescuableUpgradeable,
     StoragePlaceholder200,

--- a/contracts/TokenDistributor.sol
+++ b/contracts/TokenDistributor.sol
@@ -63,7 +63,7 @@ contract TokenDistributor is
 
     function __TokenDistributor_init() internal onlyInitializing {
         __AccessControl_init_unchained();
-        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
+        __AccessControlExt_init_unchained();
         __Context_init_unchained();
         __ERC165_init_unchained();
         __Pausable_init_unchained();

--- a/contracts/base/AccessControlExtUpgradeable.sol
+++ b/contracts/base/AccessControlExtUpgradeable.sol
@@ -32,7 +32,6 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
      *
      * See {AccessControlExtUpgradeable-__AccessControlExt_init}.
      */
-    // EZ Prettier (`npm run prettier`) told me this formatting
     function __AccessControlExt_init_unchained() internal onlyInitializing {}
 
     /**
@@ -48,7 +47,6 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
      * May emit a {RoleGranted} event for each account.
      */
     function grantRoleBatch(bytes32 role, address[] memory accounts) public virtual onlyRole(getRoleAdmin(role)) {
-        // EZ Prettier (`npm run prettier`) told me this formatting
         for (uint i = 0; i < accounts.length; i++) {
             _grantRole(role, accounts[i]);
         }
@@ -66,17 +64,8 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
      * May emit a {RoleRevoked} event for each account.
      */
     function revokeRoleBatch(bytes32 role, address[] memory accounts) public virtual onlyRole(getRoleAdmin(role)) {
-        // EZ Prettier (`npm run prettier`) told me this formatting
         for (uint i = 0; i < accounts.length; i++) {
             _revokeRole(role, accounts[i]);
         }
     }
-
-    /**
-     * @dev This empty reserved space is put in place to allow future versions to add new
-     * variables without shifting down storage in the inheritance chain.
-     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-     */
-    // EZ It is wrong because adds 49 more storage slots.
-    //uint256[49] private __gap;
 }

--- a/contracts/base/AccessControlExtUpgradeable.sol
+++ b/contracts/base/AccessControlExtUpgradeable.sol
@@ -14,7 +14,6 @@ import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/ac
  * that is allowed to grant and revoke roles in batch.
  */
 abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
-
     /**
      * @dev The internal initializer of the upgradable contract.
      *
@@ -33,8 +32,8 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
      *
      * See {AccessControlExtUpgradeable-__AccessControlExt_init}.
      */
-    function __AccessControlExt_init_unchained() internal onlyInitializing {
-    }
+    // EZ Prettier (`npm run prettier`) told me this formatting
+    function __AccessControlExt_init_unchained() internal onlyInitializing {}
 
     /**
      * @dev Grants `role` to `account` in batch.
@@ -49,7 +48,8 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
      * May emit a {RoleGranted} event for each account.
      */
     function grantRoleBatch(bytes32 role, address[] memory accounts) public virtual onlyRole(getRoleAdmin(role)) {
-        for (uint i = 0; i < accounts.length ; i++) {
+        // EZ Prettier (`npm run prettier`) told me this formatting
+        for (uint i = 0; i < accounts.length; i++) {
             _grantRole(role, accounts[i]);
         }
     }
@@ -66,7 +66,8 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
      * May emit a {RoleRevoked} event for each account.
      */
     function revokeRoleBatch(bytes32 role, address[] memory accounts) public virtual onlyRole(getRoleAdmin(role)) {
-        for (uint i = 0; i < accounts.length ; i++) {
+        // EZ Prettier (`npm run prettier`) told me this formatting
+        for (uint i = 0; i < accounts.length; i++) {
             _revokeRole(role, accounts[i]);
         }
     }
@@ -76,5 +77,6 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[49] private __gap;
+    // EZ It is wrong because adds 49 more storage slots.
+    //uint256[49] private __gap;
 }

--- a/contracts/base/AccessControlExtUpgradeable.sol
+++ b/contracts/base/AccessControlExtUpgradeable.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+/**
+ * @title AccessControlExtUpgradeable base contract
+ * @author CloudWalk Inc.
+ * @dev Extends the OpenZeppelin's {AccessControlUpgradeable} contract by adding the `grantRoleBatch` and
+ * `revokeRoleBatch` function.
+ *
+ * This contract is used through inheritance. It introduces the `grantRoleBatch` and `revokeRoleBatch` functions
+ * that is allowed to grant and revoke roles in batch.
+ */
+abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
+
+    /**
+     * @dev The internal initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function __AccessControlExt_init() internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __AccessControl_init_unchained();
+
+        __AccessControlExt_init_unchained();
+    }
+
+    /**
+     * @dev The unchained internal initializer of the upgradable contract.
+     *
+     * See {AccessControlExtUpgradeable-__AccessControlExt_init}.
+     */
+    function __AccessControlExt_init_unchained() internal onlyInitializing {
+    }
+
+    /**
+     * @dev Grants `role` to `account` in batch.
+     *
+     * If `accounts` had not been already granted `role`, emits a {RoleGranted}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     *
+     * May emit a {RoleGranted} event for each account.
+     */
+    function grantRoleBatch(bytes32 role, address[] memory accounts) public virtual onlyRole(getRoleAdmin(role)) {
+        for (uint i = 0; i < accounts.length ; i++) {
+            _grantRole(role, accounts[i]);
+        }
+    }
+
+    /**
+     * @dev Revokes `role` from `account` in batch.
+     *
+     * If `accounts` had been granted `role`, emits a {RoleRevoked} event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     *
+     * May emit a {RoleRevoked} event for each account.
+     */
+    function revokeRoleBatch(bytes32 role, address[] memory accounts) public virtual onlyRole(getRoleAdmin(role)) {
+        for (uint i = 0; i < accounts.length ; i++) {
+            _revokeRole(role, accounts[i]);
+        }
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[49] private __gap;
+}

--- a/contracts/base/BlacklistableUpgradeable.sol
+++ b/contracts/base/BlacklistableUpgradeable.sol
@@ -59,6 +59,7 @@ abstract contract BlacklistableUpgradeable is AccessControlExtUpgradeable {
         __Context_init_unchained();
         __ERC165_init_unchained();
         __AccessControl_init_unchained();
+        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
 
         __Blacklistable_init_unchained(blacklisterRoleAdmin);
     }

--- a/contracts/base/BlacklistableUpgradeable.sol
+++ b/contracts/base/BlacklistableUpgradeable.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { AccessControlExtUpgradeable } from "./AccessControlExtUpgradeable.sol";
 
 /**
  * @title BlacklistableUpgradeable base contract
@@ -12,7 +12,7 @@ import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/ac
  * This contract is used through inheritance. It makes available the modifier `notBlacklisted`,
  * which can be applied to functions to restrict their usage to not blacklisted accounts only.
  */
-abstract contract BlacklistableUpgradeable is AccessControlUpgradeable {
+abstract contract BlacklistableUpgradeable is AccessControlExtUpgradeable {
     /// @dev The role of the blacklister that is allowed to blacklist and unblacklist accounts.
     bytes32 public constant BLACKLISTER_ROLE = keccak256("BLACKLISTER_ROLE");
 

--- a/contracts/base/BlacklistableUpgradeable.sol
+++ b/contracts/base/BlacklistableUpgradeable.sol
@@ -59,7 +59,7 @@ abstract contract BlacklistableUpgradeable is AccessControlExtUpgradeable {
         __Context_init_unchained();
         __ERC165_init_unchained();
         __AccessControl_init_unchained();
-        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
+        __AccessControlExt_init_unchained();
 
         __Blacklistable_init_unchained(blacklisterRoleAdmin);
     }

--- a/contracts/base/PausableExtUpgradeable.sol
+++ b/contracts/base/PausableExtUpgradeable.sol
@@ -29,6 +29,7 @@ abstract contract PausableExtUpgradeable is AccessControlExtUpgradeable, Pausabl
         __Context_init_unchained();
         __ERC165_init_unchained();
         __AccessControl_init_unchained();
+        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
         __Pausable_init_unchained();
 
         __PausableExt_init_unchained(pauserRoleAdmin);

--- a/contracts/base/PausableExtUpgradeable.sol
+++ b/contracts/base/PausableExtUpgradeable.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.8;
 
-import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+
+import { AccessControlExtUpgradeable } from "./AccessControlExtUpgradeable.sol";
 
 /**
  * @title PausableExtUpgradeable base contract
@@ -13,7 +14,7 @@ import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/securit
  * This contract is used through inheritance. It introduces the {PAUSER_ROLE} role that is allowed to
  * trigger the paused or unpaused state of the contract that is inherited from this one.
  */
-abstract contract PausableExtUpgradeable is AccessControlUpgradeable, PausableUpgradeable {
+abstract contract PausableExtUpgradeable is AccessControlExtUpgradeable, PausableUpgradeable {
     /// @dev The role of pauser that is allowed to trigger the paused or unpaused state of the contract.
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 

--- a/contracts/base/PausableExtUpgradeable.sol
+++ b/contracts/base/PausableExtUpgradeable.sol
@@ -29,7 +29,7 @@ abstract contract PausableExtUpgradeable is AccessControlExtUpgradeable, Pausabl
         __Context_init_unchained();
         __ERC165_init_unchained();
         __AccessControl_init_unchained();
-        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
+        __AccessControlExt_init_unchained();
         __Pausable_init_unchained();
 
         __PausableExt_init_unchained(pauserRoleAdmin);

--- a/contracts/base/RescuableUpgradeable.sol
+++ b/contracts/base/RescuableUpgradeable.sol
@@ -32,6 +32,7 @@ abstract contract RescuableUpgradeable is AccessControlExtUpgradeable {
         __Context_init_unchained();
         __ERC165_init_unchained();
         __AccessControl_init_unchained();
+        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
 
         __Rescuable_init_unchained(rescuerRoleAdmin);
     }

--- a/contracts/base/RescuableUpgradeable.sol
+++ b/contracts/base/RescuableUpgradeable.sol
@@ -32,7 +32,7 @@ abstract contract RescuableUpgradeable is AccessControlExtUpgradeable {
         __Context_init_unchained();
         __ERC165_init_unchained();
         __AccessControl_init_unchained();
-        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
+        __AccessControlExt_init_unchained();
 
         __Rescuable_init_unchained(rescuerRoleAdmin);
     }

--- a/contracts/base/RescuableUpgradeable.sol
+++ b/contracts/base/RescuableUpgradeable.sol
@@ -4,7 +4,8 @@ pragma solidity ^0.8.8;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
-import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+import { AccessControlExtUpgradeable } from "./AccessControlExtUpgradeable.sol";
 
 /**
  * @title RescuableUpgradeable base contract
@@ -14,7 +15,7 @@ import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/ac
  * This contract is used through inheritance. It introduces the {RESCUER_ROLE} role that is allowed to
  * rescue tokens locked up in the contract that is inherited from this one.
  */
-abstract contract RescuableUpgradeable is AccessControlUpgradeable {
+abstract contract RescuableUpgradeable is AccessControlExtUpgradeable {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     /// @dev The role of rescuer that is allowed to rescue tokens locked up in the contract.

--- a/contracts/mocks/base/AccessControlExtUpgradeableMock.sol
+++ b/contracts/mocks/base/AccessControlExtUpgradeableMock.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { AccessControlExtUpgradeable } from "../../base/AccessControlExtUpgradeable.sol";
+
+/**
+ * @title AccessControlExtUpgradeableMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {AccessControlExtUpgradeable} contract for test purposes.
+ */
+contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable {
+    /// @dev The role of this contract owner.
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+    bytes32 public constant USER_ROLE = keccak256("USER_ROLE");
+
+    /**
+     * @dev The initialize function of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function initialize() public initializer {
+        _setupRole(OWNER_ROLE, _msgSender());
+        _setupRole(USER_ROLE, _msgSender());
+
+        __AccessControlExt_init();
+    }
+
+    function setUserRoleAdmin() public {
+        _setRoleAdmin(USER_ROLE, OWNER_ROLE);
+    }
+
+    /**
+     * @dev Needed to check that the initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize() public {
+        __AccessControlExt_init();
+    }
+
+    /**
+     * @dev Needed to check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize_unchained() public {
+        __AccessControlExt_init_unchained();
+    }
+}

--- a/contracts/mocks/base/AccessControlExtUpgradeableMock.sol
+++ b/contracts/mocks/base/AccessControlExtUpgradeableMock.sol
@@ -20,11 +20,9 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable {
      * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
      */
     function initialize() public initializer {
-        __AccessControlExt_init();
-        __AccessControlExt_init_unchained();
-
         _setupRole(OWNER_ROLE, _msgSender());
         _setRoleAdmin(USER_ROLE, OWNER_ROLE);
+        __AccessControlExt_init();
     }
 
     /**

--- a/contracts/mocks/base/AccessControlExtUpgradeableMock.sol
+++ b/contracts/mocks/base/AccessControlExtUpgradeableMock.sol
@@ -20,21 +20,12 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable {
      * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
      */
     function initialize() public initializer {
-        //EZ The configuration should be done only after initialization
-        //_setupRole(OWNER_ROLE, _msgSender());
-        //_setRoleAdmin(USER_ROLE, OWNER_ROLE);
-
         __AccessControlExt_init();
-        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
+        __AccessControlExt_init_unchained();
 
         _setupRole(OWNER_ROLE, _msgSender());
         _setRoleAdmin(USER_ROLE, OWNER_ROLE);
     }
-
-    // EZ It is redundant for testing and can be executed directly in the initialize function
-    //    function setUserRoleAdmin() public {
-    //        _setRoleAdmin(USER_ROLE, OWNER_ROLE);
-    //    }
 
     /**
      * @dev Needed to check that the initialize function of the ancestor contract

--- a/contracts/mocks/base/AccessControlExtUpgradeableMock.sol
+++ b/contracts/mocks/base/AccessControlExtUpgradeableMock.sol
@@ -20,15 +20,21 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable {
      * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
      */
     function initialize() public initializer {
-        _setupRole(OWNER_ROLE, _msgSender());
-        _setupRole(USER_ROLE, _msgSender());
+        //EZ The configuration should be done only after initialization
+        //_setupRole(OWNER_ROLE, _msgSender());
+        //_setRoleAdmin(USER_ROLE, OWNER_ROLE);
 
         __AccessControlExt_init();
-    }
+        __AccessControlExt_init_unchained(); // EZ we are following the existing logic of calling all unchained initializers
 
-    function setUserRoleAdmin() public {
+        _setupRole(OWNER_ROLE, _msgSender());
         _setRoleAdmin(USER_ROLE, OWNER_ROLE);
     }
+
+    // EZ It is redundant for testing and can be executed directly in the initialize function
+    //    function setUserRoleAdmin() public {
+    //        _setRoleAdmin(USER_ROLE, OWNER_ROLE);
+    //    }
 
     /**
      * @dev Needed to check that the initialize function of the ancestor contract

--- a/test/base/AccessControlExtUpgradeable.test.ts
+++ b/test/base/AccessControlExtUpgradeable.test.ts
@@ -1,0 +1,171 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../../test-utils/eth";
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contract 'AccessControlExtUpgradeable'", async () => {
+  const EVENT_NAME_ROLE_GRANTED = "RoleGranted";
+  const EVENT_NAME_ROLE_REVOKED = "RoleRevoked";
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+
+  const ownerRole: string = ethers.utils.id("OWNER_ROLE");
+  const userRole: string = ethers.utils.id("USER_ROLE");
+
+  let accessControlExtMockFactory: ContractFactory;
+  let deployer: SignerWithAddress;
+  let users: SignerWithAddress[];
+  let userAddresses: string[];
+
+  before(async () => {
+    accessControlExtMockFactory = await ethers.getContractFactory("AccessControlExtUpgradeableMock");
+    [deployer, ...users] = await ethers.getSigners();
+    userAddresses = [
+      users[0].address,
+      users[1].address,
+      users[2].address,
+      users[3].address
+    ];
+  });
+
+  async function deployAccessControlExtMock(): Promise<{ accessControlExtMock: Contract }> {
+    const accessControlExtMock: Contract = await upgrades.deployProxy(accessControlExtMockFactory);
+    await accessControlExtMock.deployed();
+    return { accessControlExtMock };
+  }
+
+  describe("Function 'initialize()'", async () => {
+    it("The external initializer configures the contract as expected", async () => {
+      const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
+
+      //The roles
+      expect((await accessControlExtMock.OWNER_ROLE()).toLowerCase()).to.equal(ownerRole);
+
+      // The role admins
+      expect(await accessControlExtMock.getRoleAdmin(ownerRole)).to.equal(ethers.constants.HashZero);
+
+      // The deployer should have the owner role, but not the other roles
+      expect(await accessControlExtMock.hasRole(ownerRole, deployer.address)).to.equal(true);
+    });
+
+    it("The external initializer is reverted if it is called a second time", async () => {
+      const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
+      await expect(
+        accessControlExtMock.initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("The internal initializer is reverted if it is called outside the init process", async () => {
+      const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
+      await expect(
+        accessControlExtMock.call_parent_initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+
+    it("The internal unchained initializer is reverted if it is called outside the init process", async () => {
+      const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
+      await expect(
+        accessControlExtMock.call_parent_initialize_unchained()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+  });
+
+  describe("Function 'grantRoleBatch()'", async () => {
+    it("The function 'grantRoleBatch' executes as expected with 1 user", async () => {
+      const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
+      await proveTx(accessControlExtMock.setUserRoleAdmin());
+
+      await expect(accessControlExtMock.grantRoleBatch(userRole, [userAddresses[0]]))
+        .to.emit(accessControlExtMock, EVENT_NAME_ROLE_GRANTED)
+        .withArgs(userRole, userAddresses[0], deployer.address);
+
+      expect(await accessControlExtMock.hasRole(userRole, userAddresses[0])).to.equal(true);
+    });
+
+    it("The function 'grantRoleBatch' executes as expected with multiple users", async () => {
+      const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
+      await proveTx(accessControlExtMock.setUserRoleAdmin());
+
+      await expect(accessControlExtMock.grantRoleBatch(userRole, userAddresses))
+        .to.emit(accessControlExtMock, EVENT_NAME_ROLE_GRANTED)
+        .withArgs(userRole, userAddresses[0], deployer.address)
+        .and.to.emit(accessControlExtMock, EVENT_NAME_ROLE_GRANTED)
+        .withArgs(userRole, userAddresses[1], deployer.address)
+        .and.to.emit(accessControlExtMock, EVENT_NAME_ROLE_GRANTED)
+        .withArgs(userRole, userAddresses[2], deployer.address)
+        .and.to.emit(accessControlExtMock, EVENT_NAME_ROLE_GRANTED)
+        .withArgs(userRole, userAddresses[3], deployer.address)
+      ;
+      for (let userAddress of userAddresses) {
+        expect(await accessControlExtMock.hasRole(userRole, userAddress)).to.equal(true);
+      }
+    });
+
+    it("The function 'grantRoleBatch' revert if user does not have rights", async () => {
+      const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
+      const REVERT_MESSAGE_IF_USER_DOES_NOT_HAVE_RIGHTS = `AccessControl: account ${userAddresses[0].toLowerCase()} is missing role ${ownerRole.toLowerCase()}`;
+      await proveTx(accessControlExtMock.setUserRoleAdmin());
+
+      await expect(
+        accessControlExtMock.connect(users[0]).grantRoleBatch(userRole, [])
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_USER_DOES_NOT_HAVE_RIGHTS);
+    });
+
+    it("The function 'revokeRoleBatch' executes as expected with 1 user", async () => {
+      const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
+      await proveTx(accessControlExtMock.setUserRoleAdmin());
+      await proveTx(accessControlExtMock.grantRoleBatch(userRole, [userAddresses[0]]));
+      await expect(accessControlExtMock.revokeRoleBatch(userRole, [
+        userAddresses[0]
+      ]))
+        .to.emit(accessControlExtMock, EVENT_NAME_ROLE_REVOKED)
+        .withArgs(userRole, userAddresses[0], deployer.address);
+
+      expect(await accessControlExtMock.hasRole(userRole, userAddresses[0])).to.equal(false);
+    });
+
+    it("The function 'revokeRoleBatch' executes as expected with multiple users", async () => {
+      const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
+      await proveTx(accessControlExtMock.setUserRoleAdmin());
+      await proveTx(accessControlExtMock.grantRoleBatch(userRole, userAddresses));
+      for (let userAddress of userAddresses) {
+        expect(await accessControlExtMock.hasRole(userRole, userAddress)).to.equal(true);
+      }
+      await expect(accessControlExtMock.revokeRoleBatch(userRole, userAddresses))
+        .to.emit(accessControlExtMock, EVENT_NAME_ROLE_REVOKED)
+        .withArgs(userRole, userAddresses[0], deployer.address)
+        .and.to.emit(accessControlExtMock, EVENT_NAME_ROLE_REVOKED)
+        .withArgs(userRole, userAddresses[1], deployer.address)
+        .and.to.emit(accessControlExtMock, EVENT_NAME_ROLE_REVOKED)
+        .withArgs(userRole, userAddresses[2], deployer.address)
+        .and.to.emit(accessControlExtMock, EVENT_NAME_ROLE_REVOKED)
+        .withArgs(userRole, userAddresses[3], deployer.address)
+      ;
+
+      for (let userAddress of userAddresses) {
+        expect(await accessControlExtMock.hasRole(userRole, userAddress)).to.equal(false);
+      }
+    });
+
+    it("The function 'revokeRoleBatch' revert if user does not have rights", async () => {
+      const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
+      const REVERT_MESSAGE_IF_USER_DOES_NOT_HAVE_RIGHTS = `AccessControl: account ${userAddresses[0].toLowerCase()} is missing role ${ownerRole.toLowerCase()}`;
+      await proveTx(accessControlExtMock.setUserRoleAdmin());
+      await proveTx(accessControlExtMock.grantRoleBatch(userRole, userAddresses));
+      await expect(
+        accessControlExtMock.connect(users[0]).revokeRoleBatch(userRole, userAddresses)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_USER_DOES_NOT_HAVE_RIGHTS);
+    });
+  });
+});

--- a/test/base/AccessControlExtUpgradeable.test.ts
+++ b/test/base/AccessControlExtUpgradeable.test.ts
@@ -27,14 +27,14 @@ describe("Contract 'AccessControlExtUpgradeable'", async () => {
 
   let accessControlExtMockFactory: ContractFactory;
   let deployer: SignerWithAddress;
-  let attacker: SignerWithAddress; // EZ Add more readability
+  let attacker: SignerWithAddress;
   let users: SignerWithAddress[];
   let userAddresses: string[];
 
   before(async () => {
     accessControlExtMockFactory = await ethers.getContractFactory("AccessControlExtUpgradeableMock");
     [deployer, attacker, ...users] = await ethers.getSigners();
-    // EZ 3 users is more than enough
+
     userAddresses = [
       users[0].address,
       users[1].address,
@@ -86,9 +86,7 @@ describe("Contract 'AccessControlExtUpgradeable'", async () => {
     });
   });
 
-  // EZ Split tests by the functions
   describe("Function 'grantRoleBatch()'", async () => {
-    // EZ Split tests by the checking way (positive and negative ones)
     describe("Executes as expected if the input account array contains", async () => {
       it("A single account without the previously granted role", async () => {
         const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
@@ -103,7 +101,6 @@ describe("Contract 'AccessControlExtUpgradeable'", async () => {
         expect(await accessControlExtMock.hasRole(userRole, userAddresses[0])).to.equal(true);
       });
 
-      // EZ We should test this too
       it("A single account with the previously granted role", async () => {
         const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
         await proveTx(accessControlExtMock.grantRoleBatch(userRole, [userAddresses[0]]));
@@ -131,7 +128,6 @@ describe("Contract 'AccessControlExtUpgradeable'", async () => {
         }
       });
 
-      // EZ Testing when the input array is empty
       it("No accounts", async () => {
         const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
 
@@ -151,9 +147,7 @@ describe("Contract 'AccessControlExtUpgradeable'", async () => {
       });
     });
 
-    // EZ Split tests by the functions
     describe("Function 'revokeRoleBatch()'", async () => {
-      // EZ Split tests by the checking way (positive and negative ones)
       describe("Executes as expected if the input account array contains", async () => {
         it("A single account with the previously granted role", async () => {
           const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
@@ -169,7 +163,6 @@ describe("Contract 'AccessControlExtUpgradeable'", async () => {
           expect(await accessControlExtMock.hasRole(userRole, userAddresses[0])).to.equal(false);
         });
 
-        // EZ We should test this too
         it("A single account without the previously granted role", async () => {
           const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
           expect(await accessControlExtMock.hasRole(userRole, userAddresses[0])).to.equal(false);
@@ -197,7 +190,6 @@ describe("Contract 'AccessControlExtUpgradeable'", async () => {
           }
         });
 
-        // EZ Testing when the input array is empty
         it("No accounts", async () => {
           const { accessControlExtMock } = await setUpFixture(deployAccessControlExtMock);
 


### PR DESCRIPTION
**Main Changes**

This pull request overrides `AccessControlUpgradeable` with `AccessControlExtUpgradeable` to add batch functions:
- `grantRoleBatch` - grants role to batch of accounts
- `revokeRoleBatch` - revokes role from batch from accounts

**Test coverage**

File                                  |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
--------------------------------------|----------|----------|----------|----------|----------------|
 contracts/                           |      100 |    98.34 |      100 |      100 |                |
&nbsp;&nbsp;  CardPaymentProcessor.sol            |      100 |    99.28 |      100 |      100 |                |
&nbsp;&nbsp;  CardPaymentProcessorStorage.sol     |      100 |      100 |      100 |      100 |                |
&nbsp;&nbsp;  CashbackDistributor.sol             |      100 |    97.67 |      100 |      100 |                |
&nbsp;&nbsp;  CashbackDistributorStorage.sol      |      100 |      100 |      100 |      100 |                |
&nbsp;&nbsp;  PixCashier.sol                      |      100 |    97.96 |      100 |      100 |                |
&nbsp;&nbsp;  PixCashierStorage.sol               |      100 |      100 |      100 |      100 |                |
&nbsp;&nbsp;  TokenDistributor.sol                |      100 |       90 |      100 |      100 |                |
 contracts/base/                      |      100 |      100 |      100 |      100 |                |
&nbsp;&nbsp;  AccessControlExtUpgradeable.sol     |      100 |      100 |      100 |      100 |                |
&nbsp;&nbsp;  BlacklistableUpgradeable.sol        |      100 |      100 |      100 |      100 |                |
&nbsp;&nbsp;  PausableExtUpgradeable.sol          |      100 |      100 |      100 |      100 |                |
&nbsp;&nbsp;  RescuableUpgradeable.sol            |      100 |      100 |      100 |      100 |                |
&nbsp;&nbsp;  StoragePlaceholder200.sol           |      100 |      100 |      100 |      100 |                |
 contracts/interfaces/                |      100 |      100 |      100 |      100 |                |
 contracts/mocks/                     |      100 |      100 |      100 |      100 |                |
 contracts/mocks/base/                |      100 |      100 |      100 |      100 |                |
 contracts/mocks/tokens/              |      100 |       50 |      100 |      100 |                |
--------------------------------------|----------|----------|----------|----------|----------------|
All files                             |      100 |    98.34 |      100 |      100 |                |
--------------------------------------|----------|----------|----------|----------|----------------|
