### PR TITLE
Minor changes in CPPv2

### DIFF
--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -39,18 +39,18 @@ contract CardPaymentProcessor is
     /// @dev The role of executor that is allowed to execute the card payment operations.
     bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
 
+    /// @dev The number of decimals that is used in the underlying token contract.
+    uint256 public constant TOKE_DECIMALS = 6;
+
     /**
      * @dev The factor to represent the cashback rates in the contract, e.g. number 15 means 1.5% cashback rate.
      *
-     * The formula to calculate cashback by an amount: `cashbackAmount = cashbackRate * amount / CASHBACK_FACTOR` .
+     * The formula to calculate cashback by an amount: `cashbackAmount = cashbackRate * amount / CASHBACK_FACTOR`.
      */
     uint256 public constant CASHBACK_FACTOR = 1000;
 
     /// @dev The maximum allowable cashback rate in units of `CASHBACK_FACTOR`.
     uint256 public constant MAX_CASHBACK_RATE = 250;
-
-    /// @dev The number of decimals that is used in the underlying token contract.
-    uint256 public constant TOKE_DECIMALS = 6;
 
     /**
      * @dev The coefficient used to round the cashback according to the formula:

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -49,19 +49,22 @@ contract CardPaymentProcessor is
     /// @dev The maximum allowable cashback rate in units of `CASHBACK_FACTOR`.
     uint256 public constant MAX_CASHBACK_RATE = 250;
 
+    /// @dev The number of decimals that is used in the underlying token contract.
+    uint256 public constant TOKE_DECIMALS = 6;
+
     /**
      * @dev The coefficient used to round the cashback according to the formula:
      *      `roundedCashback = ((cashback + coef / 2) / coef) * coef`.
      *
      * Currently, it can only be changed by deploying a new implementation of the contract.
      */
-    uint256 public constant CASHBACK_ROUNDING_COEF = 10000;
+    uint256 public constant CASHBACK_ROUNDING_COEF = 10 ** (TOKE_DECIMALS - 2);
 
     /// @dev The cashback cap reset period.
     uint256 public constant CASHBACK_CAP_RESET_PERIOD = 30 days;
 
     /// @dev The maximum cashback for a cap period.
-    uint256 public constant MAX_CASHBACK_FOR_CAP_PERIOD = 300 * 10 ** 6;
+    uint256 public constant MAX_CASHBACK_FOR_CAP_PERIOD = 300 * 10 ** TOKE_DECIMALS;
 
     /// @dev Event data flag mask defining whether the payment is sponsored.
     uint256 internal constant EVENT_FLAG_MASK_SPONSORED = 1;

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -149,6 +149,9 @@ contract CardPaymentProcessor is
     /// @dev Zero payment ID has been passed as a function argument.
     error PaymentZeroId();
 
+    /// @dev The sponsor address is zero while the subsidy limit is non-zero.
+    error SponsorZeroAddress();
+
     /// @dev The zero token address has been passed as a function argument.
     error TokenZeroAddress();
 
@@ -907,9 +910,10 @@ contract CardPaymentProcessor is
         if (sumAmount > type(uint64).max) {
             revert OverflowOfSumAmount();
         }
-        if (operation.sponsor == address(0)) {
-            operation.subsidyLimit = 0;
-        } else if (operation.subsidyLimit > type(uint64).max) {
+        if (operation.sponsor == address(0) && operation.subsidyLimit != 0) {
+            revert SponsorZeroAddress();
+        }
+        if (operation.subsidyLimit > type(uint64).max) {
             revert OverflowOfSubsidyLimit();
         }
         (uint256 payerSumAmount, uint256 sponsorSumAmount) = _defineSumAmountParts(sumAmount, operation.subsidyLimit);

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -31,7 +31,7 @@ contract CardPaymentProcessor is
 {
     using SafeERC20 for IERC20;
 
-    // -------------------- Constants --------------------------------
+    // ------------------ Constants ------------------------------- //
 
     /// @dev The role of this contract owner.
     bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
@@ -42,7 +42,7 @@ contract CardPaymentProcessor is
     /**
      * @dev The factor to represent the cashback rates in the contract, e.g. number 15 means 1.5% cashback rate.
      *
-     * The formula to calculate cashback by an amount: cashbackAmount = cashbackRate * amount / CASHBACK_FACTOR
+     * The formula to calculate cashback by an amount: `cashbackAmount = cashbackRate * amount / CASHBACK_FACTOR` .
      */
     uint256 public constant CASHBACK_FACTOR = 1000;
 
@@ -72,7 +72,7 @@ contract CardPaymentProcessor is
     /// @dev Default version of the event data.
     uint8 internal constant EVENT_DEFAULT_VERSION = 1;
 
-    // -------------------- Events -----------------------------------
+    // ------------------ Events ---------------------------------- //
 
     /// @dev Emitted when the cash-out account is changed.
     event CashOutAccountChanged(
@@ -80,7 +80,7 @@ contract CardPaymentProcessor is
         address newCashOutAccount
     );
 
-    // -------------------- Errors -----------------------------------
+    // ------------------ Errors ---------------------------------- //
 
     /// @dev The zero payer address has been passed as a function argument.
     error AccountZeroAddress();
@@ -158,7 +158,7 @@ contract CardPaymentProcessor is
     /// @dev The zero token address has been passed as a function argument.
     error TokenZeroAddress();
 
-    // -------------------- Initializers -----------------------------
+    // ------------------ Initializers ---------------------------- //
 
     /**
      * @dev The initializer of the upgradable contract.
@@ -212,7 +212,7 @@ contract CardPaymentProcessor is
         _grantRole(OWNER_ROLE, _msgSender());
     }
 
-    // -------------------- Functions --------------------------------
+    // ------------------ Functions ------------------------------- //
 
     /// @dev Contains parameters of a payment making operation.
     struct MakingOperation {
@@ -593,67 +593,51 @@ contract CardPaymentProcessor is
         emit CashbackDisabled();
     }
 
-    // -------------------- View functions ---------------------------
+    // ------------------ View functions -------------------------- //
 
-    /**
-     * @inheritdoc ICardPaymentProcessor
-     */
+    /// @inheritdoc ICardPaymentProcessor
     function cashOutAccount() external view returns (address) {
         return _cashOutAccount;
     }
 
-    /**
-     * @inheritdoc ICardPaymentProcessor
-     */
+    /// @inheritdoc ICardPaymentProcessor
     function token() external view returns (address) {
         return _token;
     }
 
-    /**
-     * @inheritdoc ICardPaymentProcessor
-     */
+    /// @inheritdoc ICardPaymentProcessor
     function getPayment(bytes32 paymentId) external view returns (Payment memory) {
         return _payments[paymentId];
     }
 
-    /**
-     * @inheritdoc ICardPaymentProcessor
-     */
+    /// @inheritdoc ICardPaymentProcessor
     function getPaymentStatistics() external view returns (PaymentStatistics memory) {
         return _paymentStatistics;
     }
 
-    /**
-     * @inheritdoc ICardPaymentCashback
-     */
+    /// @inheritdoc ICardPaymentCashback
     function cashbackTreasury() external view returns (address) {
         return _cashbackTreasury;
     }
 
-    /**
-     * @inheritdoc ICardPaymentCashback
-     */
+    /// @inheritdoc ICardPaymentCashback
     function cashbackEnabled() external view returns (bool) {
         return _cashbackEnabled;
     }
 
-    /**
-     * @inheritdoc ICardPaymentCashback
-     */
+    /// @inheritdoc ICardPaymentCashback
     function cashbackRate() external view returns (uint256) {
         return _cashbackRate;
     }
 
-    /**
-     * @inheritdoc ICardPaymentCashback
-     */
+    /// @inheritdoc ICardPaymentCashback
     function getAccountCashbackState(address account) external view returns (AccountCashbackState memory) {
         return _accountCashbackStates[account];
     }
 
-    // -------------------- Internal functions ---------------------------
+    // ------------------ Internal functions ---------------------- //
 
-    /// @dev Making a payment internally
+    /// @dev Making a payment internally.
     function _makePayment(MakingOperation memory operation) internal {
         if (operation.paymentId == 0) {
             revert PaymentZeroId();
@@ -693,13 +677,13 @@ contract CardPaymentProcessor is
         );
     }
 
-    /// @dev Kind of a payment updating operation
+    /// @dev Kind of a payment updating operation.
     enum UpdatingOperationKind {
         Full, // 0 The operation is executed fully regardless of the new values of the base amount and extra amount.
         Lazy  // 1 The operation is executed only if the new amounts differ from the current ones of the payment.
     }
 
-    /// @dev Updates the base amount and extra amount of a payment internally
+    /// @dev Updates the base amount and extra amount of a payment internally.
     function _updatePayment(
         bytes32 paymentId,
         uint256 newBaseAmount,
@@ -762,7 +746,7 @@ contract CardPaymentProcessor is
         );
     }
 
-    /// @dev Cancels a payment internally
+    /// @dev Cancels a payment internally.
     function _cancelPayment(
         bytes32 paymentId,
         PaymentStatus targetStatus
@@ -814,7 +798,7 @@ contract CardPaymentProcessor is
         }
     }
 
-    /// @dev Confirms a payment internally
+    /// @dev Confirms a payment internally.
     function _confirmPayment(
         bytes32 paymentId,
         uint256 confirmationAmount
@@ -848,7 +832,7 @@ contract CardPaymentProcessor is
         return confirmationAmount;
     }
 
-    /// @dev Confirms a payment internally with the token transfer to the cash-out account
+    /// @dev Confirms a payment internally with the token transfer to the cash-out account.
     function _confirmPaymentWithTransfer(
         bytes32 paymentId,
         uint256 confirmationAmount
@@ -860,7 +844,7 @@ contract CardPaymentProcessor is
         IERC20(_token).safeTransfer(_requireCashOutAccount(), confirmationAmount);
     }
 
-    /// @dev Makes a refund for a payment internally
+    /// @dev Makes a refund for a payment internally.
     function _refundPayment(
         bytes32 paymentId,
         uint256 refundingAmount
@@ -1032,6 +1016,7 @@ contract CardPaymentProcessor is
         }
     }
 
+    /// @dev Emits an appropriate event when the confirmed amount is changed for a payment.
     function _emitPaymentConfirmedAmountChanged(
         bytes32 paymentId,
         address payer,
@@ -1125,9 +1110,7 @@ contract CardPaymentProcessor is
         }
     }
 
-    /**
-     * @dev Updates the account cashback state and checks the cashback cap.
-     */
+    /// @dev Updates the account cashback state and checks the cashback cap.
     function _updateAccountCashbackState(
         address account,
         uint256 amount
@@ -1170,9 +1153,7 @@ contract CardPaymentProcessor is
         state.capPeriodStartTime = uint32(capPeriodStartTime);
     }
 
-    /**
-     * @dev Reduces the total cashback amount for an account.
-     */
+    /// @dev Reduces the total cashback amount for an account.
     function _reduceTotalCashback(address account, uint256 amount) internal {
         AccountCashbackState storage state = _accountCashbackStates[account];
         state.totalAmount = uint72(uint256(state.totalAmount) - amount);
@@ -1370,15 +1351,13 @@ contract CardPaymentProcessor is
         return eventFlags;
     }
 
-    /**
-     * @dev The upgrade authorization function for UUPSProxy.
-     */
+    /// @dev The upgrade authorization function for UUPSProxy.
     function _authorizeUpgrade(address newImplementation) internal view override {
         newImplementation; // Suppresses a compiler warning about the unused variable
         _checkRole(OWNER_ROLE);
     }
 
-    // -------------------- Service functions ------------------------
+    // ------------------ Service functions ----------------------- //
 
     /**
      * @dev The version of the standard upgrade function without the second parameter for backward compatibility.

--- a/contracts/CardPaymentProcessorStorage.sol
+++ b/contracts/CardPaymentProcessorStorage.sol
@@ -5,9 +5,7 @@ pragma solidity ^0.8.20;
 import { ICardPaymentProcessorTypes } from "./interfaces/ICardPaymentProcessor.sol";
 import { ICardPaymentCashbackTypes } from "./interfaces/ICardPaymentCashback.sol";
 
-/**
- * @title CardPaymentProcessor storage version 1
- */
+/// @title CardPaymentProcessor storage version 1
 abstract contract CardPaymentProcessorStorageV1 is ICardPaymentProcessorTypes, ICardPaymentCashbackTypes {
     /// @dev The address of the underlying token.
     address internal _token;

--- a/contracts/base/AccessControlExtUpgradeable.sol
+++ b/contracts/base/AccessControlExtUpgradeable.sol
@@ -14,7 +14,7 @@ import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/ac
  * that is allowed to grant and revoke roles in batch.
  */
 abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
-    // -------------------- Initializers -----------------------------
+    // ------------------ Initializers ---------------------------- //
 
     /**
      * @dev The internal initializer of the upgradable contract.
@@ -36,7 +36,7 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
      */
     function __AccessControlExt_init_unchained() internal onlyInitializing {}
 
-    // -------------------- Functions --------------------------------
+    // ------------------ Functions ------------------------------- //
 
     /**
      * @dev Grants `role` to `account` in batch.

--- a/contracts/base/BlocklistableUpgradeable.sol
+++ b/contracts/base/BlocklistableUpgradeable.sol
@@ -33,7 +33,7 @@ abstract contract BlocklistableUpgradeable is AccessControlExtUpgradeable {
         mapping(address => bool) blocklisted; // Mapping of presence in the blocklist for a given address.
     }
 
-    // -------------------- Events -----------------------------------
+    // ------------------ Events ---------------------------------- //
 
     /// @dev Emitted when an account is blocklisted.
     event Blocklisted(address indexed account);
@@ -44,12 +44,12 @@ abstract contract BlocklistableUpgradeable is AccessControlExtUpgradeable {
     /// @dev Emitted when an account is self blocklisted.
     event SelfBlocklisted(address indexed account);
 
-    // -------------------- Errors -----------------------------------
+    // ------------------ Errors ---------------------------------- //
 
     /// @dev The account is blocklisted.
     error BlocklistedAccount(address account);
 
-    // -------------------- Modifiers --------------------------------
+    // ------------------ Modifiers ------------------------------- //
 
     /**
      * @dev Throws if called by a blocklisted account.
@@ -62,7 +62,7 @@ abstract contract BlocklistableUpgradeable is AccessControlExtUpgradeable {
         _;
     }
 
-    // -------------------- Initializers -----------------------------
+    // ------------------ Initializers ---------------------------- //
 
     /**
      * @dev The internal initializer of the upgradable contract.
@@ -87,7 +87,7 @@ abstract contract BlocklistableUpgradeable is AccessControlExtUpgradeable {
         _setRoleAdmin(BLOCKLISTER_ROLE, blocklisterRoleAdmin);
     }
 
-    // -------------------- Functions --------------------------------
+    // ------------------ Functions ------------------------------- //
 
     /**
      * @dev Adds an account to the blocklist.
@@ -153,7 +153,7 @@ abstract contract BlocklistableUpgradeable is AccessControlExtUpgradeable {
         emit Blocklisted(sender);
     }
 
-    // -------------------- View functions ---------------------------
+    // ------------------ View functions -------------------------- //
 
     /**
      * @dev Checks if an account is blocklisted.
@@ -164,7 +164,7 @@ abstract contract BlocklistableUpgradeable is AccessControlExtUpgradeable {
         return _getBlocklistableStorage().blocklisted[account];
     }
 
-    // -------------------- Private functions ------------------------
+    // ------------------ Private functions ----------------------- //
 
     /**
      * @dev Returns the contract storage structure.

--- a/contracts/base/PausableExtUpgradeable.sol
+++ b/contracts/base/PausableExtUpgradeable.sol
@@ -18,7 +18,7 @@ abstract contract PausableExtUpgradeable is AccessControlExtUpgradeable, Pausabl
     /// @dev The role of pauser that is allowed to trigger the paused or unpaused state of the contract.
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
-    // -------------------- Initializers -----------------------------
+    // ------------------ Initializers ---------------------------- //
 
     /**
      * @dev The internal initializer of the upgradable contract.
@@ -44,7 +44,7 @@ abstract contract PausableExtUpgradeable is AccessControlExtUpgradeable, Pausabl
         _setRoleAdmin(PAUSER_ROLE, pauserRoleAdmin);
     }
 
-    // -------------------- Functions --------------------------------
+    // ------------------ Functions ------------------------------- //
 
     /**
      * @dev Triggers the paused state of the contract.

--- a/contracts/base/RescuableUpgradeable.sol
+++ b/contracts/base/RescuableUpgradeable.sol
@@ -21,7 +21,7 @@ abstract contract RescuableUpgradeable is AccessControlExtUpgradeable {
     /// @dev The role of rescuer that is allowed to rescue tokens locked up in the contract.
     bytes32 public constant RESCUER_ROLE = keccak256("RESCUER_ROLE");
 
-    // -------------------- Initializers -----------------------------
+    // ------------------ Initializers ---------------------------- //
 
     /**
      * @dev The internal initializer of the upgradable contract.
@@ -46,7 +46,7 @@ abstract contract RescuableUpgradeable is AccessControlExtUpgradeable {
         _setRoleAdmin(RESCUER_ROLE, rescuerRoleAdmin);
     }
 
-    // -------------------- Functions --------------------------------
+    // ------------------ Functions ------------------------------- //
 
     /**
      * @dev Withdraws ERC20 tokens locked up in the contract.

--- a/contracts/interfaces/ICardPaymentCashback.sol
+++ b/contracts/interfaces/ICardPaymentCashback.sol
@@ -2,14 +2,13 @@
 
 pragma solidity ^0.8.0;
 
-/**
- * @title CardPaymentCashback types interface
- */
+/// @title CardPaymentCashback types interface
 interface ICardPaymentCashbackTypes {
     /**
      * @dev Statuses of a cashback operation as an enum.
      *
      * The possible values:
+     *
      * - Undefined - The operation does not exist (the default value).
      * - Success --- The operation has been successfully executed with a full amount transfer.
      * - Partial --- The operation has been successfully executed but with a partial amount transfer.
@@ -24,7 +23,7 @@ interface ICardPaymentCashbackTypes {
         Failed     // 4
     }
 
-    /// @dev Structure with cashback-related data for a single account
+    /// @dev Structure with cashback-related data for a single account.
     struct AccountCashbackState {
         uint72 totalAmount;
         uint72 capPeriodStartAmount;
@@ -37,7 +36,7 @@ interface ICardPaymentCashbackTypes {
  * @dev The interface of the wrapper contract for the card payment cashback operations.
  */
 interface ICardPaymentCashback is ICardPaymentCashbackTypes {
-    // -------------------- Events -----------------------------------
+    // ------------------ Events ---------------------------------- //
 
     /**
      * @dev Emitted when the cashback rate is changed.
@@ -106,7 +105,7 @@ interface ICardPaymentCashback is ICardPaymentCashbackTypes {
     /// @dev Emitted when cashback operations for new payments are disabled. Does not affect the existing payments.
     event CashbackDisabled();
 
-    // -------------------- Functions --------------------------------
+    // ------------------ Functions ------------------------------- //
 
     /**
      * @dev Sets a new address of the cashback treasury.
@@ -140,21 +139,15 @@ interface ICardPaymentCashback is ICardPaymentCashbackTypes {
      */
     function disableCashback() external;
 
-    // -------------------- View functions ---------------------------
+    // ------------------ View functions -------------------------- //
 
-    /**
-     * @dev Returns the current cashback treasury address.
-     */
+    /// @dev Returns the current cashback treasury address.
     function cashbackTreasury() external view returns (address);
 
-    /**
-     * @dev Checks if the cashback operations are enabled.
-     */
+    /// @dev Checks if the cashback operations are enabled.
     function cashbackEnabled() external view returns (bool);
 
-    /**
-     * @dev Returns the current cashback rate.
-     */
+    /// @dev Returns the current cashback rate.
     function cashbackRate() external view returns (uint256);
 
     /**

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -12,9 +12,6 @@ interface ICardPaymentProcessorTypes {
      * The possible values:
      * - Nonexistent - The payment does not exist (the default value).
      * - Active ------ The status immediately after the payment making.
-     * - Merged ------ The payment was merged to another payment. Obsolete and is not used anymore.
-     *                 The payment cannot be made again with the same ID.
-     *                 All further operations with this payment are prohibited.
      * - Revoked ----- The payment was cancelled due to some technical reason.
      *                 The related tokens have been transferred back to the payer and (optionally) sponsor.
      *                 The payment can be made again with the same ID.
@@ -27,9 +24,8 @@ interface ICardPaymentProcessorTypes {
     enum PaymentStatus {
         Nonexistent, // 0
         Active,      // 1
-        Merged,      // 2
-        Revoked,     // 3
-        Reversed     // 4
+        Revoked,     // 2
+        Reversed     // 3
     }
 
     /** @dev Structure with data of a single payment.

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -2,14 +2,13 @@
 
 pragma solidity ^0.8.0;
 
-/**
- * @title CardPaymentProcessor types interface
- */
+/// @title CardPaymentProcessor types interface
 interface ICardPaymentProcessorTypes {
     /**
      * @dev Possible statuses of a payment as an enum.
      *
      * The possible values:
+     *
      * - Nonexistent - The payment does not exist (the default value).
      * - Active ------ The status immediately after the payment making.
      * - Revoked ----- The payment was cancelled due to some technical reason.
@@ -54,17 +53,17 @@ interface ICardPaymentProcessorTypes {
      *  - `commonReminder >= confirmedAmount`.
      */
     struct Payment {
-        //slot1
+        // Slot1
         PaymentStatus status;   // The current status of the payment.
         uint8 reserve1;         // The reserved filed for future changes.
         address payer;          // The account who made the payment.
         uint16 cashbackRate;    // The cashback rate in units of `CASHBACK_FACTOR`.
         uint64 confirmedAmount; // The confirmed amount that was transferred to the cash-out account.
-        //slot2
+        // Slot2
         address sponsor;        // The sponsor of the payment if it is subsidized. Otherwise the zero address.
         uint64 subsidyLimit;    // The subsidy limit of the payment if it is subsidized. Otherwise zero.
         uint32 reserve2;        // The reserved filed for future changes.
-        //slot3
+        // Slot3
         uint64 baseAmount;      // The base amount of tokens in the payment.
         uint64 extraAmount;     // The extra amount of tokens in the payment, without a cashback.
         uint64 cashbackAmount;  // The cumulative cashback amount that was granted to payer related to the payment.
@@ -90,7 +89,7 @@ interface ICardPaymentProcessorTypes {
  * @dev The interface of the wrapper contract for the card payment operations.
  */
 interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
-    // -------------------- Events -----------------------------------
+    // ------------------ Events ---------------------------------- //
 
     /**
      * @dev Emitted when a payment is made.
@@ -252,7 +251,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
         bytes addendum
     );
 
-    // -------------------- Functions --------------------------------
+    // ------------------ Functions ------------------------------- //
 
     /**
      * @dev Makes a card payment for a given account initiated by a service account.
@@ -436,16 +435,12 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
         uint256 refundingAmount
     ) external;
 
-    // -------------------- View functions ---------------------------
+    // ------------------ View functions -------------------------- //
 
-    /**
-     * @dev Returns the address of the underlying token.
-     */
+    /// @dev Returns the address of the underlying token.
     function token() external view returns (address);
 
-    /**
-     * @dev Returns the address of the cash-out account.
-     */
+    /// @dev Returns the address of the cash-out account.
     function cashOutAccount() external view returns (address);
 
     /**
@@ -454,8 +449,6 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      */
     function getPayment(bytes32 paymentId) external view returns (Payment memory);
 
-    /**
-     * @dev Returns statistics of all payments.
-     */
+    /// @dev Returns statistics of all payments.
     function getPaymentStatistics() external view returns (PaymentStatistics memory);
 }

--- a/contracts/mocks/base/AccessControlExtUpgradeableMock.sol
+++ b/contracts/mocks/base/AccessControlExtUpgradeableMock.sol
@@ -16,7 +16,7 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable, UUPSUpg
     bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
     bytes32 public constant USER_ROLE = keccak256("USER_ROLE");
 
-    // -------------------- Initializers -----------------------------
+    // ------------------ Initializers ---------------------------- //
 
     /**
      * @dev The initialize function of the upgradable contract.
@@ -32,7 +32,7 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable, UUPSUpg
         _authorizeUpgrade(address(0));
     }
 
-    // -------------------- Functions --------------------------------
+    // ------------------ Functions ------------------------------- //
 
     /**
      * @dev Needed to check that the initialize function of the ancestor contract
@@ -50,11 +50,9 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable, UUPSUpg
         __AccessControlExt_init_unchained();
     }
 
-    // -------------------- Internal functions -----------------------
+    // ------------------ Internal functions ---------------------- //
 
-    /**
-     * @dev The upgrade authorization function for UUPSProxy.
-     */
+    /// @dev The upgrade authorization function for UUPSProxy.
     function _authorizeUpgrade(address newImplementation) internal pure override {
         newImplementation; // Suppresses a compiler warning about the unused variable
     }

--- a/contracts/mocks/base/BlocklistableUpgradeableMock.sol
+++ b/contracts/mocks/base/BlocklistableUpgradeableMock.sol
@@ -15,12 +15,12 @@ contract BlocklistableUpgradeableMock is BlocklistableUpgradeable, UUPSUpgradeab
     /// @dev The role of this contract owner.
     bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
 
-    // -------------------- Events -----------------------------------
+    // ------------------ Events ---------------------------------- //
 
     /// @dev Emitted when a test function of the `notBlocklisted` modifier executes successfully.
     event TestNotBlocklistedModifierSucceeded();
 
-    // -------------------- Initializers -----------------------------
+    // ------------------ Initializers ---------------------------- //
 
     /**
      * @dev The initialize function of the upgradable contract.
@@ -35,7 +35,7 @@ contract BlocklistableUpgradeableMock is BlocklistableUpgradeable, UUPSUpgradeab
         _authorizeUpgrade(address(0));
     }
 
-    // -------------------- Functions --------------------------------
+    // ------------------ Functions ------------------------------- //
 
     /**
      * @dev Needed to check that the initialize function of the ancestor contract
@@ -61,11 +61,9 @@ contract BlocklistableUpgradeableMock is BlocklistableUpgradeable, UUPSUpgradeab
         emit TestNotBlocklistedModifierSucceeded();
     }
 
-    // -------------------- Internal functions -----------------------
+    // ------------------ Internal functions ---------------------- //
 
-    /**
-     * @dev The upgrade authorization function for UUPSProxy.
-     */
+    /// @dev The upgrade authorization function for UUPSProxy.
     function _authorizeUpgrade(address newImplementation) internal pure override {
         newImplementation; // Suppresses a compiler warning about the unused variable
     }

--- a/contracts/mocks/base/PausableExtUpgradeableMock.sol
+++ b/contracts/mocks/base/PausableExtUpgradeableMock.sol
@@ -15,7 +15,7 @@ contract PausableExtUpgradeableMock is PausableExtUpgradeable, UUPSUpgradeable {
     /// @dev The role of this contract owner.
     bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
 
-    // -------------------- Initializers -----------------------------
+    // ------------------ Initializers ---------------------------- //
 
     /**
      * @dev The initialize function of the upgradable contract.
@@ -30,7 +30,7 @@ contract PausableExtUpgradeableMock is PausableExtUpgradeable, UUPSUpgradeable {
         _authorizeUpgrade(address(0));
     }
 
-    // -------------------- Functions --------------------------------
+    // ------------------ Functions ------------------------------- //
 
     /**
      * @dev Needed to check that the initialize function of the ancestor contract
@@ -48,11 +48,9 @@ contract PausableExtUpgradeableMock is PausableExtUpgradeable, UUPSUpgradeable {
         __PausableExt_init_unchained(OWNER_ROLE);
     }
 
-    // -------------------- Internal functions -----------------------
+    // ------------------ Internal functions ---------------------- //
 
-    /**
-     * @dev The upgrade authorization function for UUPSProxy.
-     */
+    /// @dev The upgrade authorization function for UUPSProxy.
     function _authorizeUpgrade(address newImplementation) internal pure override {
         newImplementation; // Suppresses a compiler warning about the unused variable
     }

--- a/contracts/mocks/base/RescuableUpgradeableMock.sol
+++ b/contracts/mocks/base/RescuableUpgradeableMock.sol
@@ -15,7 +15,7 @@ contract RescuableUpgradeableMock is RescuableUpgradeable, UUPSUpgradeable {
     /// @dev The role of this contract owner.
     bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
 
-    // -------------------- Initializers -----------------------------
+    // ------------------ Initializers ---------------------------- //
 
     /**
      * @dev The initialize function of the upgradable contract.
@@ -30,7 +30,7 @@ contract RescuableUpgradeableMock is RescuableUpgradeable, UUPSUpgradeable {
         _authorizeUpgrade(address(0));
     }
 
-    // -------------------- Functions --------------------------------
+    // ------------------ Functions ------------------------------- //
 
     /**
      * @dev Needed to check that the initialize function of the ancestor contract
@@ -48,11 +48,9 @@ contract RescuableUpgradeableMock is RescuableUpgradeable, UUPSUpgradeable {
         __Rescuable_init_unchained(OWNER_ROLE);
     }
 
-    // -------------------- Internal functions -----------------------
+    // ------------------ Internal functions ---------------------- //
 
-    /**
-     * @dev The upgrade authorization function for UUPSProxy.
-     */
+    /// @dev The upgrade authorization function for UUPSProxy.
     function _authorizeUpgrade(address newImplementation) internal pure override {
         newImplementation; // Suppresses a compiler warning about the unused variable
     }

--- a/contracts/mocks/tokens/ERC20TokenMock.sol
+++ b/contracts/mocks/tokens/ERC20TokenMock.sol
@@ -16,7 +16,7 @@ contract ERC20TokenMock is ERC20Upgradeable, UUPSUpgradeable {
     /// @dev A special amount when the transfer functions should revert.
     uint256 public specialAmountToRevert;
 
-    // -------------------- Initializers -----------------------------
+    // ------------------ Initializers ---------------------------- //
 
     /**
      * @dev The initialize function of the upgradable contract.
@@ -32,7 +32,7 @@ contract ERC20TokenMock is ERC20Upgradeable, UUPSUpgradeable {
         _authorizeUpgrade(address(0));
     }
 
-    // -------------------- Functions --------------------------------
+    // ------------------ Functions ------------------------------- //
 
     /**
      * @dev Calls the appropriate internal function to mint needed amount of tokens for an account.
@@ -43,9 +43,7 @@ contract ERC20TokenMock is ERC20Upgradeable, UUPSUpgradeable {
         _mint(account, amount);
     }
 
-    /**
-     * @dev The variation of the standard transfer function that returns `false` if the special amount is passed.
-     */
+    /// @dev The variation of the standard transfer function that returns `false` if the special amount is passed.
     function transfer(address to, uint256 amount) public override returns (bool) {
         if (amount == specialAmountToRevert) {
             revert("ERC20TokenMock: The special amount has been used inside the 'transfer()' function");
@@ -56,9 +54,7 @@ contract ERC20TokenMock is ERC20Upgradeable, UUPSUpgradeable {
         }
     }
 
-    /**
-     * @dev The variation of the standard transfer from function that returns `false` if the special amount is passed.
-     */
+    /// @dev The variation of the standard transfer from function that returns `false` if the special amount is passed.
     function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
         if (amount == specialAmountToRevert) {
             revert("ERC20TokenMock: The special amount has been used inside the 'transferFrom()' function");
@@ -69,25 +65,19 @@ contract ERC20TokenMock is ERC20Upgradeable, UUPSUpgradeable {
         }
     }
 
-    /**
-     * @dev Configures the special amount when the transfer functions should return `false`.
-     */
+    /// @dev Configures the special amount when the transfer functions should return `false`.
     function setSpecialAmountToReturnFalse(uint256 newSpecialAmount) external {
         specialAmountToReturnFalse = newSpecialAmount;
     }
 
-    /**
-     * @dev Configures the special amount when the transfer functions should revert.
-     */
+    /// @dev Configures the special amount when the transfer functions should revert.
     function setSpecialAmountToRevert(uint256 newSpecialAmount) external {
         specialAmountToRevert = newSpecialAmount;
     }
 
-    // -------------------- Internal functions -----------------------
+    // ------------------ Internal functions ---------------------- //
 
-    /**
-     * @dev The upgrade authorization function for UUPSProxy.
-     */
+    /// @dev The upgrade authorization function for UUPSProxy.
     function _authorizeUpgrade(address newImplementation) internal pure override {
         newImplementation; // Suppresses a compiler warning about the unused variable
     }

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -57,9 +57,8 @@ const EVENT_NAME_PAYMENT_UPDATED = "PaymentUpdated";
 enum PaymentStatus {
   // Nonexistent = 0, is not used in the tests.
   Active = 1,
-  // Merged = 2, is not used in the tests.
-  Revoked = 3,
-  Reversed = 4
+  Revoked = 2,
+  Reversed = 3
 }
 
 enum CashbackOperationStatus {

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -20,13 +20,14 @@ const ZERO_SPONSOR_ADDRESS = ethers.ZeroAddress;
 const ZERO_SUBSIDY_LIMIT = 0;
 const BYTES32_LENGTH: number = 32;
 const CASHBACK_RATE_AS_IN_CONTRACT = -1;
-const CASHBACK_ROUNDING_COEF = 10000;
-const DIGITS_COEF = 1000000;
+const TOKE_DECIMALS = 6;
+const CASHBACK_ROUNDING_COEF = 10 ** (TOKE_DECIMALS - 2);
+const DIGITS_COEF = 10 ** TOKE_DECIMALS;
 const INITIAL_USER_BALANCE = 1000_000 * DIGITS_COEF;
 const INITIAL_SPONSOR_BALANCE = INITIAL_USER_BALANCE * 2;
 const CASHBACK_FACTOR = 1000;
 const CASHBACK_CAP_RESET_PERIOD = 30 * 24 * 60 * 60;
-const MAX_CASHBACK_FOR_CAP_PERIOD = 300 * 10 ** 6;
+const MAX_CASHBACK_FOR_CAP_PERIOD = 300 * 10 ** TOKE_DECIMALS;
 
 const EVENT_DATA_FIELD_VERSION_DEFAULT_VALUE = "01";
 const EVENT_DATA_FIELD_FLAGS_NON_SUBSIDIZED = "00";
@@ -1725,6 +1726,8 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       expect(await cardPaymentProcessor.cashbackRate()).to.equal(0);
       expect(await cardPaymentProcessor.MAX_CASHBACK_RATE()).to.equal(CASHBACK_RATE_MAX);
       expect(await cardPaymentProcessor.CASHBACK_FACTOR()).to.equal(CASHBACK_FACTOR);
+      expect(await cardPaymentProcessor.TOKE_DECIMALS()).to.equal(TOKE_DECIMALS);
+      expect(await cardPaymentProcessor.CASHBACK_ROUNDING_COEF()).to.equal(CASHBACK_ROUNDING_COEF);
       expect(await cardPaymentProcessor.CASHBACK_CAP_RESET_PERIOD()).to.equal(CASHBACK_CAP_RESET_PERIOD);
       expect(await cardPaymentProcessor.MAX_CASHBACK_FOR_CAP_PERIOD()).to.equal(MAX_CASHBACK_FOR_CAP_PERIOD);
 

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1561,6 +1561,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   const REVERT_ERROR_IF_PAYMENT_CONFIRMATION_ARRAY_EMPTY = "PaymentConfirmationArrayEmpty";
   const REVERT_ERROR_IF_PAYMENT_NON_EXISTENT = "PaymentNonExistent";
   const REVERT_ERROR_IF_PAYMENT_ZERO_ID = "PaymentZeroId";
+  const REVERT_ERROR_IF_SPONSOR_ZERO_ADDRESS = "SponsorZeroAddress";
   const REVERT_ERROR_IF_TOKEN_ZERO_ADDRESS = "TokenZeroAddress";
 
   const ownerRole: string = ethers.id("OWNER_ROLE");
@@ -2084,10 +2085,9 @@ describe("Contract 'CardPaymentProcessor'", async () => {
                 await checkPaymentMakingFor(context);
               });
 
-              it("Both nonzero, and if the subsidy limit argument is not zero", async () => {
+              it("Both nonzero, and if the subsidy limit argument is zero", async () => {
                 const context = await beforeMakingPayments();
-                const subsidyLimit = Math.floor(context.payments[0].baseAmount / 2);
-                await checkPaymentMakingFor(context, { subsidyLimit });
+                await checkPaymentMakingFor(context);
               });
 
               it("Both zero", async () => {
@@ -2493,6 +2493,24 @@ describe("Contract 'CardPaymentProcessor'", async () => {
             ZERO_CONFIRMATION_AMOUNT
           )
         ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_OVERFLOW_OF_SUM_AMOUNT);
+      });
+
+      it("The payment subsidy limit is not zero, but the sponsor address is zero", async () => {
+        const context = await prepareForPayments();
+        const { cardPaymentProcessorShell, payments: [payment] } = context;
+
+        await expect(
+          (cardPaymentProcessorShell.contract.connect(executor) as Contract).makePaymentFor(
+            payment.id,
+            payment.payer.address,
+            payment.baseAmount,
+            payment.extraAmount,
+            ZERO_SPONSOR_ADDRESS,
+            subsidyLimit,
+            CASHBACK_RATE_AS_IN_CONTRACT,
+            ZERO_CONFIRMATION_AMOUNT
+          )
+        ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_SPONSOR_ZERO_ADDRESS);
       });
 
       it("The payment subsidy limit is greater than 64-bit unsigned integer", async () => {


### PR DESCRIPTION
### Changes
1. The `Merged` payment status has been completely removed from the contract. The `PaymentStatus` enumeration values have been shifted. It might demand the appropriate changes of the backend.
2. It has been prohibited to make a payment with the zero sponsor address but non-zero subsidy limit. The transaction will be reverted with the `SponsorZeroAddress()` custom error in that case. Previously the subsidy limit would just be zeroed is the sponsor address was zero. The new check has been introduced to make the making payment logic more strict.
3. The new `TOKE_DECIMALS` public constant has been introduced to present the number of decimals that is used in the underlying token. 
4. Minor improvements in code and comments have been done.

### Test coverage
![image](https://github.com/cloudwalk/brlc-periphery/assets/97302011/1586a2cb-5fb5-4889-8680-39e048ab4b39)
