### PR TITLE
Migrate tests to EthersJS v.6 with the Solidity compiler version updating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^16.4.5",
         "eslint": "^8.57.0",
         "hardhat-contract-sizer": "^2.10.0",
+        "hardhat-gas-reporter": "^1.0.10",
         "prettier": "^3.2.5",
         "prettier-plugin-solidity": "^1.3.1"
       }
@@ -1199,8 +1200,7 @@
           "type": "individual",
           "url": "https://paulmillr.com/funding/"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1684,91 +1684,6 @@
         "@nomicfoundation/solidity-analyzer-win32-x64-msvc": "0.1.1"
       }
     },
-    "node_modules/@nomicfoundation/solidity-analyzer-darwin-arm64": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.1.tgz",
-      "integrity": "sha512-KcTodaQw8ivDZyF+D76FokN/HdpgGpfjc/gFCImdLUyqB6eSWVaZPazMbeAjmfhx3R0zm/NYVzxwAokFKgrc0w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/solidity-analyzer-darwin-x64": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.1.1.tgz",
-      "integrity": "sha512-XhQG4BaJE6cIbjAVtzGOGbK3sn1BO9W29uhk9J8y8fZF1DYz0Doj8QDMfpMu+A6TjPDs61lbsmeYodIDnfveSA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/solidity-analyzer-freebsd-x64": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-freebsd-x64/-/solidity-analyzer-freebsd-x64-0.1.1.tgz",
-      "integrity": "sha512-GHF1VKRdHW3G8CndkwdaeLkVBi5A9u2jwtlS7SLhBc8b5U/GcoL39Q+1CSO3hYqePNP+eV5YI7Zgm0ea6kMHoA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-gnu": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.1.tgz",
-      "integrity": "sha512-g4Cv2fO37ZsUENQ2vwPnZc2zRenHyAxHcyBjKcjaSmmkKrFr64yvzeNO8S3GBFCo90rfochLs99wFVGT/0owpg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-musl": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.1.tgz",
-      "integrity": "sha512-WJ3CE5Oek25OGE3WwzK7oaopY8xMw9Lhb0mlYuJl/maZVo+WtP36XoQTb7bW/i8aAdHW5Z+BqrHMux23pvxG3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-gnu": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.1.tgz",
@@ -1780,74 +1695,6 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-musl": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.1.1.tgz",
-      "integrity": "sha512-KdYMkJOq0SYPQMmErv/63CwGwMm5XHenEna9X9aB8mQmhDBrYrlAOSsIPgFCUSL0hjxE3xHP65/EPXR/InD2+w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/solidity-analyzer-win32-arm64-msvc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/-/solidity-analyzer-win32-arm64-msvc-0.1.1.tgz",
-      "integrity": "sha512-VFZASBfl4qiBYwW5xeY20exWhmv6ww9sWu/krWSesv3q5hA0o1JuzmPHR4LPN6SUZj5vcqci0O6JOL8BPw+APg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/solidity-analyzer-win32-ia32-msvc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/-/solidity-analyzer-win32-ia32-msvc-0.1.1.tgz",
-      "integrity": "sha512-JnFkYuyCSA70j6Si6cS1A9Gh1aHTEb8kOTBApp/c7NRTFGNMH8eaInKlyuuiIbvYFhlXW4LicqyYuWNNq9hkpQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/solidity-analyzer-win32-x64-msvc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.1.tgz",
-      "integrity": "sha512-HrVJr6+WjIXGnw3Q9u6KQcbZCtk0caVWhCdFADySvRyUxJ8PnzlaP+MhwNE8oyT8OZ6ejHBRrrgjSqDCFXGirw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "peer": true,
       "engines": {
@@ -2043,7 +1890,6 @@
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
       "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==",
       "dev": true,
-      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -2235,7 +2081,6 @@
       "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.5.tgz",
       "integrity": "sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4"
       }
@@ -2432,7 +2277,6 @@
       "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.1.tgz",
       "integrity": "sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2458,7 +2302,6 @@
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
       "integrity": "sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2530,8 +2373,7 @@
       "version": "6.9.15",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
       "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/secp256k1": {
       "version": "4.0.6",
@@ -2956,15 +2798,13 @@
       "version": "0.5.0-alpha.4",
       "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
       "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -2978,7 +2818,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -3039,7 +2878,6 @@
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3090,8 +2928,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
@@ -3217,7 +3054,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -3291,8 +3127,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
@@ -3343,8 +3178,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -3395,7 +3229,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3407,8 +3240,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/cbor": {
       "version": "8.1.0",
@@ -3476,7 +3308,6 @@
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -3592,7 +3423,6 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -3622,7 +3452,6 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -3803,7 +3632,6 @@
       "engines": [
         "node >= 0.8"
       ],
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -3816,7 +3644,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3831,15 +3658,13 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/concat-stream/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3858,8 +3683,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
@@ -3914,7 +3738,6 @@
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -3999,7 +3822,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4094,7 +3916,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4337,7 +4158,6 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
       "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4654,7 +4474,6 @@
       "resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.2.27.tgz",
       "integrity": "sha512-femhvoAM7wL0GcI8ozTdxfuBtBFJ9qsyIAsmKVjlWAHUbdnnXHt+lKzz/kmldM5lA9jLuNHGwuIxorNpLbR1Zw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@solidity-parser/parser": "^0.14.0",
         "axios": "^1.5.1",
@@ -4689,8 +4508,7 @@
           "type": "individual",
           "url": "https://paulmillr.com/funding/"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/eth-gas-reporter/node_modules/@scure/bip32": {
       "version": "1.1.5",
@@ -4703,7 +4521,6 @@
           "url": "https://paulmillr.com/funding/"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "~1.2.0",
         "@noble/secp256k1": "~1.7.0",
@@ -4721,7 +4538,6 @@
           "url": "https://paulmillr.com/funding/"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "~1.2.0",
         "@scure/base": "~1.1.0"
@@ -4732,7 +4548,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
       "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4742,7 +4557,6 @@
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
       "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "object-assign": "^4.1.0",
         "string-width": "^2.1.1"
@@ -4759,7 +4573,6 @@
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
       "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.2.0",
         "@noble/secp256k1": "1.7.1",
@@ -4782,7 +4595,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/abstract-provider": "5.7.0",
@@ -4821,7 +4633,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4831,7 +4642,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -4845,7 +4655,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^3.0.0"
       },
@@ -5168,7 +4977,6 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -5262,29 +5070,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
       "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -5327,7 +5119,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -5366,7 +5157,6 @@
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
       "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -5768,7 +5558,6 @@
       "resolved": "https://registry.npmjs.org/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.10.tgz",
       "integrity": "sha512-02N4+So/fZrzJ88ci54GqwVA3Zrf0C9duuTyGt0CFRIh/CdNwbnTgkXkRfojOMLBQ+6t+lBIkgbsOtqMvNwikA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-uniq": "1.0.3",
         "eth-gas-reporter": "^0.2.25",
@@ -6147,7 +5936,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "he": "bin/he"
       }
@@ -6175,7 +5963,6 @@
       "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
       "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "caseless": "^0.12.0",
         "concat-stream": "^1.6.2",
@@ -6208,7 +5995,6 @@
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
       "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "^10.0.3"
       }
@@ -6217,8 +6003,7 @@
       "version": "10.17.60",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -6419,7 +6204,6 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -6576,7 +6360,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6662,7 +6445,6 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6903,7 +6685,6 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -6943,8 +6724,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
       "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -7081,7 +6861,6 @@
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.4.0.tgz",
       "integrity": "sha512-eqhGB8JKapEYcC4ytX/xrzKforgEc3j1pGlAXVy3eRwrtAy5/nIfT1SvgGzfN0XZZxeLq0aQWkOUAmqIJiv+bA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
@@ -7117,7 +6896,6 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7133,7 +6911,6 @@
           "url": "https://paulmillr.com/funding/"
         }
       ],
-      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -7155,7 +6932,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7175,7 +6951,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -7188,7 +6963,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
       "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -7200,15 +6974,13 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -7332,7 +7104,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7364,7 +7135,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7527,8 +7297,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -7693,15 +7462,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/promise": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
       "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "asap": "~2.0.6"
       }
@@ -7760,7 +7527,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
       "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -7835,7 +7601,6 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -7848,7 +7613,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -7939,7 +7703,6 @@
       "resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-2.0.0.tgz",
       "integrity": "sha512-ueoIoLo1OfB6b05COxAA9UpeoscNpYyM+BqYlA7H6LVF4hKGPXQQSSaD2YmvDVJMkk4UDpAHIeU1zG53IqjvlQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "req-from": "^2.0.0"
       },
@@ -7952,7 +7715,6 @@
       "resolved": "https://registry.npmjs.org/req-from/-/req-from-2.0.0.tgz",
       "integrity": "sha512-LzTfEVDVQHBRfjOUMgNBA+V6DWsSnoeKzf42J7l0xa/B4jyPOuuF5MlNSmomLNGemWTnV2TIdjSSLnEn95fOQA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "resolve-from": "^3.0.0"
       },
@@ -7965,7 +7727,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7975,7 +7736,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8343,7 +8103,6 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
       "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -8411,7 +8170,6 @@
       "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
       "integrity": "sha512-dZBS6OrMjtgVkopB1Gmo4RQCDKiZsqcpAQpkV/aaj+FCrCg8r4I4qMkDPQjBgLIxlmu9k4nUbWq6ohXahOneYA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "charenc": ">= 0.0.1",
         "crypt": ">= 0.0.1"
@@ -9009,7 +8767,6 @@
       "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
       "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "http-response-object": "^3.0.1",
         "sync-rpc": "^1.2.1",
@@ -9024,7 +8781,6 @@
       "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
       "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "get-port": "^3.1.0"
       }
@@ -9117,7 +8873,6 @@
       "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
       "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/concat-stream": "^1.6.0",
         "@types/form-data": "0.0.33",
@@ -9139,15 +8894,13 @@
       "version": "8.10.66",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
       "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/then-request/node_modules/form-data": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
       "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -9572,8 +9325,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/typescript": {
       "version": "5.4.5",
@@ -9894,15 +9646,13 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
       "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -9948,7 +9698,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9958,7 +9707,6 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -9977,7 +9725,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
       "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9987,7 +9734,6 @@
       "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
       "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "camelcase": "^6.0.0",
         "decamelize": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
         "@openzeppelin/hardhat-upgrades": "^3.1.0",
-        "@stylistic/eslint-plugin": "^2.1.0",
+        "@stylistic/eslint-plugin": "^1.8.1",
         "@typescript-eslint/eslint-plugin": "^7.10.0",
         "@typescript-eslint/parser": "^7.10.0",
         "dotenv": "^16.4.5",
@@ -122,18 +122,6 @@
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
-    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
@@ -174,35 +162,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.9.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -1684,6 +1643,91 @@
         "@nomicfoundation/solidity-analyzer-win32-x64-msvc": "0.1.1"
       }
     },
+    "node_modules/@nomicfoundation/solidity-analyzer-darwin-arm64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.1.tgz",
+      "integrity": "sha512-KcTodaQw8ivDZyF+D76FokN/HdpgGpfjc/gFCImdLUyqB6eSWVaZPazMbeAjmfhx3R0zm/NYVzxwAokFKgrc0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-darwin-x64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.1.1.tgz",
+      "integrity": "sha512-XhQG4BaJE6cIbjAVtzGOGbK3sn1BO9W29uhk9J8y8fZF1DYz0Doj8QDMfpMu+A6TjPDs61lbsmeYodIDnfveSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-freebsd-x64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-freebsd-x64/-/solidity-analyzer-freebsd-x64-0.1.1.tgz",
+      "integrity": "sha512-GHF1VKRdHW3G8CndkwdaeLkVBi5A9u2jwtlS7SLhBc8b5U/GcoL39Q+1CSO3hYqePNP+eV5YI7Zgm0ea6kMHoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-gnu": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.1.tgz",
+      "integrity": "sha512-g4Cv2fO37ZsUENQ2vwPnZc2zRenHyAxHcyBjKcjaSmmkKrFr64yvzeNO8S3GBFCo90rfochLs99wFVGT/0owpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-musl": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.1.tgz",
+      "integrity": "sha512-WJ3CE5Oek25OGE3WwzK7oaopY8xMw9Lhb0mlYuJl/maZVo+WtP36XoQTb7bW/i8aAdHW5Z+BqrHMux23pvxG3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-gnu": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.1.tgz",
@@ -1695,6 +1739,74 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-musl": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.1.1.tgz",
+      "integrity": "sha512-KdYMkJOq0SYPQMmErv/63CwGwMm5XHenEna9X9aB8mQmhDBrYrlAOSsIPgFCUSL0hjxE3xHP65/EPXR/InD2+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-arm64-msvc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/-/solidity-analyzer-win32-arm64-msvc-0.1.1.tgz",
+      "integrity": "sha512-VFZASBfl4qiBYwW5xeY20exWhmv6ww9sWu/krWSesv3q5hA0o1JuzmPHR4LPN6SUZj5vcqci0O6JOL8BPw+APg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-ia32-msvc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/-/solidity-analyzer-win32-ia32-msvc-0.1.1.tgz",
+      "integrity": "sha512-JnFkYuyCSA70j6Si6cS1A9Gh1aHTEb8kOTBApp/c7NRTFGNMH8eaInKlyuuiIbvYFhlXW4LicqyYuWNNq9hkpQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-x64-msvc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.1.tgz",
+      "integrity": "sha512-HrVJr6+WjIXGnw3Q9u6KQcbZCtk0caVWhCdFADySvRyUxJ8PnzlaP+MhwNE8oyT8OZ6ejHBRrrgjSqDCFXGirw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "peer": true,
       "engines": {
@@ -2086,85 +2198,86 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.1.0.tgz",
-      "integrity": "sha512-cBBowKP2u/+uE5CzgH5w8pE9VKqcM7BXdIDPIbGt2rmLJGnA6MJPr9vYGaqgMoJFs7R/FzsMQerMvvEP40g2uw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.8.1.tgz",
+      "integrity": "sha512-64My6I7uCcmSQ//427Pfg2vjSf9SDzfsGIWohNFgISMLYdC5BzJqDo647iDDJzSxINh3WTC0Ql46ifiKuOoTyA==",
       "dev": true,
       "dependencies": {
-        "@stylistic/eslint-plugin-js": "2.1.0",
-        "@stylistic/eslint-plugin-jsx": "2.1.0",
-        "@stylistic/eslint-plugin-plus": "2.1.0",
-        "@stylistic/eslint-plugin-ts": "2.1.0",
+        "@stylistic/eslint-plugin-js": "1.8.1",
+        "@stylistic/eslint-plugin-jsx": "1.8.1",
+        "@stylistic/eslint-plugin-plus": "1.8.1",
+        "@stylistic/eslint-plugin-ts": "1.8.1",
         "@types/eslint": "^8.56.10"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
       }
     },
     "node_modules/@stylistic/eslint-plugin-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.1.0.tgz",
-      "integrity": "sha512-gdXUjGNSsnY6nPyqxu6lmDTtVrwCOjun4x8PUn0x04d5ucLI74N3MT1Q0UhdcOR9No3bo5PGDyBgXK+KmD787A==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.8.1.tgz",
+      "integrity": "sha512-c5c2C8Mos5tTQd+NWpqwEu7VT6SSRooAguFPMj1cp2RkTYl1ynKoXo8MWy3k4rkbzoeYHrqC2UlUzsroAN7wtQ==",
       "dev": true,
       "dependencies": {
         "@types/eslint": "^8.56.10",
         "acorn": "^8.11.3",
-        "eslint-visitor-keys": "^4.0.0",
-        "espree": "^10.0.1"
+        "escape-string-regexp": "^4.0.0",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
       }
     },
     "node_modules/@stylistic/eslint-plugin-jsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-2.1.0.tgz",
-      "integrity": "sha512-mMD7S+IndZo2vxmwpHVTCwx2O1VdtE5tmpeNwgaEcXODzWV1WTWpnsc/PECQKIr/mkLPFWiSIqcuYNhQ/3l6AQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.8.1.tgz",
+      "integrity": "sha512-k1Eb6rcjMP+mmjvj+vd9y5KUdWn1OBkkPLHXhsrHt5lCDFZxJEs0aVQzE5lpYrtVZVkpc5esTtss/cPJux0lfA==",
       "dev": true,
       "dependencies": {
-        "@stylistic/eslint-plugin-js": "^2.1.0",
+        "@stylistic/eslint-plugin-js": "^1.8.1",
         "@types/eslint": "^8.56.10",
         "estraverse": "^5.3.0",
         "picomatch": "^4.0.2"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
       }
     },
     "node_modules/@stylistic/eslint-plugin-plus": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-2.1.0.tgz",
-      "integrity": "sha512-S5QAlgYXESJaSBFhBSBLZy9o36gXrXQwWSt6QkO+F0SrT9vpV5JF/VKoh+ojO7tHzd8Ckmyouq02TT9Sv2B0zQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.8.1.tgz",
+      "integrity": "sha512-4+40H3lHYTN8OWz+US8CamVkO+2hxNLp9+CAjorI7top/lHqemhpJvKA1LD9Uh+WMY9DYWiWpL2+SZ2wAXY9fQ==",
       "dev": true,
       "dependencies": {
         "@types/eslint": "^8.56.10",
-        "@typescript-eslint/utils": "^7.8.0"
+        "@typescript-eslint/utils": "^6.21.0"
       },
       "peerDependencies": {
         "eslint": "*"
       }
     },
     "node_modules/@stylistic/eslint-plugin-ts": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.1.0.tgz",
-      "integrity": "sha512-2ioFibufHYBALx2TBrU4KXovCkN8qCqcb9yIHc0fyOfTaO5jw4d56WW7YRcF3Zgde6qFyXwAN6z/+w4pnmos1g==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.8.1.tgz",
+      "integrity": "sha512-/q1m+ZuO1JHfiSF16EATFzv7XSJkc5W6DocfvH5o9oB6WWYFMF77fVoBWnKT3wGptPOc2hkRupRKhmeFROdfWA==",
       "dev": true,
       "dependencies": {
-        "@stylistic/eslint-plugin-js": "2.1.0",
+        "@stylistic/eslint-plugin-js": "1.8.1",
         "@types/eslint": "^8.56.10",
-        "@typescript-eslint/utils": "^7.8.0"
+        "@typescript-eslint/utils": "^6.21.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
@@ -2384,6 +2497,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.10.0.tgz",
@@ -2415,6 +2534,28 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.10.0.tgz",
+      "integrity": "sha512-olzif1Fuo8R8m/qKkzJqT7qwy16CzPRWBvERS0uvyc+DHd8AKbO4Jb7kpAvVzMmZm8TrHnI7hvjN4I05zow+tg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.10.0",
+        "@typescript-eslint/types": "7.10.0",
+        "@typescript-eslint/typescript-estree": "7.10.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -2489,6 +2630,28 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.10.0.tgz",
+      "integrity": "sha512-olzif1Fuo8R8m/qKkzJqT7qwy16CzPRWBvERS0uvyc+DHd8AKbO4Jb7kpAvVzMmZm8TrHnI7hvjN4I05zow+tg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.10.0",
+        "@typescript-eslint/types": "7.10.0",
+        "@typescript-eslint/typescript-estree": "7.10.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.10.0.tgz",
@@ -2543,25 +2706,130 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.10.0.tgz",
-      "integrity": "sha512-olzif1Fuo8R8m/qKkzJqT7qwy16CzPRWBvERS0uvyc+DHd8AKbO4Jb7kpAvVzMmZm8TrHnI7hvjN4I05zow+tg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.10.0",
-        "@typescript-eslint/types": "7.10.0",
-        "@typescript-eslint/typescript-estree": "7.10.0"
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -2579,18 +2847,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -2998,9 +3254,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.1.tgz",
-      "integrity": "sha512-+LV37nQcd1EpFalkXksWNBiA17NZ5m5/WspmHGmZmdx1qBOg/VNq/c4eRJiA9VQQHBOs+N0ZhhdU10h2TyNK7Q==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -4334,12 +4590,12 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4355,35 +4611,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.9.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4397,17 +4624,17 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
-      "integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.11.3",
+        "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.0.0"
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -5077,6 +5304,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
         "@openzeppelin/hardhat-upgrades": "^3.1.0",
-        "@stylistic/eslint-plugin": "^1.8.0",
-        "@typescript-eslint/eslint-plugin": "^7.8.0",
-        "@typescript-eslint/parser": "^7.8.0",
+        "@stylistic/eslint-plugin": "^2.1.0",
+        "@typescript-eslint/eslint-plugin": "^7.10.0",
+        "@typescript-eslint/parser": "^7.10.0",
         "dotenv": "^16.4.5",
         "eslint": "^8.57.0",
         "hardhat-contract-sizer": "^2.10.0",
@@ -50,12 +50,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.567.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.577.0.tgz",
+      "integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^2.12.0",
+        "@smithy/types": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -121,6 +121,18 @@
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
@@ -161,6 +173,35 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -1197,138 +1238,89 @@
       }
     },
     "node_modules/@nomicfoundation/edr": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.3.7.tgz",
-      "integrity": "sha512-v2JFWnFKRsnOa6PDUrD+sr8amcdhxnG/YbL7LzmgRGU1odWEyOF4/EwNeUajQr4ZNKVWrYnJ6XjydXtUge5OBQ==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.3.8.tgz",
+      "integrity": "sha512-u2UJ5QpznSHVkZRh6ePWoeVb6kmPrrqh08gCnZ9FHlJV9CITqlrTQHJkacd+INH31jx88pTAJnxePE4XAiH5qg==",
       "dev": true,
       "peer": true,
+      "dependencies": {
+        "@nomicfoundation/edr-darwin-arm64": "0.3.8",
+        "@nomicfoundation/edr-darwin-x64": "0.3.8",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.3.8",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.3.8",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.3.8",
+        "@nomicfoundation/edr-linux-x64-musl": "0.3.8",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.3.8"
+      },
       "engines": {
         "node": ">= 18"
-      },
-      "optionalDependencies": {
-        "@nomicfoundation/edr-darwin-arm64": "0.3.7",
-        "@nomicfoundation/edr-darwin-x64": "0.3.7",
-        "@nomicfoundation/edr-linux-arm64-gnu": "0.3.7",
-        "@nomicfoundation/edr-linux-arm64-musl": "0.3.7",
-        "@nomicfoundation/edr-linux-x64-gnu": "0.3.7",
-        "@nomicfoundation/edr-linux-x64-musl": "0.3.7",
-        "@nomicfoundation/edr-win32-x64-msvc": "0.3.7"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-arm64": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.3.7.tgz",
-      "integrity": "sha512-6tK9Lv/lSfyBvpEQ4nsTfgxyDT1y1Uv/x8Wa+aB+E8qGo3ToexQ1BMVjxJk6PChXCDOWxB3B4KhqaZFjdhl3Ow==",
-      "cpu": [
-        "arm64"
-      ],
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.3.8.tgz",
+      "integrity": "sha512-eB0leCexS8sQEmfyD72cdvLj9djkBzQGP4wSQw6SNf2I4Sw4Cnzb3d45caG2FqFFjbvfqL0t+badUUIceqQuMw==",
       "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
       "peer": true,
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-x64": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.3.7.tgz",
-      "integrity": "sha512-1RrQ/1JPwxrYO69e0tglFv5H+ggour5Ii3bb727+yBpBShrxtOTQ7fZyfxA5h62LCN+0Z9wYOPeQ7XFcVurMaQ==",
-      "cpu": [
-        "x64"
-      ],
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.3.8.tgz",
+      "integrity": "sha512-JksVCS1N5ClwVF14EvO25HCQ+Laljh/KRfHERMVAC9ZwPbTuAd/9BtKvToCBi29uCHWqsXMI4lxCApYQv2nznw==",
       "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
       "peer": true,
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.3.7.tgz",
-      "integrity": "sha512-ds/CKlBoVXIihjhflhgPn13EdKWed6r5bgvMs/YwRqT5wldQAQJZWAfA2+nYm0Yi2gMGh1RUpBcfkyl4pq7G+g==",
-      "cpu": [
-        "arm64"
-      ],
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.3.8.tgz",
+      "integrity": "sha512-raCE+fOeNXhVBLUo87cgsHSGvYYRB6arih4eG6B9KGACWK5Veebtm9xtKeiD8YCsdUlUfat6F7ibpeNm91fpsA==",
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "peer": true,
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.3.7.tgz",
-      "integrity": "sha512-e29udiRaPujhLkM3+R6ju7QISrcyOqpcaxb2FsDWBkuD7H8uU9JPZEyyUIpEp5uIY0Jh1eEJPKZKIXQmQAEAuw==",
-      "cpu": [
-        "arm64"
-      ],
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.3.8.tgz",
+      "integrity": "sha512-PwiDp4wBZWMCIy29eKkv8moTKRrpiSDlrc+GQMSZLhOAm8T33JKKXPwD/2EbplbhCygJDGXZdtEKl9x9PaH66A==",
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "peer": true,
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.3.7.tgz",
-      "integrity": "sha512-/xkjmTyv+bbJ4akBCW0qzFKxPOV4AqLOmqurov+s9umHb16oOv72osSa3SdzJED2gHDaKmpMITT4crxbar4Axg==",
-      "cpu": [
-        "x64"
-      ],
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.3.8.tgz",
+      "integrity": "sha512-6AcvA/XKoipGap5jJmQ9Y6yT7Uf39D9lu2hBcDCXnXbMcXaDGw4mn1/L4R63D+9VGZyu1PqlcJixCUZlGGIWlg==",
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "peer": true,
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.3.7.tgz",
-      "integrity": "sha512-QwBP9xlmsbf/ldZDGLcE4QiAb8Zt46E/+WLpxHBATFhGa7MrpJh6Zse+h2VlrT/SYLPbh2cpHgSmoSlqVxWG9g==",
-      "cpu": [
-        "x64"
-      ],
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.3.8.tgz",
+      "integrity": "sha512-cxb0sEmZjlwhYWO28sPsV64VDx31ekskhC1IsDXU1p9ntjHSJRmW4KEIqJ2O3QwJap/kLKfMS6TckvY10gjc6w==",
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "peer": true,
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.3.7.tgz",
-      "integrity": "sha512-j/80DEnkxrF2ewdbk/gQ2EOPvgF0XSsg8D0o4+6cKhUVAW6XwtWKzIphNL6dyD2YaWEPgIrNvqiJK/aln0ww4Q==",
-      "cpu": [
-        "x64"
-      ],
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.3.8.tgz",
+      "integrity": "sha512-yVuVPqRRNLZk7TbBMkKw7lzCvI8XO8fNTPTYxymGadjr9rEGRuNTU1yBXjfJ59I1jJU/X2TSkRk1OFX0P5tpZQ==",
       "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
       "peer": true,
       "engines": {
         "node": ">= 18"
@@ -1423,9 +1415,9 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-ethers": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.5.tgz",
-      "integrity": "sha512-RNFe8OtbZK6Ila9kIlHp0+S80/0Bu/3p41HUpaRIoHLm6X3WekTd83vob3rE54Duufu1edCiBDxspBzi2rxHHw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.6.tgz",
+      "integrity": "sha512-/xzkFQAaHQhmIAYOQmvHBPwL+NkwLzT9gRZBsgWUYeV+E6pzXsBQsHfRYbAZ3XEYare+T7S+5Tg/1KDJgepSkA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -1438,14 +1430,14 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-ignition": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.2.tgz",
-      "integrity": "sha512-tdI+D+GwP8qBt3/sq0hGKk46lAfKnNj3ZtqxrNinOnQUfc3f9qXgZDFqWT2JudsmuQcuHFbn1FQ1zoDvjUVjRA==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.4.tgz",
+      "integrity": "sha512-x1lhLN9ZRSJ9eiNY9AoinMdeQeU4LDQSQOIw90W9DiZIG/g9YUzcTEIY58QTi2TZOF8YFiF6vJqLSePCpi8R1Q==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/ignition-core": "^0.15.2",
-        "@nomicfoundation/ignition-ui": "^0.15.2",
+        "@nomicfoundation/ignition-core": "^0.15.4",
+        "@nomicfoundation/ignition-ui": "^0.15.4",
         "chalk": "^4.0.0",
         "debug": "^4.3.2",
         "fs-extra": "^10.0.0",
@@ -1457,15 +1449,15 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-ignition-ethers": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.2.tgz",
-      "integrity": "sha512-rXkEpzl4ZNGfrht6ZFO+37dQvL+byrJaX7pNeSFzdKKqhEe4oboRwDWaBohQO+pCn837Qh/86xwwOFoGEv2+hg==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.4.tgz",
+      "integrity": "sha512-vY30V4b788GSziW/nOd0L/4IPw6mwpluahLs4+gPUUKWaHHGMA8OIeHaYpRRljM1i0M/Kg1yIozrDM/aeRebkg==",
       "dev": true,
       "peer": true,
       "peerDependencies": {
         "@nomicfoundation/hardhat-ethers": "^3.0.4",
-        "@nomicfoundation/hardhat-ignition": "^0.15.2",
-        "@nomicfoundation/ignition-core": "^0.15.2",
+        "@nomicfoundation/hardhat-ignition": "^0.15.4",
+        "@nomicfoundation/ignition-core": "^0.15.4",
         "ethers": "^6.7.0",
         "hardhat": "^2.18.0"
       }
@@ -1510,9 +1502,9 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-verify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.6.tgz",
-      "integrity": "sha512-oKUI5fl8QC8jysE2LUBHE6rObzEmccJcc4b43Ov7LFMlCBZJE27qoqGIsg/++wX7L8Jdga+bkejPxl8NvsecpQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.7.tgz",
+      "integrity": "sha512-jiYHBX+K6bBN0YhwFHQ5SWWc3dQZliM3pdgpH33C7tnsVACsX1ubZn6gZ9hfwlzG0tyjFM72XQhpaXQ56cE6Ew==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -1609,9 +1601,9 @@
       }
     },
     "node_modules/@nomicfoundation/ignition-core": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.2.tgz",
-      "integrity": "sha512-6kchZOBh6zSl0BgG1bs6+ZbNYlGjeH22yi72mgeOa0oNOYFqCpka9a4FEYv0gfcphsMMmKTMlxadanf02ZoE4w==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.4.tgz",
+      "integrity": "sha512-i379lH+xOLFdaDv0KiNma550ZXCHc5ZkmKYhM44xyLMKBlvX6skUVFkgUjjN1gvprgOIxc17GVQXlR1R5FhGZA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -1664,9 +1656,9 @@
       }
     },
     "node_modules/@nomicfoundation/ignition-ui": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.2.tgz",
-      "integrity": "sha512-NEX2prbfLEm45KbnBS0imvSgQgwLTgmT8zD3rAPmcIFZx+tLG4lKKw99k6EgEwmKwBiaO2zQMmt+FNoF7xGaiQ==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.4.tgz",
+      "integrity": "sha512-cHbmuxmhso5n2zdIaaIW4p8NNzrFj0mrnv8ufhAZfM3s3IFrRoGc1zo8hI/n1CiOTPuqUbdZcB79d+2tCKtCNw==",
       "dev": true,
       "peer": true
     },
@@ -1868,12 +1860,12 @@
       "integrity": "sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA=="
     },
     "node_modules/@openzeppelin/defender-admin-client": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-admin-client/-/defender-admin-client-1.54.1.tgz",
-      "integrity": "sha512-kRpSUdTsnSqntp4FOXIm95t+6VKHc8CUY2Si71VDuxs0q7HSPZkdpRPSntcolwEzWy9L4a8NS/QMwDF5NJ4X1g==",
+      "version": "1.54.4",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-admin-client/-/defender-admin-client-1.54.4.tgz",
+      "integrity": "sha512-WbHevtyrTTYIoCNO0jjdIZdQ1lAXZBIXXM4dhk/vqn3B7PnY+dvwjaR9YYEpZ/kjEQCcDUSm++njBJ/h7tTnhw==",
       "dev": true,
       "dependencies": {
-        "@openzeppelin/defender-base-client": "1.54.1",
+        "@openzeppelin/defender-base-client": "1.54.4",
         "axios": "^1.4.0",
         "ethers": "^5.7.2",
         "lodash": "^4.17.19",
@@ -1929,9 +1921,9 @@
       }
     },
     "node_modules/@openzeppelin/defender-base-client": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-base-client/-/defender-base-client-1.54.1.tgz",
-      "integrity": "sha512-DRGz/7KN3ZQwu28YWMOaojrC7jjPkz/uCwkC8/C8B11qwZhA5qIVvyhYHhhFOCl0J84+E3TNdvkPD2q3p2WaJw==",
+      "version": "1.54.4",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-base-client/-/defender-base-client-1.54.4.tgz",
+      "integrity": "sha512-LEDiHFI8BavbjVjR/H8IJSyw0Dlr2NTiutTwMIJk6QKtQ1ZlTuUktl+tBzl3Fe3SpLiaBZvqYx4/3tN0byeE4Q==",
       "dev": true,
       "dependencies": {
         "amazon-cognito-identity-js": "^6.0.1",
@@ -1942,9 +1934,9 @@
       }
     },
     "node_modules/@openzeppelin/defender-sdk-base-client": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-sdk-base-client/-/defender-sdk-base-client-1.12.0.tgz",
-      "integrity": "sha512-6n5SwJWCjFciC+T7QhfXnkEmkNZGKK0efkCZDAfu/Kd8L1AICnIkWwVte71dnzCBln7wglMiZupSHL3fZqePmQ==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-sdk-base-client/-/defender-sdk-base-client-1.13.1.tgz",
+      "integrity": "sha512-FI7YdfgDf0px+cXbXyDkS0mpqzyySHeLkKj90ymzAy1/sGYKHNC03vyzMnMfIRuxa4bF15wdL4MCpA60PSWGpQ==",
       "dev": true,
       "dependencies": {
         "amazon-cognito-identity-js": "^6.3.6",
@@ -1952,23 +1944,23 @@
       }
     },
     "node_modules/@openzeppelin/defender-sdk-deploy-client": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-sdk-deploy-client/-/defender-sdk-deploy-client-1.12.0.tgz",
-      "integrity": "sha512-E1RTyh0kXGRJJy7Kq/qSjQlyHJmtytLLKGHIVbI4Ijo9vwRZ7FZhZgK9lapJNshS4E1p3WgXHSOUJtOfn3F1bg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-sdk-deploy-client/-/defender-sdk-deploy-client-1.13.1.tgz",
+      "integrity": "sha512-zQEoURBRMknrOXLDNzK3gXiHfQbDImLKtEVPBOybya/MYqququBdNkRmPpSkJ45LHVbuxWyqRkkGFQp8+l/UQg==",
       "dev": true,
       "dependencies": {
-        "@openzeppelin/defender-sdk-base-client": "^1.12.0",
+        "@openzeppelin/defender-sdk-base-client": "^1.13.1",
         "axios": "^1.6.7",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@openzeppelin/defender-sdk-network-client": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-sdk-network-client/-/defender-sdk-network-client-1.12.0.tgz",
-      "integrity": "sha512-0dlEHC27hOVRY+iVcoP2zH8K0jy4O+sOGKz2Ep9eebNcWc7GO6z1wsc4fU51AoiMh+G7cYb+l5z1wQ4Q3Y9vIA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-sdk-network-client/-/defender-sdk-network-client-1.13.1.tgz",
+      "integrity": "sha512-QR9dTZ6MuJ5o+GwAKH4Hxy+xuElI0iCwpVqN/ntHG0Ar7neHoq/f7jPtk04/DgEmrwTUMLzTKpZWmUO1fxiEMA==",
       "dev": true,
       "dependencies": {
-        "@openzeppelin/defender-sdk-base-client": "^1.12.0",
+        "@openzeppelin/defender-sdk-base-client": "^1.13.1",
         "axios": "^1.6.7",
         "lodash": "^4.17.21"
       }
@@ -2007,9 +1999,9 @@
       }
     },
     "node_modules/@openzeppelin/hardhat-upgrades/node_modules/undici": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.15.0.tgz",
-      "integrity": "sha512-VviMt2tlMg1BvQ0FKXxrz1eJuyrcISrL2sPfBf7ZskX/FCEc/7LeThQaoygsMJpNqrATWQIsRVx+1Dpe4jaYuQ==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.18.0.tgz",
+      "integrity": "sha512-nT8jjv/fE9Et1ilR6QoW8ingRTY2Pp4l2RUrdzV5Yz35RJDrtPc1DXvuNqcpsJSGIRHFdt3YKKktTzJA6r0fTA==",
       "dev": true,
       "engines": {
         "node": ">=18.17"
@@ -2221,15 +2213,15 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/types/node_modules/tslib": {
@@ -2249,86 +2241,85 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.8.0.tgz",
-      "integrity": "sha512-JRR0lCDU97AiE0X6qTc/uf8Hv0yETUdyJgoNzTLUIWdhVJVe/KGPnFmEsO1iXfNUIS6vhv3JJ5vaZ2qtXhZe1g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.1.0.tgz",
+      "integrity": "sha512-cBBowKP2u/+uE5CzgH5w8pE9VKqcM7BXdIDPIbGt2rmLJGnA6MJPr9vYGaqgMoJFs7R/FzsMQerMvvEP40g2uw==",
       "dev": true,
       "dependencies": {
-        "@stylistic/eslint-plugin-js": "1.8.0",
-        "@stylistic/eslint-plugin-jsx": "1.8.0",
-        "@stylistic/eslint-plugin-plus": "1.8.0",
-        "@stylistic/eslint-plugin-ts": "1.8.0",
+        "@stylistic/eslint-plugin-js": "2.1.0",
+        "@stylistic/eslint-plugin-jsx": "2.1.0",
+        "@stylistic/eslint-plugin-plus": "2.1.0",
+        "@stylistic/eslint-plugin-ts": "2.1.0",
         "@types/eslint": "^8.56.10"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
       }
     },
     "node_modules/@stylistic/eslint-plugin-js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.8.0.tgz",
-      "integrity": "sha512-jdvnzt+pZPg8TfclZlTZPiUbbima93ylvQ+wNgHLNmup3obY6heQvgewSu9i2CfS61BnRByv+F9fxQLPoNeHag==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.1.0.tgz",
+      "integrity": "sha512-gdXUjGNSsnY6nPyqxu6lmDTtVrwCOjun4x8PUn0x04d5ucLI74N3MT1Q0UhdcOR9No3bo5PGDyBgXK+KmD787A==",
       "dev": true,
       "dependencies": {
         "@types/eslint": "^8.56.10",
         "acorn": "^8.11.3",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1"
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.0.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
       }
     },
     "node_modules/@stylistic/eslint-plugin-jsx": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.8.0.tgz",
-      "integrity": "sha512-PC7tYXipF03TTilGJva1amAham7qOAFXT5r5jLTY6iIxkFqyb6H7Ljx5pv8d7n98VyIVidOEKY/AP8vNzAFNKg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-2.1.0.tgz",
+      "integrity": "sha512-mMD7S+IndZo2vxmwpHVTCwx2O1VdtE5tmpeNwgaEcXODzWV1WTWpnsc/PECQKIr/mkLPFWiSIqcuYNhQ/3l6AQ==",
       "dev": true,
       "dependencies": {
-        "@stylistic/eslint-plugin-js": "^1.8.0",
+        "@stylistic/eslint-plugin-js": "^2.1.0",
         "@types/eslint": "^8.56.10",
         "estraverse": "^5.3.0",
         "picomatch": "^4.0.2"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
       }
     },
     "node_modules/@stylistic/eslint-plugin-plus": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.8.0.tgz",
-      "integrity": "sha512-TkrjzzYmTuAaLvFwtxomsgMUD8g8PREOQOQzTfKmiJ6oc4XOyFW4q/L9ES1J3UFSLybNCwbhu36lhXJut1w2Sg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-2.1.0.tgz",
+      "integrity": "sha512-S5QAlgYXESJaSBFhBSBLZy9o36gXrXQwWSt6QkO+F0SrT9vpV5JF/VKoh+ojO7tHzd8Ckmyouq02TT9Sv2B0zQ==",
       "dev": true,
       "dependencies": {
         "@types/eslint": "^8.56.10",
-        "@typescript-eslint/utils": "^6.21.0"
+        "@typescript-eslint/utils": "^7.8.0"
       },
       "peerDependencies": {
         "eslint": "*"
       }
     },
     "node_modules/@stylistic/eslint-plugin-ts": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.8.0.tgz",
-      "integrity": "sha512-WuCIhz4JEHxzhAWjrBASMGj6Or1wAjDqTsRIck3DRRrw/FJ8C/8AAuHPk8ECHNSDI5PZ0OT72nF2uSUn0aQq1w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.1.0.tgz",
+      "integrity": "sha512-2ioFibufHYBALx2TBrU4KXovCkN8qCqcb9yIHc0fyOfTaO5jw4d56WW7YRcF3Zgde6qFyXwAN6z/+w4pnmos1g==",
       "dev": true,
       "dependencies": {
-        "@stylistic/eslint-plugin-js": "1.8.0",
+        "@stylistic/eslint-plugin-js": "2.1.0",
         "@types/eslint": "^8.56.10",
-        "@typescript-eslint/utils": "^6.21.0"
+        "@typescript-eslint/utils": "^7.8.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
@@ -2420,9 +2411,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.15",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.15.tgz",
-      "integrity": "sha512-PYVSvyeZqy9++MoSegq88PxoPndWDDLGbJmE/OZnzUk3D4cCRTmA4N6EX3g0GgLVA+vtys7bj4luhkVCglGTkQ==",
+      "version": "4.3.16",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.16.tgz",
+      "integrity": "sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==",
       "dev": true,
       "peer": true
     },
@@ -2511,9 +2502,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.8.tgz",
-      "integrity": "sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==",
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -2551,28 +2542,20 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.8.0.tgz",
-      "integrity": "sha512-gFTT+ezJmkwutUPmB0skOj3GZJtlEGnlssems4AjkVweUPGj7jRwwqg0Hhg7++kPGJqKtTYx+R05Ftww372aIg==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.10.0.tgz",
+      "integrity": "sha512-PzCr+a/KAef5ZawX7nbyNwBDtM1HdLIT53aSA2DDlxmxMngZ43O8SIePOeX8H5S+FHXeI6t97mTt/dDdzY4Fyw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.8.0",
-        "@typescript-eslint/type-utils": "7.8.0",
-        "@typescript-eslint/utils": "7.8.0",
-        "@typescript-eslint/visitor-keys": "7.8.0",
-        "debug": "^4.3.4",
+        "@typescript-eslint/scope-manager": "7.10.0",
+        "@typescript-eslint/type-utils": "7.10.0",
+        "@typescript-eslint/utils": "7.10.0",
+        "@typescript-eslint/visitor-keys": "7.10.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "semver": "^7.6.0",
         "ts-api-utils": "^1.3.0"
       },
       "engines": {
@@ -2592,56 +2575,16 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.8.0.tgz",
-      "integrity": "sha512-L0yFqOCflVqXxiZyXrDr80lnahQfSOfc9ELAAZ75sqicqp2i36kEZZGuUymHNFoYOqxRT05up760b4iGsl02nQ==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.15",
-        "@types/semver": "^7.5.8",
-        "@typescript-eslint/scope-manager": "7.8.0",
-        "@typescript-eslint/types": "7.8.0",
-        "@typescript-eslint/typescript-estree": "7.8.0",
-        "semver": "^7.6.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.8.0.tgz",
-      "integrity": "sha512-KgKQly1pv0l4ltcftP59uQZCi4HUYswCLbTqVZEJu7uLX8CTLyswqMLqLN+2QFz4jCptqWVV4SB7vdxcH2+0kQ==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.10.0.tgz",
+      "integrity": "sha512-2EjZMA0LUW5V5tGQiaa2Gys+nKdfrn2xiTIBLR4fxmPmVSvgPcKNW+AE/ln9k0A4zDUti0J/GZXMDupQoI+e1w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.8.0",
-        "@typescript-eslint/types": "7.8.0",
-        "@typescript-eslint/typescript-estree": "7.8.0",
-        "@typescript-eslint/visitor-keys": "7.8.0",
+        "@typescript-eslint/scope-manager": "7.10.0",
+        "@typescript-eslint/types": "7.10.0",
+        "@typescript-eslint/typescript-estree": "7.10.0",
+        "@typescript-eslint/visitor-keys": "7.10.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2661,13 +2604,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.8.0.tgz",
-      "integrity": "sha512-viEmZ1LmwsGcnr85gIq+FCYI7nO90DVbE37/ll51hjv9aG+YZMb4WDE2fyWpUR4O/UrhGRpYXK/XajcGTk2B8g==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.10.0.tgz",
+      "integrity": "sha512-7L01/K8W/VGl7noe2mgH0K7BE29Sq6KAbVmxurj8GGaPDZXPr8EEQ2seOeAS+mEV9DnzxBQB6ax6qQQ5C6P4xg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.8.0",
-        "@typescript-eslint/visitor-keys": "7.8.0"
+        "@typescript-eslint/types": "7.10.0",
+        "@typescript-eslint/visitor-keys": "7.10.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -2678,13 +2621,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.8.0.tgz",
-      "integrity": "sha512-H70R3AefQDQpz9mGv13Uhi121FNMh+WEaRqcXTX09YEDky21km4dV1ZXJIp8QjXc4ZaVkXVdohvWDzbnbHDS+A==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.10.0.tgz",
+      "integrity": "sha512-D7tS4WDkJWrVkuzgm90qYw9RdgBcrWmbbRkrLA4d7Pg3w0ttVGDsvYGV19SH8gPR5L7OtcN5J1hTtyenO9xE9g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.8.0",
-        "@typescript-eslint/utils": "7.8.0",
+        "@typescript-eslint/typescript-estree": "7.10.0",
+        "@typescript-eslint/utils": "7.10.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -2704,50 +2647,10 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.8.0.tgz",
-      "integrity": "sha512-L0yFqOCflVqXxiZyXrDr80lnahQfSOfc9ELAAZ75sqicqp2i36kEZZGuUymHNFoYOqxRT05up760b4iGsl02nQ==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.15",
-        "@types/semver": "^7.5.8",
-        "@typescript-eslint/scope-manager": "7.8.0",
-        "@typescript-eslint/types": "7.8.0",
-        "@typescript-eslint/typescript-estree": "7.8.0",
-        "semver": "^7.6.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.8.0.tgz",
-      "integrity": "sha512-wf0peJ+ZGlcH+2ZS23aJbOv+ztjeeP8uQ9GgwMJGVLx/Nj9CJt17GWgWWoSmoRVKAX2X+7fzEnAjxdvK2gqCLw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.10.0.tgz",
+      "integrity": "sha512-7fNj+Ya35aNyhuqrA1E/VayQX9Elwr8NKZ4WueClR3KwJ7Xx9jcCdOrLW04h51de/+gNbyFMs+IDxh5xIwfbNg==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -2758,13 +2661,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.8.0.tgz",
-      "integrity": "sha512-5pfUCOwK5yjPaJQNy44prjCwtr981dO8Qo9J9PwYXZ0MosgAbfEMB008dJ5sNo3+/BN6ytBPuSvXUg9SAqB0dg==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.10.0.tgz",
+      "integrity": "sha512-LXFnQJjL9XIcxeVfqmNj60YhatpRLt6UhdlFwAkjNc6jSUlK8zQOl1oktAP8PlWFzPQC1jny/8Bai3/HPuvN5g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.8.0",
-        "@typescript-eslint/visitor-keys": "7.8.0",
+        "@typescript-eslint/types": "7.10.0",
+        "@typescript-eslint/visitor-keys": "7.10.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2786,13 +2689,10 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2801,142 +2701,34 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.10.0.tgz",
+      "integrity": "sha512-olzif1Fuo8R8m/qKkzJqT7qwy16CzPRWBvERS0uvyc+DHd8AKbO4Jb7kpAvVzMmZm8TrHnI7hvjN4I05zow+tg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "semver": "^7.5.4"
+        "@typescript-eslint/scope-manager": "7.10.0",
+        "@typescript-eslint/types": "7.10.0",
+        "@typescript-eslint/typescript-estree": "7.10.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
-      "dev": true,
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "eslint": "^8.56.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.8.0.tgz",
-      "integrity": "sha512-q4/gibTNBQNA0lGyYQCmWRS5D15n8rXh4QjK3KV+MBPlTYHpfBUT3D3PaPR/HeNiI9W6R7FvlkcGhNyAoP+caA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.10.0.tgz",
+      "integrity": "sha512-9ntIVgsi6gg6FIq9xjEO4VQJvwOqA3jaBFQJ/6TK5AvEup2+cECI6Fh7QiBxmfMHXU0V0J4RyPeOU1VDNzl9cg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.8.0",
+        "@typescript-eslint/types": "7.10.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -2945,6 +2737,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -3357,9 +3161,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.1.tgz",
+      "integrity": "sha512-+LV37nQcd1EpFalkXksWNBiA17NZ5m5/WspmHGmZmdx1qBOg/VNq/c4eRJiA9VQQHBOs+N0ZhhdU10h2TyNK7Q==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -3466,12 +3270,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -3639,16 +3443,16 @@
       }
     },
     "node_modules/chai-as-promised": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
+      "integrity": "sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "check-error": "^1.0.2"
       },
       "peerDependencies": {
-        "chai": ">= 2.1.2 < 5"
+        "chai": ">= 2.1.2 < 6"
       }
     },
     "node_modules/chalk": {
@@ -3769,9 +3573,9 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.4.tgz",
-      "integrity": "sha512-Lm3L0p+/npIQWNIiyF/nAn7T5dnOwR3xNTHXYEBFBFVPXzCVNZ5lqEC/1eo/EVfpDsQ1I+TX4ORPQgp+UI0CRw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
       "dev": true,
       "dependencies": {
         "string-width": "^4.2.0"
@@ -4710,12 +4514,12 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
       "dev": true,
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4731,6 +4535,35 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4744,17 +4577,17 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
+      "integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.11.3",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
+        "eslint-visitor-keys": "^4.0.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -5290,9 +5123,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -5850,15 +5683,15 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.22.3",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.3.tgz",
-      "integrity": "sha512-k8JV2ECWNchD6ahkg2BR5wKVxY0OiKot7fuxiIpRK0frRqyOljcR2vKwgWSLw6YIeDcNNA4xybj7Og7NSxr2hA==",
+      "version": "2.22.4",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.4.tgz",
+      "integrity": "sha512-09qcXJFBHQUaraJkYNr7XlmwjOj27xBB0SL2rYS024hTj9tPMbp26AFjlf5quBMO9SR4AJFg+4qWahcYcvXBuQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/edr": "^0.3.5",
+        "@nomicfoundation/edr": "^0.3.7",
         "@nomicfoundation/ethereumjs-common": "4.0.4",
         "@nomicfoundation/ethereumjs-tx": "5.0.4",
         "@nomicfoundation/ethereumjs-util": "9.0.4",
@@ -6455,9 +6288,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
-      "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
+      "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
       "dev": true,
       "peer": true
     },
@@ -7099,18 +6932,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -7163,28 +6984,16 @@
       "peer": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.6.tgz",
+      "integrity": "sha512-Y4Ypn3oujJYxJcMacVgcs92wofTHxp9FzfDpQON4msDefoC0lb3ETvQLOdLcbhSwU1bz8HrL/1sygfBIHudrkQ==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
+        "braces": "^3.0.3",
+        "picomatch": "^4.0.2"
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime-db": {
@@ -7869,13 +7678,10 @@
       "dev": true
     },
     "node_modules/prettier-plugin-solidity/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8949,14 +8755,11 @@
       }
     },
     "node_modules/solidity-coverage/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
       "peer": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -10149,12 +9952,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,26 +8,24 @@
         "@openzeppelin/contracts-upgradeable": "4.9.6"
       },
       "devDependencies": {
-        "@nomicfoundation/hardhat-toolbox": "^2.0.2",
-        "@openzeppelin/hardhat-upgrades": "^1.28.0",
-        "@stylistic/eslint-plugin": "^1.5.4",
-        "@typescript-eslint/eslint-plugin": "^6.19.0",
-        "@typescript-eslint/parser": "^6.19.0",
+        "@nomicfoundation/hardhat-toolbox": "^5.0.0",
+        "@openzeppelin/hardhat-upgrades": "^3.1.0",
+        "@stylistic/eslint-plugin": "^1.8.0",
+        "@typescript-eslint/eslint-plugin": "^7.8.0",
+        "@typescript-eslint/parser": "^7.8.0",
         "dotenv": "^16.4.5",
-        "eslint": "^8.56.0",
+        "eslint": "^8.57.0",
         "hardhat-contract-sizer": "^2.10.0",
-        "prettier": "^3.2.4",
+        "prettier": "^3.2.5",
         "prettier-plugin-solidity": "^1.3.1"
       }
     },
-    "node_modules/@aashutoshrathi/word-wrap": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "peer": true
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "1.2.2",
@@ -52,16 +50,16 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.535.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
       "dev": true,
       "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/types/node_modules/tslib": {
@@ -214,6 +212,32 @@
         "node": ">=14"
       }
     },
+    "node_modules/@ethereumjs/util/node_modules/@noble/curves": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.3.3"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@ethereumjs/util/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@ethereumjs/util/node_modules/ethereum-cryptography": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.1.3.tgz",
@@ -359,7 +383,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/properties": "^5.7.0"
@@ -439,7 +462,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/abstract-provider": "^5.7.0",
@@ -495,7 +517,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/basex": "^5.7.0",
@@ -526,7 +547,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/address": "^5.7.0",
@@ -542,6 +562,12 @@
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
+    },
+    "node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "dev": true
     },
     "node_modules/@ethersproject/keccak256": {
       "version": "5.7.0",
@@ -613,7 +639,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/sha2": "^5.7.0"
@@ -653,7 +678,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -677,6 +701,27 @@
         "ws": "7.4.6"
       }
     },
+    "node_modules/@ethersproject/providers/node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ethersproject/random": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
@@ -692,7 +737,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0"
@@ -733,7 +777,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
@@ -779,7 +822,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -852,7 +894,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/constants": "^5.7.0",
@@ -874,7 +915,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -931,7 +971,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/hash": "^5.7.0",
@@ -1000,9 +1039,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
-      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1084,22 +1123,22 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
-      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@noble/hashes": "1.3.3"
+        "@noble/hashes": "1.3.2"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
-      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -1158,30 +1197,28 @@
       }
     },
     "node_modules/@nomicfoundation/edr": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.3.2.tgz",
-      "integrity": "sha512-HGWtjibAK1mo4I2A7nJ/fXqe/J9G54OrSPJnnkY2K8TiXotYLShGd9GvHkae3PuFjTJKm6ZgBy7tveJj5yrCfw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.3.7.tgz",
+      "integrity": "sha512-v2JFWnFKRsnOa6PDUrD+sr8amcdhxnG/YbL7LzmgRGU1odWEyOF4/EwNeUajQr4ZNKVWrYnJ6XjydXtUge5OBQ==",
       "dev": true,
       "peer": true,
       "engines": {
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@nomicfoundation/edr-darwin-arm64": "0.3.2",
-        "@nomicfoundation/edr-darwin-x64": "0.3.2",
-        "@nomicfoundation/edr-linux-arm64-gnu": "0.3.2",
-        "@nomicfoundation/edr-linux-arm64-musl": "0.3.2",
-        "@nomicfoundation/edr-linux-x64-gnu": "0.3.2",
-        "@nomicfoundation/edr-linux-x64-musl": "0.3.2",
-        "@nomicfoundation/edr-win32-arm64-msvc": "0.3.2",
-        "@nomicfoundation/edr-win32-ia32-msvc": "0.3.2",
-        "@nomicfoundation/edr-win32-x64-msvc": "0.3.2"
+        "@nomicfoundation/edr-darwin-arm64": "0.3.7",
+        "@nomicfoundation/edr-darwin-x64": "0.3.7",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.3.7",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.3.7",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.3.7",
+        "@nomicfoundation/edr-linux-x64-musl": "0.3.7",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.3.7"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-arm64": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.3.2.tgz",
-      "integrity": "sha512-l6wfSBUUbGJiCENT6272CDI8yoMuf0sZH56H5qz3HnAyVzenkOvmzyF6/lar54m986kdAQqWls4cLvDxiOuLxg==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.3.7.tgz",
+      "integrity": "sha512-6tK9Lv/lSfyBvpEQ4nsTfgxyDT1y1Uv/x8Wa+aB+E8qGo3ToexQ1BMVjxJk6PChXCDOWxB3B4KhqaZFjdhl3Ow==",
       "cpu": [
         "arm64"
       ],
@@ -1196,9 +1233,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-x64": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.3.2.tgz",
-      "integrity": "sha512-OboExL7vEw+TRJQl3KkaEKU4K7PTdZPTInZ0fxMAtOpcWp7EKR+dQo68vc/iAOusB3xszHKxt7t+WpisItfdcg==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.3.7.tgz",
+      "integrity": "sha512-1RrQ/1JPwxrYO69e0tglFv5H+ggour5Ii3bb727+yBpBShrxtOTQ7fZyfxA5h62LCN+0Z9wYOPeQ7XFcVurMaQ==",
       "cpu": [
         "x64"
       ],
@@ -1213,9 +1250,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.3.2.tgz",
-      "integrity": "sha512-xtEK+1eg++3pHi6405NDXd80S3CGOFEGQIyVGCwjMGQFOLSzBGGCsrb/0GB4J19zd1o/8ftCd/HjZcbVAWWTLQ==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.3.7.tgz",
+      "integrity": "sha512-ds/CKlBoVXIihjhflhgPn13EdKWed6r5bgvMs/YwRqT5wldQAQJZWAfA2+nYm0Yi2gMGh1RUpBcfkyl4pq7G+g==",
       "cpu": [
         "arm64"
       ],
@@ -1230,9 +1267,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.3.2.tgz",
-      "integrity": "sha512-3cIsskJOXQ1yEVsImmCacY7O03tUTiWrmd54F05PnPFrDLkjbzodQ3b2gUWzfbzUZWl67ZTJd1CvVSzpe7XGzw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.3.7.tgz",
+      "integrity": "sha512-e29udiRaPujhLkM3+R6ju7QISrcyOqpcaxb2FsDWBkuD7H8uU9JPZEyyUIpEp5uIY0Jh1eEJPKZKIXQmQAEAuw==",
       "cpu": [
         "arm64"
       ],
@@ -1247,9 +1284,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.3.2.tgz",
-      "integrity": "sha512-ouPdphHNsyO7wqwa4hwahC5WqBglK/fIvMmhR/SXNZ9qruIpsA8ZZKIURaHMOv/2h2BbNGcyTX9uEk6+5rK/MQ==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.3.7.tgz",
+      "integrity": "sha512-/xkjmTyv+bbJ4akBCW0qzFKxPOV4AqLOmqurov+s9umHb16oOv72osSa3SdzJED2gHDaKmpMITT4crxbar4Axg==",
       "cpu": [
         "x64"
       ],
@@ -1264,9 +1301,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.3.2.tgz",
-      "integrity": "sha512-sRhwhiPbkpJMOUwXW1FZw9ks6xWyQhIhM0E8o3TXEXKSPKTE6whQLEk1R37iFITaI36vb6rSwLKTU1cb32gCoA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.3.7.tgz",
+      "integrity": "sha512-QwBP9xlmsbf/ldZDGLcE4QiAb8Zt46E/+WLpxHBATFhGa7MrpJh6Zse+h2VlrT/SYLPbh2cpHgSmoSlqVxWG9g==",
       "cpu": [
         "x64"
       ],
@@ -1280,44 +1317,10 @@
         "node": ">= 18"
       }
     },
-    "node_modules/@nomicfoundation/edr-win32-arm64-msvc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-arm64-msvc/-/edr-win32-arm64-msvc-0.3.2.tgz",
-      "integrity": "sha512-IEwVealKfumu1HSSnama26yPuQC/uthRPK5IWtFsQUOGwOXaS1r9Bu7cGYH2jBHl3IT/JbxD4xzPq/2pM9uK0A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/edr-win32-ia32-msvc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-ia32-msvc/-/edr-win32-ia32-msvc-0.3.2.tgz",
-      "integrity": "sha512-jYMnf6SFgguqROswwdsjJ1wvneD/5c16pVu9OD4DxNqhKNP5bHEw6L2N4DcJ89tpXMpJ6AlOpc0QuwzddiZ3tA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.3.2.tgz",
-      "integrity": "sha512-Byn4QuWczRy/DUUQM3WjglgX/jGVUURVFaUsmIhnGg//MPlCLawubBGRqsrMuvaYedlIIJ4I2rgKvZlxdgHrqg==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.3.7.tgz",
+      "integrity": "sha512-j/80DEnkxrF2ewdbk/gQ2EOPvgF0XSsg8D0o4+6cKhUVAW6XwtWKzIphNL6dyD2YaWEPgIrNvqiJK/aln0ww4Q==",
       "cpu": [
         "x64"
       ],
@@ -1401,23 +1404,70 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-chai-matchers": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-1.0.6.tgz",
-      "integrity": "sha512-f5ZMNmabZeZegEfuxn/0kW+mm7+yV7VNDxLpMOMGXWFJ2l/Ct3QShujzDRF9cOkK9Ui/hbDeOWGZqyQALDXVCQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.6.tgz",
+      "integrity": "sha512-Te1Uyo9oJcTCF0Jy9dztaLpshmlpjLf2yPtWXlXuLjMt3RRSmJLm/+rKVTW6gfadAEs12U/it6D0ZRnnRGiICQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@ethersproject/abi": "^5.1.2",
         "@types/chai-as-promised": "^7.1.3",
         "chai-as-promised": "^7.1.1",
         "deep-eql": "^4.0.1",
         "ordinal": "^1.0.3"
       },
       "peerDependencies": {
-        "@nomiclabs/hardhat-ethers": "^2.0.0",
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
         "chai": "^4.2.0",
-        "ethers": "^5.0.0",
+        "ethers": "^6.1.0",
         "hardhat": "^2.9.4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ethers": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.5.tgz",
+      "integrity": "sha512-RNFe8OtbZK6Ila9kIlHp0+S80/0Bu/3p41HUpaRIoHLm6X3WekTd83vob3rE54Duufu1edCiBDxspBzi2rxHHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "lodash.isequal": "^4.5.0"
+      },
+      "peerDependencies": {
+        "ethers": "^6.1.0",
+        "hardhat": "^2.0.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.2.tgz",
+      "integrity": "sha512-tdI+D+GwP8qBt3/sq0hGKk46lAfKnNj3ZtqxrNinOnQUfc3f9qXgZDFqWT2JudsmuQcuHFbn1FQ1zoDvjUVjRA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/ignition-core": "^0.15.2",
+        "@nomicfoundation/ignition-ui": "^0.15.2",
+        "chalk": "^4.0.0",
+        "debug": "^4.3.2",
+        "fs-extra": "^10.0.0",
+        "prompts": "^2.4.2"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-verify": "^2.0.1",
+        "hardhat": "^2.18.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition-ethers": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.2.tgz",
+      "integrity": "sha512-rXkEpzl4ZNGfrht6ZFO+37dQvL+byrJaX7pNeSFzdKKqhEe4oboRwDWaBohQO+pCn837Qh/86xwwOFoGEv2+hg==",
+      "dev": true,
+      "peer": true,
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^3.0.4",
+        "@nomicfoundation/hardhat-ignition": "^0.15.2",
+        "@nomicfoundation/ignition-core": "^0.15.2",
+        "ethers": "^6.7.0",
+        "hardhat": "^2.18.0"
       }
     },
     "node_modules/@nomicfoundation/hardhat-network-helpers": {
@@ -1434,31 +1484,191 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-toolbox": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-2.0.2.tgz",
-      "integrity": "sha512-vnN1AzxbvpSx9pfdRHbUzTRIXpMLPXnUlkW855VaDk6N1pwRaQ2gNzEmFAABk4lWf11E00PKwFd/q27HuwYrYg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-5.0.0.tgz",
+      "integrity": "sha512-FnUtUC5PsakCbwiVNsqlXVIWG5JIb5CEZoSXbJUsEBun22Bivx2jhF1/q9iQbzuaGpJKFQyOhemPB2+XlEE6pQ==",
       "dev": true,
       "peerDependencies": {
-        "@ethersproject/abi": "^5.4.7",
-        "@ethersproject/providers": "^5.4.7",
-        "@nomicfoundation/hardhat-chai-matchers": "^1.0.0",
+        "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "@nomicfoundation/hardhat-ignition-ethers": "^0.15.0",
         "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
-        "@nomiclabs/hardhat-ethers": "^2.0.0",
-        "@nomiclabs/hardhat-etherscan": "^3.0.0",
-        "@typechain/ethers-v5": "^10.1.0",
-        "@typechain/hardhat": "^6.1.2",
+        "@nomicfoundation/hardhat-verify": "^2.0.0",
+        "@typechain/ethers-v6": "^0.5.0",
+        "@typechain/hardhat": "^9.0.0",
         "@types/chai": "^4.2.0",
         "@types/mocha": ">=9.1.0",
-        "@types/node": ">=12.0.0",
+        "@types/node": ">=18.0.0",
         "chai": "^4.2.0",
-        "ethers": "^5.4.7",
+        "ethers": "^6.4.0",
         "hardhat": "^2.11.0",
         "hardhat-gas-reporter": "^1.0.8",
         "solidity-coverage": "^0.8.1",
         "ts-node": ">=8.0.0",
-        "typechain": "^8.1.0",
+        "typechain": "^8.3.0",
         "typescript": ">=4.5.0"
       }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.6.tgz",
+      "integrity": "sha512-oKUI5fl8QC8jysE2LUBHE6rObzEmccJcc4b43Ov7LFMlCBZJE27qoqGIsg/++wX7L8Jdga+bkejPxl8NvsecpQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.1.2",
+        "@ethersproject/address": "^5.0.2",
+        "cbor": "^8.1.0",
+        "chalk": "^2.4.2",
+        "debug": "^4.1.1",
+        "lodash.clonedeep": "^4.5.0",
+        "semver": "^6.3.0",
+        "table": "^6.8.0",
+        "undici": "^5.14.0"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@nomicfoundation/hardhat-verify/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.2.tgz",
+      "integrity": "sha512-6kchZOBh6zSl0BgG1bs6+ZbNYlGjeH22yi72mgeOa0oNOYFqCpka9a4FEYv0gfcphsMMmKTMlxadanf02ZoE4w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/address": "5.6.1",
+        "@nomicfoundation/solidity-analyzer": "^0.1.1",
+        "cbor": "^9.0.0",
+        "debug": "^4.3.2",
+        "ethers": "^6.7.0",
+        "fs-extra": "^10.0.0",
+        "immer": "10.0.2",
+        "lodash": "4.17.21",
+        "ndjson": "2.0.0"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/@ethersproject/address": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
+      "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.6.2",
+        "@ethersproject/bytes": "^5.6.1",
+        "@ethersproject/keccak256": "^5.6.1",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/rlp": "^5.6.1"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/cbor": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.2.tgz",
+      "integrity": "sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "nofilter": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-ui": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.2.tgz",
+      "integrity": "sha512-NEX2prbfLEm45KbnBS0imvSgQgwLTgmT8zD3rAPmcIFZx+tLG4lKKw99k6EgEwmKwBiaO2zQMmt+FNoF7xGaiQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@nomicfoundation/solidity-analyzer": {
       "version": "0.1.1",
@@ -1652,44 +1862,71 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@nomiclabs/hardhat-ethers": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.3.tgz",
-      "integrity": "sha512-YhzPdzb612X591FOe68q+qXVXGG2ANZRvDo0RRUtimev85rCrAlv/TLMEZw5c+kq9AbzocLTVX/h2jVIFPL9Xg==",
-      "dev": true,
-      "peer": true,
-      "peerDependencies": {
-        "ethers": "^5.0.0",
-        "hardhat": "^2.0.0"
-      }
-    },
-    "node_modules/@nomiclabs/hardhat-etherscan": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.8.tgz",
-      "integrity": "sha512-v5F6IzQhrsjHh6kQz4uNrym49brK9K5bYCq2zQZ729RYRaifI9hHbtmK+KkIVevfhut7huQFEQ77JLRMAzWYjQ==",
-      "deprecated": "The @nomiclabs/hardhat-etherscan package is deprecated, please use @nomicfoundation/hardhat-verify instead",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/abi": "^5.1.2",
-        "@ethersproject/address": "^5.0.2",
-        "cbor": "^8.1.0",
-        "chalk": "^2.4.2",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.1",
-        "lodash": "^4.17.11",
-        "semver": "^6.3.0",
-        "table": "^6.8.0",
-        "undici": "^5.14.0"
-      },
-      "peerDependencies": {
-        "hardhat": "^2.0.4"
-      }
-    },
     "node_modules/@openzeppelin/contracts-upgradeable": {
       "version": "4.9.6",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.6.tgz",
       "integrity": "sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA=="
+    },
+    "node_modules/@openzeppelin/defender-admin-client": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-admin-client/-/defender-admin-client-1.54.1.tgz",
+      "integrity": "sha512-kRpSUdTsnSqntp4FOXIm95t+6VKHc8CUY2Si71VDuxs0q7HSPZkdpRPSntcolwEzWy9L4a8NS/QMwDF5NJ4X1g==",
+      "dev": true,
+      "dependencies": {
+        "@openzeppelin/defender-base-client": "1.54.1",
+        "axios": "^1.4.0",
+        "ethers": "^5.7.2",
+        "lodash": "^4.17.19",
+        "node-fetch": "^2.6.0"
+      }
+    },
+    "node_modules/@openzeppelin/defender-admin-client/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
+      }
     },
     "node_modules/@openzeppelin/defender-base-client": {
       "version": "1.54.1",
@@ -1704,131 +1941,84 @@
         "node-fetch": "^2.6.0"
       }
     },
-    "node_modules/@openzeppelin/hardhat-upgrades": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.28.0.tgz",
-      "integrity": "sha512-7sb/Jf+X+uIufOBnmHR0FJVWuxEs2lpxjJnLNN6eCJCP8nD0v+Ot5lTOW2Qb/GFnh+fLvJtEkhkowz4ZQ57+zQ==",
+    "node_modules/@openzeppelin/defender-sdk-base-client": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-sdk-base-client/-/defender-sdk-base-client-1.12.0.tgz",
+      "integrity": "sha512-6n5SwJWCjFciC+T7QhfXnkEmkNZGKK0efkCZDAfu/Kd8L1AICnIkWwVte71dnzCBln7wglMiZupSHL3fZqePmQ==",
       "dev": true,
       "dependencies": {
-        "@openzeppelin/defender-base-client": "^1.46.0",
-        "@openzeppelin/platform-deploy-client": "^0.8.0",
-        "@openzeppelin/upgrades-core": "^1.27.0",
+        "amazon-cognito-identity-js": "^6.3.6",
+        "async-retry": "^1.3.3"
+      }
+    },
+    "node_modules/@openzeppelin/defender-sdk-deploy-client": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-sdk-deploy-client/-/defender-sdk-deploy-client-1.12.0.tgz",
+      "integrity": "sha512-E1RTyh0kXGRJJy7Kq/qSjQlyHJmtytLLKGHIVbI4Ijo9vwRZ7FZhZgK9lapJNshS4E1p3WgXHSOUJtOfn3F1bg==",
+      "dev": true,
+      "dependencies": {
+        "@openzeppelin/defender-sdk-base-client": "^1.12.0",
+        "axios": "^1.6.7",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@openzeppelin/defender-sdk-network-client": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-sdk-network-client/-/defender-sdk-network-client-1.12.0.tgz",
+      "integrity": "sha512-0dlEHC27hOVRY+iVcoP2zH8K0jy4O+sOGKz2Ep9eebNcWc7GO6z1wsc4fU51AoiMh+G7cYb+l5z1wQ4Q3Y9vIA==",
+      "dev": true,
+      "dependencies": {
+        "@openzeppelin/defender-sdk-base-client": "^1.12.0",
+        "axios": "^1.6.7",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@openzeppelin/hardhat-upgrades": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-3.1.0.tgz",
+      "integrity": "sha512-CQ5Cg2kE8WeW6qajUTacBsmkntiAwJd7f6p+BUtd1fEvEv7si4H2lmAqvjOjkFc9ihIEQxMBy50IsBXSZGktmg==",
+      "dev": true,
+      "dependencies": {
+        "@openzeppelin/defender-admin-client": "^1.52.0",
+        "@openzeppelin/defender-base-client": "^1.52.0",
+        "@openzeppelin/defender-sdk-base-client": "^1.10.0",
+        "@openzeppelin/defender-sdk-deploy-client": "^1.10.0",
+        "@openzeppelin/defender-sdk-network-client": "^1.10.0",
+        "@openzeppelin/upgrades-core": "^1.32.0",
         "chalk": "^4.1.0",
         "debug": "^4.1.1",
-        "proper-lockfile": "^4.1.1"
+        "ethereumjs-util": "^7.1.5",
+        "proper-lockfile": "^4.1.1",
+        "undici": "^6.11.1"
       },
       "bin": {
         "migrate-oz-cli-project": "dist/scripts/migrate-oz-cli-project.js"
       },
       "peerDependencies": {
-        "@nomiclabs/hardhat-ethers": "^2.0.0",
-        "@nomiclabs/hardhat-etherscan": "^3.1.0",
-        "ethers": "^5.0.5",
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "@nomicfoundation/hardhat-verify": "^2.0.0",
+        "ethers": "^6.6.0",
         "hardhat": "^2.0.2"
       },
       "peerDependenciesMeta": {
-        "@nomiclabs/harhdat-etherscan": {
+        "@nomicfoundation/hardhat-verify": {
           "optional": true
         }
       }
     },
-    "node_modules/@openzeppelin/hardhat-upgrades/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@openzeppelin/hardhat-upgrades/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@openzeppelin/hardhat-upgrades/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@openzeppelin/hardhat-upgrades/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@openzeppelin/hardhat-upgrades/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+    "node_modules/@openzeppelin/hardhat-upgrades/node_modules/undici": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.15.0.tgz",
+      "integrity": "sha512-VviMt2tlMg1BvQ0FKXxrz1eJuyrcISrL2sPfBf7ZskX/FCEc/7LeThQaoygsMJpNqrATWQIsRVx+1Dpe4jaYuQ==",
       "dev": true,
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@openzeppelin/hardhat-upgrades/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@openzeppelin/platform-deploy-client": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/platform-deploy-client/-/platform-deploy-client-0.8.0.tgz",
-      "integrity": "sha512-POx3AsnKwKSV/ZLOU/gheksj0Lq7Is1q2F3pKmcFjGZiibf+4kjGxr4eSMrT+2qgKYZQH1ZLQZ+SkbguD8fTvA==",
-      "deprecated": "@openzeppelin/platform-deploy-client is deprecated. Please use @openzeppelin/defender-sdk-deploy-client",
-      "dev": true,
-      "dependencies": {
-        "@ethersproject/abi": "^5.6.3",
-        "@openzeppelin/defender-base-client": "^1.46.0",
-        "axios": "^0.21.2",
-        "lodash": "^4.17.19",
-        "node-fetch": "^2.6.0"
-      }
-    },
-    "node_modules/@openzeppelin/platform-deploy-client/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/@openzeppelin/upgrades-core": {
-      "version": "1.32.5",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.32.5.tgz",
-      "integrity": "sha512-R0wprsyJ4xWiRW05kaTfZZkRVpG2g0af3/hpjE7t2mX0Eb2n40MQLokTwqIk4LDzpp910JfLSpB0vBuZ6WNPog==",
+      "version": "1.33.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.33.1.tgz",
+      "integrity": "sha512-YRxIRhTY1b+j7+NUUu8Uuem5ugxKexEMVd8dBRWNgWeoN1gS1OCrhgUg0ytL+54vzQ+SGWZDfNnzjVuI1Cj1Zw==",
       "dev": true,
       "dependencies": {
         "cbor": "^9.0.0",
@@ -1844,21 +2034,6 @@
         "openzeppelin-upgrades-core": "dist/cli/cli.js"
       }
     },
-    "node_modules/@openzeppelin/upgrades-core/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/@openzeppelin/upgrades-core/node_modules/cbor": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.2.tgz",
@@ -1869,61 +2044,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@openzeppelin/upgrades-core/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@openzeppelin/upgrades-core/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@openzeppelin/upgrades-core/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@openzeppelin/upgrades-core/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@openzeppelin/upgrades-core/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@scure/base": {
@@ -1946,6 +2066,32 @@
         "@noble/curves": "~1.3.0",
         "@noble/hashes": "~1.3.2",
         "@scure/base": "~1.1.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.3.3"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2103,16 +2249,16 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.7.0.tgz",
-      "integrity": "sha512-ThMUjGIi/jeWYNvOdjZkoLw1EOVs0tEuKXDgWvTn8uWaEz55HuPlajKxjKLpv19C+qRDbKczJfzUODfCdME53A==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.8.0.tgz",
+      "integrity": "sha512-JRR0lCDU97AiE0X6qTc/uf8Hv0yETUdyJgoNzTLUIWdhVJVe/KGPnFmEsO1iXfNUIS6vhv3JJ5vaZ2qtXhZe1g==",
       "dev": true,
       "dependencies": {
-        "@stylistic/eslint-plugin-js": "1.7.0",
-        "@stylistic/eslint-plugin-jsx": "1.7.0",
-        "@stylistic/eslint-plugin-plus": "1.7.0",
-        "@stylistic/eslint-plugin-ts": "1.7.0",
-        "@types/eslint": "^8.56.2"
+        "@stylistic/eslint-plugin-js": "1.8.0",
+        "@stylistic/eslint-plugin-jsx": "1.8.0",
+        "@stylistic/eslint-plugin-plus": "1.8.0",
+        "@stylistic/eslint-plugin-ts": "1.8.0",
+        "@types/eslint": "^8.56.10"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2122,12 +2268,12 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin-js": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.7.0.tgz",
-      "integrity": "sha512-PN6On/+or63FGnhhMKSQfYcWutRlzOiYlVdLM6yN7lquoBTqUJHYnl4TA4MHwiAt46X5gRxDr1+xPZ1lOLcL+Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.8.0.tgz",
+      "integrity": "sha512-jdvnzt+pZPg8TfclZlTZPiUbbima93ylvQ+wNgHLNmup3obY6heQvgewSu9i2CfS61BnRByv+F9fxQLPoNeHag==",
       "dev": true,
       "dependencies": {
-        "@types/eslint": "^8.56.2",
+        "@types/eslint": "^8.56.10",
         "acorn": "^8.11.3",
         "escape-string-regexp": "^4.0.0",
         "eslint-visitor-keys": "^3.4.3",
@@ -2141,15 +2287,15 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin-jsx": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.7.0.tgz",
-      "integrity": "sha512-BACdBwXakQvjYIST5N2WWhRbvhRsIxa/F59BiZol+0IH4FSmDXhie7v/yaxDIIA9CbfElzOmIA5nWNYTVXcnwQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.8.0.tgz",
+      "integrity": "sha512-PC7tYXipF03TTilGJva1amAham7qOAFXT5r5jLTY6iIxkFqyb6H7Ljx5pv8d7n98VyIVidOEKY/AP8vNzAFNKg==",
       "dev": true,
       "dependencies": {
-        "@stylistic/eslint-plugin-js": "^1.7.0",
-        "@types/eslint": "^8.56.2",
+        "@stylistic/eslint-plugin-js": "^1.8.0",
+        "@types/eslint": "^8.56.10",
         "estraverse": "^5.3.0",
-        "picomatch": "^4.0.1"
+        "picomatch": "^4.0.2"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2159,12 +2305,12 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin-plus": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.7.0.tgz",
-      "integrity": "sha512-AabDw8sXsc70Ydx3qnbeTlRHZnIwY6UKEenBPURPhY3bfYWX+/pDpZH40HkOu94v8D0DUrocPkeeEUxl4e0JDg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.8.0.tgz",
+      "integrity": "sha512-TkrjzzYmTuAaLvFwtxomsgMUD8g8PREOQOQzTfKmiJ6oc4XOyFW4q/L9ES1J3UFSLybNCwbhu36lhXJut1w2Sg==",
       "dev": true,
       "dependencies": {
-        "@types/eslint": "^8.56.2",
+        "@types/eslint": "^8.56.10",
         "@typescript-eslint/utils": "^6.21.0"
       },
       "peerDependencies": {
@@ -2172,13 +2318,13 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin-ts": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.7.0.tgz",
-      "integrity": "sha512-QsHv98mmW1xaucVYQTyLDgEpybPJ/6jPPxVBrIchntWWwj74xCWKUiw79hu+TpYj/Pbhd9rkqJYLNq3pQGYuyA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.8.0.tgz",
+      "integrity": "sha512-WuCIhz4JEHxzhAWjrBASMGj6Or1wAjDqTsRIck3DRRrw/FJ8C/8AAuHPk8ECHNSDI5PZ0OT72nF2uSUn0aQq1w==",
       "dev": true,
       "dependencies": {
-        "@stylistic/eslint-plugin-js": "1.7.0",
-        "@types/eslint": "^8.56.2",
+        "@stylistic/eslint-plugin-js": "1.8.0",
+        "@types/eslint": "^8.56.10",
         "@typescript-eslint/utils": "^6.21.0"
       },
       "engines": {
@@ -2189,9 +2335,9 @@
       }
     },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.10.tgz",
-      "integrity": "sha512-PiaIWIoPvO6qm6t114ropMCagj6YAF24j9OkCA2mJDXFnlionEwhsBCJ8yek4aib575BI3OkART/90WsgHgLWw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
       "dev": true,
       "peer": true
     },
@@ -2216,10 +2362,10 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/@typechain/ethers-v5": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-10.2.1.tgz",
-      "integrity": "sha512-n3tQmCZjRE6IU4h6lqUGiQ1j866n5MTCBJreNEHHVWXa2u9GJTaeYyU1/k+1qLutkyw+sS6VAN+AbeiTqsxd/A==",
+    "node_modules/@typechain/ethers-v6": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.5.1.tgz",
+      "integrity": "sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -2227,29 +2373,25 @@
         "ts-essentials": "^7.0.1"
       },
       "peerDependencies": {
-        "@ethersproject/abi": "^5.0.0",
-        "@ethersproject/providers": "^5.0.0",
-        "ethers": "^5.1.3",
-        "typechain": "^8.1.1",
-        "typescript": ">=4.3.0"
+        "ethers": "6.x",
+        "typechain": "^8.3.2",
+        "typescript": ">=4.7.0"
       }
     },
     "node_modules/@typechain/hardhat": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-6.1.6.tgz",
-      "integrity": "sha512-BiVnegSs+ZHVymyidtK472syodx1sXYlYJJixZfRstHVGYTi8V1O7QG4nsjyb0PC/LORcq7sfBUcHto1y6UgJA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-9.1.0.tgz",
+      "integrity": "sha512-mtaUlzLlkqTlfPwB3FORdejqBskSnh+Jl8AIJGjXNAQfRQ4ofHADPl1+oU7Z3pAJzmZbUXII8MhOLQltcHgKnA==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "fs-extra": "^9.1.0"
       },
       "peerDependencies": {
-        "@ethersproject/abi": "^5.4.7",
-        "@ethersproject/providers": "^5.4.7",
-        "@typechain/ethers-v5": "^10.2.1",
-        "ethers": "^5.4.7",
+        "@typechain/ethers-v6": "^0.5.1",
+        "ethers": "^6.1.0",
         "hardhat": "^2.9.9",
-        "typechain": "^8.1.1"
+        "typechain": "^8.3.2"
       }
     },
     "node_modules/@typechain/hardhat/node_modules/fs-extra": {
@@ -2268,29 +2410,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@typechain/hardhat/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@typechain/hardhat/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@types/bn.js": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
@@ -2301,9 +2420,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.14",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.14.tgz",
-      "integrity": "sha512-Wj71sXE4Q4AkGdG9Tvq1u/fquNz9EdG4LIJMwVVII7ashjD/8cf8fyIfJAjRr6YcsXnSE8cOGQPq1gqeR8z+3w==",
+      "version": "4.3.15",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.15.tgz",
+      "integrity": "sha512-PYVSvyeZqy9++MoSegq88PxoPndWDDLGbJmE/OZnzUk3D4cCRTmA4N6EX3g0GgLVA+vtys7bj4luhkVCglGTkQ==",
       "dev": true,
       "peer": true
     },
@@ -2328,9 +2447,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.56.6",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.6.tgz",
-      "integrity": "sha512-ymwc+qb1XkjT/gfoQwxIeHZ6ixH23A+tCT2ADSA/DPVKzAjwYkTXBMCQ/f6fe4wEa85Lhp26VPeUxI7wMhAi7A==",
+      "version": "8.56.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*",
@@ -2392,9 +2511,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
-      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "version": "20.12.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.8.tgz",
+      "integrity": "sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -2417,9 +2536,9 @@
       "peer": true
     },
     "node_modules/@types/qs": {
-      "version": "6.9.14",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
-      "integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==",
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
       "dev": true,
       "peer": true
     },
@@ -2439,38 +2558,63 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.8.0.tgz",
+      "integrity": "sha512-gFTT+ezJmkwutUPmB0skOj3GZJtlEGnlssems4AjkVweUPGj7jRwwqg0Hhg7++kPGJqKtTYx+R05Ftww372aIg==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/type-utils": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.8.0",
+        "@typescript-eslint/type-utils": "7.8.0",
+        "@typescript-eslint/utils": "7.8.0",
+        "@typescript-eslint/visitor-keys": "7.8.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.8.0.tgz",
+      "integrity": "sha512-L0yFqOCflVqXxiZyXrDr80lnahQfSOfc9ELAAZ75sqicqp2i36kEZZGuUymHNFoYOqxRT05up760b4iGsl02nQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.15",
+        "@types/semver": "^7.5.8",
+        "@typescript-eslint/scope-manager": "7.8.0",
+        "@typescript-eslint/types": "7.8.0",
+        "@typescript-eslint/typescript-estree": "7.8.0",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
@@ -2489,26 +2633,26 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.8.0.tgz",
+      "integrity": "sha512-KgKQly1pv0l4ltcftP59uQZCi4HUYswCLbTqVZEJu7uLX8CTLyswqMLqLN+2QFz4jCptqWVV4SB7vdxcH2+0kQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.8.0",
+        "@typescript-eslint/types": "7.8.0",
+        "@typescript-eslint/typescript-estree": "7.8.0",
+        "@typescript-eslint/visitor-keys": "7.8.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2517,16 +2661,16 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.8.0.tgz",
+      "integrity": "sha512-viEmZ1LmwsGcnr85gIq+FCYI7nO90DVbE37/ll51hjv9aG+YZMb4WDE2fyWpUR4O/UrhGRpYXK/XajcGTk2B8g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
+        "@typescript-eslint/types": "7.8.0",
+        "@typescript-eslint/visitor-keys": "7.8.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2534,25 +2678,25 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.8.0.tgz",
+      "integrity": "sha512-H70R3AefQDQpz9mGv13Uhi121FNMh+WEaRqcXTX09YEDky21km4dV1ZXJIp8QjXc4ZaVkXVdohvWDzbnbHDS+A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/typescript-estree": "7.8.0",
+        "@typescript-eslint/utils": "7.8.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2560,13 +2704,53 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.8.0.tgz",
+      "integrity": "sha512-L0yFqOCflVqXxiZyXrDr80lnahQfSOfc9ELAAZ75sqicqp2i36kEZZGuUymHNFoYOqxRT05up760b4iGsl02nQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.15",
+        "@types/semver": "^7.5.8",
+        "@typescript-eslint/scope-manager": "7.8.0",
+        "@typescript-eslint/types": "7.8.0",
+        "@typescript-eslint/typescript-estree": "7.8.0",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.8.0.tgz",
+      "integrity": "sha512-wf0peJ+ZGlcH+2ZS23aJbOv+ztjeeP8uQ9GgwMJGVLx/Nj9CJt17GWgWWoSmoRVKAX2X+7fzEnAjxdvK2gqCLw==",
       "dev": true,
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2574,22 +2758,22 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.8.0.tgz",
+      "integrity": "sha512-5pfUCOwK5yjPaJQNy44prjCwtr981dO8Qo9J9PwYXZ0MosgAbfEMB008dJ5sNo3+/BN6ytBPuSvXUg9SAqB0dg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/types": "7.8.0",
+        "@typescript-eslint/visitor-keys": "7.8.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2641,6 +2825,96 @@
         "eslint": "^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -2657,16 +2931,16 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.8.0.tgz",
+      "integrity": "sha512-q4/gibTNBQNA0lGyYQCmWRS5D15n8rXh4QjK3KV+MBPlTYHpfBUT3D3PaPR/HeNiI9W6R7FvlkcGhNyAoP+caA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "7.8.0",
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2728,9 +3002,9 @@
       }
     },
     "node_modules/aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
       "dev": true,
       "peer": true
     },
@@ -2860,16 +3134,18 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "color-convert": "^1.9.0"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/antlr4ts": {
@@ -3130,8 +3406,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -3179,82 +3454,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/boxen/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/boxen/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/boxen/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/boxen/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/boxen/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/boxen/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/brace-expansion": {
@@ -3453,28 +3652,19 @@
       }
     },
     "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chalk/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/charenc": {
@@ -3606,21 +3796,22 @@
       }
     },
     "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "peer": true
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/colors": {
       "version": "1.4.0",
@@ -3683,6 +3874,19 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/command-line-usage/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/command-line-usage/node_modules/array-back": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
@@ -3691,6 +3895,71 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/command-line-usage/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/command-line-usage/node_modules/typical": {
@@ -4127,9 +4396,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.2.tgz",
-      "integrity": "sha512-60s3Xv2T2p1ICykc7c+DNDPLDMm9t4QxCOUU0K9JxiLjM3C1zB9YVdN7tjxrFd4+AkZ8CdX1ovUga4P2+1e+/w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
+      "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
       "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -4171,11 +4440,11 @@
         "safe-regex-test": "^1.0.3",
         "string.prototype.trim": "^1.2.9",
         "string.prototype.trimend": "^1.0.8",
-        "string.prototype.trimstart": "^1.0.7",
+        "string.prototype.trimstart": "^1.0.8",
         "typed-array-buffer": "^1.0.2",
         "typed-array-byte-length": "^1.0.1",
         "typed-array-byte-offset": "^1.0.2",
-        "typed-array-length": "^1.0.5",
+        "typed-array-length": "^1.0.6",
         "unbox-primitive": "^1.0.2",
         "which-typed-array": "^1.1.15"
       },
@@ -4452,21 +4721,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4475,49 +4729,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/eslint/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
@@ -4530,18 +4741,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/eslint/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/espree": {
@@ -4735,6 +4934,55 @@
         "@scure/bip39": "1.1.1"
       }
     },
+    "node_modules/eth-gas-reporter/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
+      }
+    },
     "node_modules/eth-gas-reporter/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -4773,13 +5021,26 @@
       }
     },
     "node_modules/ethereum-bloom-filters": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
-      "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.1.0.tgz",
+      "integrity": "sha512-J1gDRkLpuGNvWYzWslBQR9cDV4nd4kfvVTE/Wy4Kkm4yb3EYRSlyi0eB/inTsSTTVyA0+HyzHgbr95Fn/Z1fSw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "js-sha3": "^0.8.0"
+        "@noble/hashes": "^1.4.0"
+      }
+    },
+    "node_modules/ethereum-bloom-filters/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ethereum-cryptography": {
@@ -4866,14 +5127,14 @@
       }
     },
     "node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.12.1.tgz",
+      "integrity": "sha512-j6wcVoZf06nqEcBbDWkKg8Fp895SS96dSnTCjiXT+8vt2o02raTn4Lo9ERUuIVU5bAjoPYeA+7ytQFexFmLuVw==",
       "dev": true,
       "funding": [
         {
           "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+          "url": "https://github.com/sponsors/ethers-io/"
         },
         {
           "type": "individual",
@@ -4882,37 +5143,31 @@
       ],
       "peer": true,
       "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/ethjs-unit": {
       "version": "0.1.6",
@@ -5156,18 +5411,18 @@
       "peer": true
     },
     "node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=12"
       }
     },
     "node_modules/fs-readdir-recursive": {
@@ -5314,6 +5569,84 @@
         "testrpc-sc": "index.js"
       }
     },
+    "node_modules/ghost-testrpc/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ghost-testrpc/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ghost-testrpc/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/ghost-testrpc/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/ghost-testrpc/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ghost-testrpc/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ghost-testrpc/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -5425,12 +5758,13 @@
       }
     },
     "node_modules/globalthis": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
       "dependencies": {
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5516,15 +5850,15 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.2.tgz",
-      "integrity": "sha512-0xZ7MdCZ5sJem4MrvpQWLR3R3zGDoHw5lsR+pBFimqwagimIOn3bWuZv69KA+veXClwI1s/zpqgwPwiFrd4Dxw==",
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.3.tgz",
+      "integrity": "sha512-k8JV2ECWNchD6ahkg2BR5wKVxY0OiKot7fuxiIpRK0frRqyOljcR2vKwgWSLw6YIeDcNNA4xybj7Og7NSxr2hA==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/edr": "^0.3.1",
+        "@nomicfoundation/edr": "^0.3.5",
         "@nomicfoundation/ethereumjs-common": "4.0.4",
         "@nomicfoundation/ethereumjs-tx": "5.0.4",
         "@nomicfoundation/ethereumjs-util": "9.0.4",
@@ -5596,76 +5930,6 @@
         "hardhat": "^2.0.0"
       }
     },
-    "node_modules/hardhat-contract-sizer/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/hardhat-contract-sizer/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/hardhat-contract-sizer/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/hardhat-contract-sizer/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/hardhat-contract-sizer/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/hardhat-contract-sizer/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/hardhat-gas-reporter": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.10.tgz",
@@ -5729,6 +5993,61 @@
         "@scure/base": "~1.1.0"
       }
     },
+    "node_modules/hardhat/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hardhat/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hardhat/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/hardhat/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/hardhat/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/hardhat/node_modules/ethereum-cryptography": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
@@ -5753,6 +6072,41 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/hardhat/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hardhat/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/hardhat/node_modules/locate-path": {
@@ -5805,6 +6159,51 @@
         "node": ">=4"
       }
     },
+    "node_modules/hardhat/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hardhat/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/hardhat/node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -5815,13 +6214,12 @@
       }
     },
     "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "peer": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -6043,6 +6441,17 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",
+      "integrity": "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==",
+      "dev": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/immutable": {
@@ -6504,12 +6913,22 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -6568,6 +6987,16 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -6609,6 +7038,20 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6637,82 +7080,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/log-symbols/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/log-symbols/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/log-symbols/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/loupe": {
@@ -6854,9 +7221,9 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -6901,9 +7268,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.3.0.tgz",
-      "integrity": "sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.4.0.tgz",
+      "integrity": "sha512-eqhGB8JKapEYcC4ytX/xrzKforgEc3j1pGlAXVy3eRwrtAy5/nIfT1SvgGzfN0XZZxeLq0aQWkOUAmqIJiv+bA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -7007,16 +7374,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/mocha/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/mocha/node_modules/minimatch": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -7065,6 +7422,26 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/ndjson": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
+      "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.5",
+        "readable-stream": "^3.6.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
+      },
+      "bin": {
+        "ndjson": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -7109,9 +7486,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
-      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
+      "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
       "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
@@ -7236,17 +7613,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "dependencies": {
-        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0"
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -7414,9 +7791,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.1.tgz",
-      "integrity": "sha512-xUXwsxNjwTQ8K3GnT4pCJm+xq3RUPQbmkYJTP5aFIfNIvbcc/4MUxgBaaRSZJ6yGJZiGSyYlM6MzwTsRk8SYCg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -7523,6 +7900,20 @@
         "asap": "~2.0.6"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -7559,9 +7950,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
-      "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -8286,6 +8677,13 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8312,42 +8710,6 @@
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
-    },
-    "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/solc": {
       "version": "0.7.3",
@@ -8436,9 +8798,9 @@
       "dev": true
     },
     "node_modules/solidity-coverage": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.11.tgz",
-      "integrity": "sha512-yy0Yk+olovBbXn0Me8BWULmmv7A69ZKkP5aTOJGOO8u61Tu2zS989erfjtFlUjDnfWtxRAVkd8BsQD704yLWHw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.12.tgz",
+      "integrity": "sha512-8cOB1PtjnjFRqOgwFiD8DaUsYJtVJ6+YdXQtSZDrLGf8cdhhh8xzTtGzVTGeBf15kTv0v7lYPJlV/az7zLEPJw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -8452,7 +8814,7 @@
         "global-modules": "^2.0.0",
         "globby": "^10.0.1",
         "jsonschema": "^1.2.4",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "mocha": "^10.2.0",
         "node-emoji": "^1.10.0",
         "pify": "^4.0.1",
@@ -8475,6 +8837,61 @@
       "integrity": "sha512-yfORGUIPgLck41qyN7nbwJRAx17/jAIXCTanHOJZhB6PJ1iAk/84b/xlsVKFSyNyLXIj0dhppoE0+CRws7wlzA==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/solidity-coverage/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/solidity-coverage/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/solidity-coverage/node_modules/fs-extra": {
       "version": "8.1.0",
@@ -8511,6 +8928,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/solidity-coverage/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/solidity-coverage/node_modules/semver": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -8525,6 +8962,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/source-map": {
@@ -8560,6 +9020,16 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^3.0.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -8720,16 +9190,15 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/sync-request": {
@@ -8758,9 +9227,9 @@
       }
     },
     "node_modules/table": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
-      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
+      "integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -8811,16 +9280,16 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "uri-js": "^4.4.1"
       },
       "funding": {
         "type": "github",
@@ -8883,6 +9352,16 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "3"
       }
     },
     "node_modules/tmp": {
@@ -8952,82 +9431,6 @@
       },
       "bin": {
         "write-markdown": "dist/write-markdown.js"
-      }
-    },
-    "node_modules/ts-command-line-args/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ts-command-line-args/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ts-command-line-args/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/ts-command-line-args/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/ts-command-line-args/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ts-command-line-args/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ts-essentials": {
@@ -9191,6 +9594,21 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/typechain/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
     "node_modules/typechain/node_modules/glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
@@ -9210,6 +9628,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typechain/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/typechain/node_modules/minimatch": {
@@ -9252,6 +9680,16 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/typechain/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -9335,9 +9773,9 @@
       "peer": true
     },
     "node_modules/typescript": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -9388,9 +9826,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -9413,13 +9851,13 @@
       "dev": true
     },
     "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "peer": true,
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -9489,6 +9927,32 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-utils/node_modules/@noble/curves": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.3.3"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/web3-utils/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/web3-utils/node_modules/ethereum-cryptography": {
@@ -9588,7 +10052,6 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9649,42 +10112,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -9692,13 +10119,13 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "dev": true,
       "peer": true,
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dotenv": "^16.4.5",
     "eslint": "^8.57.0",
     "hardhat-contract-sizer": "^2.10.0",
+    "hardhat-gas-reporter": "^1.0.10",
     "prettier": "^3.2.5",
     "prettier-plugin-solidity": "^1.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
     "@openzeppelin/hardhat-upgrades": "^3.1.0",
-    "@stylistic/eslint-plugin": "^1.8.0",
-    "@typescript-eslint/eslint-plugin": "^7.8.0",
-    "@typescript-eslint/parser": "^7.8.0",
+    "@stylistic/eslint-plugin": "^2.1.0",
+    "@typescript-eslint/eslint-plugin": "^7.10.0",
+    "@typescript-eslint/parser": "^7.10.0",
     "dotenv": "^16.4.5",
     "eslint": "^8.57.0",
     "hardhat-contract-sizer": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
     "@openzeppelin/hardhat-upgrades": "^3.1.0",
-    "@stylistic/eslint-plugin": "^2.1.0",
+    "@stylistic/eslint-plugin": "^1.8.1",
     "@typescript-eslint/eslint-plugin": "^7.10.0",
     "@typescript-eslint/parser": "^7.10.0",
     "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
     "@openzeppelin/contracts-upgradeable": "4.9.6"
   },
   "devDependencies": {
-    "@nomicfoundation/hardhat-toolbox": "^2.0.2",
-    "@openzeppelin/hardhat-upgrades": "^1.28.0",
-    "@stylistic/eslint-plugin": "^1.5.4",
-    "@typescript-eslint/eslint-plugin": "^6.19.0",
-    "@typescript-eslint/parser": "^6.19.0",
+    "@nomicfoundation/hardhat-toolbox": "^5.0.0",
+    "@openzeppelin/hardhat-upgrades": "^3.1.0",
+    "@stylistic/eslint-plugin": "^1.8.0",
+    "@typescript-eslint/eslint-plugin": "^7.8.0",
+    "@typescript-eslint/parser": "^7.8.0",
     "dotenv": "^16.4.5",
-    "eslint": "^8.56.0",
+    "eslint": "^8.57.0",
     "hardhat-contract-sizer": "^2.10.0",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "prettier-plugin-solidity": "^1.3.1"
   },
   "scripts": {

--- a/test-utils/eth.ts
+++ b/test-utils/eth.ts
@@ -1,6 +1,23 @@
-import { TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
+import { BaseContract, Contract, TransactionReceipt, TransactionResponse } from "ethers";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 
 export async function proveTx(txResponsePromise: Promise<TransactionResponse>): Promise<TransactionReceipt> {
-  const txReceipt = await txResponsePromise;
-  return txReceipt.wait();
+  const txResponse = await txResponsePromise;
+  const txReceipt = await txResponse.wait();
+  if (!txReceipt) {
+    throw new Error("The transaction receipt is empty");
+  }
+  return txReceipt as TransactionReceipt;
+}
+
+export function connect(contract: BaseContract, signer: HardhatEthersSigner): Contract {
+  return contract.connect(signer) as Contract;
+}
+
+export function getAddress(contract: Contract): string {
+  const address = contract.target;
+  if (typeof address !== "string" || address.length != 42 || !address.startsWith("0x")) {
+    throw new Error("The '.target' field of the contract is not an address string");
+  }
+  return (address as string);
 }

--- a/test-utils/eth.ts
+++ b/test-utils/eth.ts
@@ -1,5 +1,7 @@
-import { BaseContract, Contract, TransactionReceipt, TransactionResponse } from "ethers";
+import { ethers, network } from "hardhat";
+import { BaseContract, BlockTag, Contract, TransactionReceipt, TransactionResponse } from "ethers";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
 
 export async function proveTx(txResponsePromise: Promise<TransactionResponse>): Promise<TransactionReceipt> {
   const txResponse = await txResponsePromise;
@@ -20,4 +22,32 @@ export function getAddress(contract: Contract): string {
     throw new Error("The '.target' field of the contract is not an address string");
   }
   return address;
+}
+
+export async function getBlockTimestamp(blockTag: BlockTag): Promise<number> {
+  const block = await ethers.provider.getBlock(blockTag);
+  return block?.timestamp ?? 0;
+}
+
+export async function getLatestBlockTimestamp(): Promise<number> {
+  return getBlockTimestamp("latest");
+}
+
+export async function increaseBlockTimestampTo(targetTimestamp: number) {
+  if (network.name === "hardhat") {
+    await time.increaseTo(targetTimestamp);
+  } else if (network.name === "stratus") {
+    await ethers.provider.send("evm_setNextBlockTimestamp", [targetTimestamp]);
+    await ethers.provider.send("evm_mine", []);
+  } else {
+    throw new Error(`Setting block timestamp for the current blockchain is not supported: ${network.name}`);
+  }
+}
+
+export async function increaseBlockTimestamp(increaseInSeconds: number) {
+  if (increaseInSeconds <= 0) {
+    throw new Error(`The block timestamp increase must be greater than zero, but it equals: ${increaseInSeconds}`);
+  }
+  const currentTimestamp = await getLatestBlockTimestamp();
+  await increaseBlockTimestampTo(currentTimestamp + increaseInSeconds);
 }

--- a/test-utils/eth.ts
+++ b/test-utils/eth.ts
@@ -19,5 +19,5 @@ export function getAddress(contract: Contract): string {
   if (typeof address !== "string" || address.length != 42 || !address.startsWith("0x")) {
     throw new Error("The '.target' field of the contract is not an address string");
   }
-  return (address as string);
+  return address;
 }

--- a/test-utils/misc.ts
+++ b/test-utils/misc.ts
@@ -1,9 +1,3 @@
-function countNumberArrayTotal(array: number[]) {
-  return array.reduce((sum: number, currentValue: number) => {
-    return sum + currentValue;
-  });
-}
-
 function createBytesString(baseString: string | number | undefined, byteLength: number) {
   baseString = !baseString ? "" : baseString.toString();
   if (baseString.length > byteLength * 2) {
@@ -29,4 +23,4 @@ function createRevertMessageDueToMissingRole(address: string, role: string) {
   return `AccessControl: account ${address.toLowerCase()} is missing role ${role.toLowerCase()}`;
 }
 
-export { countNumberArrayTotal, createBytesString, createRevertMessageDueToMissingRole };
+export { createBytesString, createRevertMessageDueToMissingRole };

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1,20 +1,19 @@
 import { ethers, network, upgrades } from "hardhat";
 import { expect } from "chai";
-import { BigNumber, Contract, ContractFactory } from "ethers";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { Contract, ContractFactory, TransactionReceipt, TransactionResponse } from "ethers";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { proveTx } from "../test-utils/eth";
+import { connect, getAddress, proveTx } from "../test-utils/eth";
 import { createBytesString, createRevertMessageDueToMissingRole } from "../test-utils/misc";
-import { TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
 import { checkEventField, checkEventFieldNotEqual } from "../test-utils/checkers";
 import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
 
-const MAX_UINT256 = ethers.constants.MaxUint256;
-const MAX_INT256 = ethers.constants.MaxInt256;
-const ZERO_ADDRESS = ethers.constants.AddressZero;
-const ZERO_SPONSOR_ADDRESS = ethers.constants.AddressZero;
+const MAX_UINT256 = ethers.MaxUint256;
+const MAX_INT256 = ethers.MaxInt256;
+const ZERO_ADDRESS = ethers.ZeroAddress;
+const ZERO_SPONSOR_ADDRESS = ethers.ZeroAddress;
 const ZERO_SUBSIDY_LIMIT = 0;
-const ZERO_TRANSACTION_HASH: string = ethers.constants.HashZero;
+const ZERO_TRANSACTION_HASH: string = ethers.ZeroHash;
 const BYTES16_LENGTH: number = 16;
 const BYTES32_LENGTH: number = 32;
 const CASHBACK_RATE_AS_IN_CONTRACT = -1;
@@ -75,7 +74,7 @@ enum CashbackKind {
 }
 
 interface TestPayment {
-  account: SignerWithAddress;
+  account: HardhatEthersSigner;
   baseAmount: number;
   extraAmount: number;
   authorizationId: string;
@@ -85,7 +84,7 @@ interface TestPayment {
 
 interface PaymentModel {
   authorizationId: string;
-  account: SignerWithAddress;
+  account: HardhatEthersSigner;
   baseAmount: number;
   extraAmount: number;
   status: PaymentStatus;
@@ -95,7 +94,7 @@ interface PaymentModel {
   cashbackEnabled: boolean;
   revocationParentTxHashes: string[];
   reversalParentTxHashes: string[];
-  sponsor?: SignerWithAddress;
+  sponsor?: HardhatEthersSigner;
   subsidyLimit: number;
 }
 
@@ -126,8 +125,8 @@ enum OperationKind {
 
 interface PaymentOperation {
   kind: OperationKind;
-  sender?: SignerWithAddress;
-  account: SignerWithAddress;
+  sender?: HardhatEthersSigner;
+  account: HardhatEthersSigner;
   newBaseAmount: number;
   newExtraAmount: number;
   refundAmountChange: number;
@@ -156,7 +155,7 @@ interface PaymentOperation {
   clearedBalance: number;
   unclearedBalance: number;
   paymentStatus: PaymentStatus;
-  sponsor?: SignerWithAddress;
+  sponsor?: HardhatEthersSigner;
   subsidyLimit: number;
   sponsorRefundAmountChange: number;
   sponsorBalanceChange: number;
@@ -243,10 +242,10 @@ class CardPaymentProcessorModel {
   makePayment(
     payment: TestPayment,
     props: {
-      sponsor?: SignerWithAddress;
+      sponsor?: HardhatEthersSigner;
       subsidyLimit?: number;
       cashbackRateInPermil?: number;
-      sender?: SignerWithAddress;
+      sender?: HardhatEthersSigner;
     } = {}
   ): number {
     const paymentModel = this.#createPayment(payment);
@@ -958,12 +957,12 @@ interface OperationResult {
 class CardPaymentProcessorShell {
   contract: Contract;
   model: CardPaymentProcessorModel;
-  executor: SignerWithAddress;
+  executor: HardhatEthersSigner;
 
   constructor(props: {
     cardPaymentProcessorContract: Contract;
     cardPaymentProcessorModel: CardPaymentProcessorModel;
-    executor: SignerWithAddress;
+    executor: HardhatEthersSigner;
   }) {
     this.contract = props.cardPaymentProcessorContract;
     this.model = props.cardPaymentProcessorModel;
@@ -980,11 +979,11 @@ class CardPaymentProcessorShell {
     await proveTx(this.contract.disableCashback());
   }
 
-  async makePayments(payments: TestPayment[], sender: SignerWithAddress = this.executor): Promise<OperationResult[]> {
+  async makePayments(payments: TestPayment[], sender: HardhatEthersSigner = this.executor): Promise<OperationResult[]> {
     const operationResults: OperationResult[] = [];
     for (const payment of payments) {
       const operationIndex = this.model.makePayment(payment, { sender });
-      const tx = this.contract.connect(sender).makePaymentFor(
+      const tx = connect(this.contract, sender).makePaymentFor(
         payment.account.address,
         payment.baseAmount,
         payment.extraAmount,
@@ -1000,17 +999,17 @@ class CardPaymentProcessorShell {
         tx,
         txReceipt
       });
-      payment.parentTxHash = txReceipt.transactionHash;
+      payment.parentTxHash = txReceipt.hash;
     }
     return operationResults;
   }
 
   async makePaymentFor(
     payment: TestPayment,
-    sponsor?: SignerWithAddress,
+    sponsor?: HardhatEthersSigner,
     subsidyLimit?: number,
     cashbackRateInPermil?: number,
-    sender: SignerWithAddress = this.executor
+    sender: HardhatEthersSigner = this.executor
   ): Promise<OperationResult> {
     const operationIndex = this.model.makePayment(payment, {
       sponsor,
@@ -1018,7 +1017,7 @@ class CardPaymentProcessorShell {
       cashbackRateInPermil,
       sender
     });
-    const tx = this.contract.connect(sender).makePaymentFor(
+    const tx = connect(this.contract, sender).makePaymentFor(
       payment.account.address,
       payment.baseAmount,
       payment.extraAmount,
@@ -1040,7 +1039,7 @@ class CardPaymentProcessorShell {
     payment: TestPayment,
     newBaseAmount: number,
     newExtraAmount: number = payment.extraAmount,
-    sender: SignerWithAddress = this.executor
+    sender: HardhatEthersSigner = this.executor
   ): Promise<OperationResult> {
     const operationIndex = this.model.updatePaymentAmount(
       newBaseAmount,
@@ -1048,7 +1047,7 @@ class CardPaymentProcessorShell {
       payment.authorizationId,
       payment.correlationId
     );
-    const tx = this.contract.connect(sender).updatePaymentAmount(
+    const tx = connect(this.contract, sender).updatePaymentAmount(
       newBaseAmount,
       newExtraAmount,
       payment.authorizationId,
@@ -1062,11 +1061,14 @@ class CardPaymentProcessorShell {
     };
   }
 
-  async clearPayments(payments: TestPayment[], sender: SignerWithAddress = this.executor): Promise<OperationResult[]> {
+  async clearPayments(
+    payments: TestPayment[],
+    sender: HardhatEthersSigner = this.executor
+  ): Promise<OperationResult[]> {
     const operationResults: OperationResult[] = [];
     for (const payment of payments) {
       const operationIndex = this.model.clearPayment(payment.authorizationId);
-      const tx = this.contract.connect(sender).clearPayment(payment.authorizationId);
+      const tx = connect(this.contract, sender).clearPayment(payment.authorizationId);
       const txReceipt: TransactionReceipt = await proveTx(tx);
       operationResults.push({
         operationIndex,
@@ -1079,12 +1081,12 @@ class CardPaymentProcessorShell {
 
   async unclearPayments(
     payments: TestPayment[],
-    sender: SignerWithAddress = this.executor
+    sender: HardhatEthersSigner = this.executor
   ): Promise<OperationResult[]> {
     const operationResults: OperationResult[] = [];
     for (const payment of payments) {
       const operationIndex = this.model.unclearPayment(payment.authorizationId);
-      const tx = this.contract.connect(sender).unclearPayment(payment.authorizationId);
+      const tx = connect(this.contract, sender).unclearPayment(payment.authorizationId);
       const txReceipt: TransactionReceipt = await proveTx(tx);
       operationResults.push({
         operationIndex,
@@ -1095,13 +1097,13 @@ class CardPaymentProcessorShell {
     return operationResults;
   }
 
-  async revokePayment(payment: TestPayment, sender: SignerWithAddress = this.executor): Promise<OperationResult> {
+  async revokePayment(payment: TestPayment, sender: HardhatEthersSigner = this.executor): Promise<OperationResult> {
     const operationIndex = this.model.revokePayment(
       payment.authorizationId,
       payment.correlationId,
       payment.parentTxHash
     );
-    const tx = this.contract.connect(sender).revokePayment(
+    const tx = connect(this.contract, sender)["revokePayment(bytes16,bytes16,bytes32)"](
       payment.authorizationId,
       payment.correlationId,
       payment.parentTxHash
@@ -1114,13 +1116,13 @@ class CardPaymentProcessorShell {
     };
   }
 
-  async reversePayment(payment: TestPayment, sender: SignerWithAddress = this.executor): Promise<OperationResult> {
+  async reversePayment(payment: TestPayment, sender: HardhatEthersSigner = this.executor): Promise<OperationResult> {
     const operationIndex = this.model.reversePayment(
       payment.authorizationId,
       payment.correlationId,
       payment.parentTxHash
     );
-    const tx = this.contract.connect(sender).reversePayment(
+    const tx = connect(this.contract, sender).reversePayment(
       payment.authorizationId,
       payment.correlationId,
       payment.parentTxHash
@@ -1135,19 +1137,19 @@ class CardPaymentProcessorShell {
 
   async confirmPayments(
     payments: TestPayment[],
-    sender: SignerWithAddress = this.executor
+    sender: HardhatEthersSigner = this.executor
   ): Promise<OperationResult[]> {
     const operationResults: OperationResult[] = [];
     for (const payment of payments) {
       const operationIndex = this.model.confirmPayment(payment.authorizationId);
-      const tx = this.contract.connect(sender).confirmPayment(payment.authorizationId);
+      const tx = connect(this.contract, sender).confirmPayment(payment.authorizationId);
       const txReceipt: TransactionReceipt = await proveTx(tx);
       operationResults.push({
         operationIndex,
         tx,
         txReceipt
       });
-      payment.parentTxHash = txReceipt.transactionHash;
+      payment.parentTxHash = txReceipt.hash;
     }
     return operationResults;
   }
@@ -1156,7 +1158,7 @@ class CardPaymentProcessorShell {
     payment: TestPayment,
     refundAmount: number,
     newExtraAmount: number = payment.extraAmount,
-    sender: SignerWithAddress = this.executor
+    sender: HardhatEthersSigner = this.executor
   ): Promise<OperationResult> {
     const operationIndex = this.model.refundPayment(
       refundAmount,
@@ -1164,7 +1166,7 @@ class CardPaymentProcessorShell {
       payment.authorizationId,
       payment.correlationId
     );
-    const tx = this.contract.connect(sender).functions[FUNCTION_REFUND_PAYMENT_FULL](
+    const tx = connect(this.contract, sender)[FUNCTION_REFUND_PAYMENT_FULL](
       refundAmount,
       newExtraAmount,
       payment.authorizationId,
@@ -1184,14 +1186,14 @@ class TestContext {
   tokenMock: Contract;
   cardPaymentProcessorShell: CardPaymentProcessorShell;
   cashbackDistributorMockShell: CashbackDistributorMockShell;
-  cashOutAccount: SignerWithAddress;
+  cashOutAccount: HardhatEthersSigner;
   payments: TestPayment[];
 
   constructor(props: {
     fixture: Fixture;
     cashbackRateInPermil: number;
-    cashOutAccount: SignerWithAddress;
-    cardPaymentProcessorExecutor: SignerWithAddress;
+    cashOutAccount: HardhatEthersSigner;
+    cardPaymentProcessorExecutor: HardhatEthersSigner;
     payments: TestPayment[];
   }) {
     this.cashbackDistributorMockConfig = { ...props.fixture.cashbackDistributorMockConfig };
@@ -1286,8 +1288,8 @@ class TestContext {
         await expect(tx)
           .to.emit(this.cashbackDistributorMockShell.contract, EVENT_NAME_SEND_CASHBACK_MOCK)
           .withArgs(
-            checkEventField("sender", this.cardPaymentProcessorShell.contract.address),
-            checkEventField("token", this.tokenMock.address),
+            checkEventField("sender", getAddress(this.cardPaymentProcessorShell.contract)),
+            checkEventField("token", getAddress(this.tokenMock)),
             checkEventField("kind", CashbackKind.CardPayment),
             checkEventField("externalId", operation.authorizationId.padEnd(BYTES32_LENGTH * 2 + 2, "0")),
             checkEventField("recipient", operation.account.address),
@@ -1297,7 +1299,7 @@ class TestContext {
           await expect(tx)
             .to.emit(this.cardPaymentProcessorShell.contract, EVENT_NAME_SEND_CASHBACK_SUCCESS)
             .withArgs(
-              checkEventField("cashbackDistributor", this.cashbackDistributorMockShell.contract.address),
+              checkEventField("cashbackDistributor", getAddress(this.cashbackDistributorMockShell.contract)),
               checkEventField("amount", operation.cashbackActualChange),
               checkEventField("nonce", operation.cashbackNonce)
             );
@@ -1306,7 +1308,7 @@ class TestContext {
           await expect(tx)
             .to.emit(this.cardPaymentProcessorShell.contract, EVENT_NAME_SEND_CASHBACK_FAILURE)
             .withArgs(
-              checkEventField("cashbackDistributor", this.cashbackDistributorMockShell.contract.address),
+              checkEventField("cashbackDistributor", getAddress(this.cashbackDistributorMockShell.contract)),
               checkEventField("amount", operation.cashbackRequestedChange),
               checkEventField("nonce", operation.cashbackNonce)
             );
@@ -1322,7 +1324,7 @@ class TestContext {
         await expect(tx)
           .to.emit(this.cashbackDistributorMockShell.contract, EVENT_NAME_REVOKE_CASHBACK_MOCK)
           .withArgs(
-            checkEventField("sender", this.cardPaymentProcessorShell.contract.address),
+            checkEventField("sender", getAddress(this.cardPaymentProcessorShell.contract)),
             checkEventField("nonce", operation.cashbackNonce),
             checkEventField("amount", -operation.cashbackRequestedChange)
           );
@@ -1331,7 +1333,7 @@ class TestContext {
           await expect(tx)
             .to.emit(this.cardPaymentProcessorShell.contract, EVENT_NAME_REVOKE_CASHBACK_SUCCESS)
             .withArgs(
-              checkEventField("cashbackDistributor", this.cashbackDistributorMockShell.contract.address),
+              checkEventField("cashbackDistributor", getAddress(this.cashbackDistributorMockShell.contract)),
               checkEventField("amount", -operation.cashbackActualChange),
               checkEventField("nonce", operation.cashbackNonce)
             );
@@ -1340,7 +1342,7 @@ class TestContext {
           await expect(tx)
             .to.emit(this.cardPaymentProcessorShell.contract, EVENT_NAME_REVOKE_CASHBACK_FAILURE)
             .withArgs(
-              checkEventField("cashbackDistributor", this.cashbackDistributorMockShell.contract.address),
+              checkEventField("cashbackDistributor", getAddress(this.cashbackDistributorMockShell.contract)),
               checkEventField("amount", -operation.cashbackRequestedChange),
               checkEventField("nonce", operation.cashbackNonce)
             );
@@ -1354,7 +1356,7 @@ class TestContext {
         await expect(tx)
           .to.emit(this.cashbackDistributorMockShell.contract, EVENT_NAME_INCREASE_CASHBACK_MOCK)
           .withArgs(
-            checkEventField("sender", this.cardPaymentProcessorShell.contract.address),
+            checkEventField("sender", getAddress(this.cardPaymentProcessorShell.contract)),
             checkEventField("nonce", operation.cashbackNonce),
             checkEventField("amount", operation.cashbackRequestedChange)
           );
@@ -1363,7 +1365,7 @@ class TestContext {
           await expect(tx)
             .to.emit(this.cardPaymentProcessorShell.contract, EVENT_NAME_INCREASE_CASHBACK_SUCCESS)
             .withArgs(
-              checkEventField("cashbackDistributor", this.cashbackDistributorMockShell.contract.address),
+              checkEventField("cashbackDistributor", getAddress(this.cashbackDistributorMockShell.contract)),
               checkEventField("amount", operation.cashbackActualChange),
               checkEventField("nonce", operation.cashbackNonce)
             );
@@ -1373,7 +1375,7 @@ class TestContext {
           await expect(tx)
             .to.emit(this.cardPaymentProcessorShell.contract, EVENT_NAME_INCREASE_CASHBACK_FAILURE)
             .withArgs(
-              checkEventField("cashbackDistributor", this.cashbackDistributorMockShell.contract.address),
+              checkEventField("cashbackDistributor", getAddress(this.cashbackDistributorMockShell.contract)),
               checkEventField("amount", operation.cashbackRequestedChange),
               checkEventField("nonce", operation.cashbackNonce)
             );
@@ -1407,8 +1409,8 @@ class TestContext {
     const cashOutAccountBalanceChange = operations
       .map(operation => operation.cashOutAccountBalanceChange)
       .reduce((sum: number, currentValue: number) => sum + currentValue);
-    const balanceChangePerAccount: Map<SignerWithAddress, number> = this.#getBalanceChangePerAccount(operations);
-    const accounts: SignerWithAddress[] = Array.from(balanceChangePerAccount.keys());
+    const balanceChangePerAccount: Map<HardhatEthersSigner, number> = this.#getBalanceChangePerAccount(operations);
+    const accounts: HardhatEthersSigner[] = Array.from(balanceChangePerAccount.keys());
     const accountBalanceChanges: number[] = accounts.map(user => balanceChangePerAccount.get(user) ?? 0);
 
     await expect(tx).to.changeTokenBalances(
@@ -1436,16 +1438,16 @@ class TestContext {
   }
 
   async setUpContractsForPayments(payments: TestPayment[] = this.payments) {
-    const accounts: Set<SignerWithAddress> = new Set(payments.map(payment => payment.account));
+    const accounts: Set<HardhatEthersSigner> = new Set(payments.map(payment => payment.account));
     for (const account of accounts) {
       await proveTx(this.tokenMock.mint(account.address, INITIAL_USER_BALANCE));
-      const allowance: BigNumber = await this.tokenMock.allowance(
+      const allowance: bigint = await this.tokenMock.allowance(
         account.address,
-        this.cardPaymentProcessorShell.contract.address
+        getAddress(this.cardPaymentProcessorShell.contract)
       );
-      if (allowance.lt(MAX_UINT256)) {
+      if (allowance < MAX_UINT256) {
         await proveTx(
-          this.tokenMock.connect(account).approve(this.cardPaymentProcessorShell.contract.address, MAX_UINT256)
+          connect(this.tokenMock, account).approve(getAddress(this.cardPaymentProcessorShell.contract), MAX_UINT256)
         );
       }
     }
@@ -1770,7 +1772,7 @@ class TestContext {
       `payment[${paymentIndex}].cashbackRate is wrong`
     );
     expect(actualOnChainPayment.sponsor).to.equal(
-      expectedPayment.sponsor?.address ?? ethers.constants.AddressZero,
+      expectedPayment.sponsor?.address ?? ZERO_ADDRESS,
       `payment[${paymentIndex}].sponsor is wrong`
     );
     expect(actualOnChainPayment.subsidyLimit).to.equal(
@@ -1810,7 +1812,7 @@ class TestContext {
       const actualCashback = await this.cardPaymentProcessorShell.contract.getCashback(authorizationId);
       const note = `The last cashback nonce of a payment with authorizationId=${authorizationId} is wrong`;
       if (!expectedCashback) {
-        expect(actualCashback.lastCashbackNonce).to.equal(ethers.constants.Zero, note);
+        expect(actualCashback.lastCashbackNonce).to.equal(0, note);
       } else {
         expect(actualCashback.lastCashbackNonce).to.equal(expectedCashback.lastCashbackNonce, note);
       }
@@ -1850,14 +1852,14 @@ class TestContext {
   }
 
   async #checkTokenBalance() {
-    expect(await this.tokenMock.balanceOf(this.cardPaymentProcessorShell.contract.address)).to.equal(
+    expect(await this.tokenMock.balanceOf(getAddress(this.cardPaymentProcessorShell.contract))).to.equal(
       this.cardPaymentProcessorShell.model.totalBalance,
       `The card payment processor token balance is wrong`
     );
   }
 
   #getBalanceChangePerAccount(operations: PaymentOperation[]) {
-    const result: Map<SignerWithAddress, number> = new Map();
+    const result: Map<HardhatEthersSigner, number> = new Map();
     operations.forEach(operation => {
       let balanceChange: number = result.get(operation.account) ?? 0;
       balanceChange += operation.userBalanceChange;
@@ -1933,22 +1935,22 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   const REVERT_ERROR_IF_NEW_EXTRA_PAYMENT_AMOUNT_IS_INAPPROPRIATE = "InappropriateNewExtraPaymentAmount";
   const REVERT_ERROR_IF_SUBSIDIZED_PAYMENT_WITH_NON_ZERO_REFUND_AMOUNT = "SubsidizedPaymentWithNonZeroRefundAmount";
 
-  const ownerRole: string = ethers.utils.id("OWNER_ROLE");
-  const blocklisterRole: string = ethers.utils.id("BLOCKLISTER_ROLE");
-  const pauserRole: string = ethers.utils.id("PAUSER_ROLE");
-  const rescuerRole: string = ethers.utils.id("RESCUER_ROLE");
-  const executorRole: string = ethers.utils.id("EXECUTOR_ROLE");
+  const ownerRole: string = ethers.id("OWNER_ROLE");
+  const blocklisterRole: string = ethers.id("BLOCKLISTER_ROLE");
+  const pauserRole: string = ethers.id("PAUSER_ROLE");
+  const rescuerRole: string = ethers.id("RESCUER_ROLE");
+  const executorRole: string = ethers.id("EXECUTOR_ROLE");
 
   let cardPaymentProcessorFactory: ContractFactory;
   let cashbackDistributorMockFactory: ContractFactory;
   let tokenMockFactory: ContractFactory;
 
-  let deployer: SignerWithAddress;
-  let cashOutAccount: SignerWithAddress;
-  let executor: SignerWithAddress;
-  let sponsor: SignerWithAddress;
-  let user1: SignerWithAddress;
-  let user2: SignerWithAddress;
+  let deployer: HardhatEthersSigner;
+  let cashOutAccount: HardhatEthersSigner;
+  let executor: HardhatEthersSigner;
+  let sponsor: HardhatEthersSigner;
+  let user1: HardhatEthersSigner;
+  let user2: HardhatEthersSigner;
 
   before(async () => {
     cardPaymentProcessorFactory = await ethers.getContractFactory("CardPaymentProcessor");
@@ -1963,7 +1965,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     const symbol = "TEST";
 
     const tokenMock: Contract = await upgrades.deployProxy(tokenMockFactory, [name, symbol]);
-    await tokenMock.deployed();
+    await tokenMock.waitForDeployment();
 
     return { tokenMock };
   }
@@ -1974,8 +1976,9 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   }> {
     const { tokenMock } = await deployTokenMock();
 
-    const cardPaymentProcessor: Contract = await upgrades.deployProxy(cardPaymentProcessorFactory, [tokenMock.address]);
-    await cardPaymentProcessor.deployed();
+    const cardPaymentProcessor: Contract =
+      await upgrades.deployProxy(cardPaymentProcessorFactory, [getAddress(tokenMock)]);
+    await cardPaymentProcessor.waitForDeployment();
 
     return {
       cardPaymentProcessor,
@@ -2003,8 +2006,8 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       cashbackDistributorMockConfig.revokeCashbackSuccessResult,
       cashbackDistributorMockConfig.increaseCashbackSuccessResult,
       cashbackDistributorMockConfig.increaseCashbackAmountResult
-    );
-    await cashbackDistributorMock.deployed();
+    ) as Contract;
+    await cashbackDistributorMock.waitForDeployment();
 
     return {
       cashbackDistributorMock,
@@ -2017,15 +2020,15 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     const { cashbackDistributorMock, cashbackDistributorMockConfig } = await deployCashbackDistributorMock();
 
     await proveTx(cardPaymentProcessor.grantRole(executorRole, executor.address));
-    await proveTx(cardPaymentProcessor.setCashbackDistributor(cashbackDistributorMock.address));
+    await proveTx(cardPaymentProcessor.setCashbackDistributor(getAddress(cashbackDistributorMock)));
     await proveTx(cardPaymentProcessor.setCashbackRate(CASHBACK_RATE_IN_PERMIL));
 
     await proveTx(cardPaymentProcessor.setCashOutAccount(cashOutAccount.address));
-    await proveTx(tokenMock.connect(cashOutAccount).approve(cardPaymentProcessor.address, MAX_UINT256));
+    await proveTx(connect(tokenMock, cashOutAccount).approve(getAddress(cardPaymentProcessor), MAX_UINT256));
 
-    await proveTx(tokenMock.mint(cashbackDistributorMock.address, MAX_INT256));
+    await proveTx(tokenMock.mint(getAddress(cashbackDistributorMock), MAX_INT256));
     await proveTx(tokenMock.mint(sponsor.address, INITIAL_SPONSOR_BALANCE));
-    await proveTx(tokenMock.connect(sponsor).approve(cardPaymentProcessor.address, MAX_UINT256));
+    await proveTx(connect(tokenMock, sponsor).approve(getAddress(cardPaymentProcessor), MAX_UINT256));
 
     return {
       cardPaymentProcessor,
@@ -2081,7 +2084,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessor, tokenMock } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
 
       // The underlying contract address
-      expect(await cardPaymentProcessor.underlyingToken()).to.equal(tokenMock.address);
+      expect(await cardPaymentProcessor.underlyingToken()).to.equal(getAddress(tokenMock));
 
       // The revocation limit
       expect(await cardPaymentProcessor.revocationLimit()).to.equal(REVOCATION_LIMIT_DEFAULT_VALUE);
@@ -2116,7 +2119,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     it("Is reverted if it is called a second time", async () => {
       const { cardPaymentProcessor, tokenMock } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await expect(
-        cardPaymentProcessor.initialize(tokenMock.address)
+        cardPaymentProcessor.initialize(getAddress(tokenMock))
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
     });
 
@@ -2151,15 +2154,20 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     it("Is reverted if the caller does not have the owner role", async () => {
       const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await expect(
-        cardPaymentProcessor.connect(user1).setRevocationLimit(REVOCATION_LIMIT)
+        connect(cardPaymentProcessor, user1).setRevocationLimit(REVOCATION_LIMIT)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
     });
   });
 
   describe("Function 'setCashbackDistributor()'", async () => {
     it("Executes as expected and emits the correct event", async () => {
-      const { cardPaymentProcessor, tokenMock } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
-      expect(await tokenMock.allowance(cardPaymentProcessor.address, CASHBACK_DISTRIBUTOR_ADDRESS_STUB1)).to.equal(0);
+      const {
+        cardPaymentProcessor,
+        tokenMock
+      } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+      expect(
+        await tokenMock.allowance(getAddress(cardPaymentProcessor), CASHBACK_DISTRIBUTOR_ADDRESS_STUB1)
+      ).to.equal(0);
 
       await expect(cardPaymentProcessor.setCashbackDistributor(CASHBACK_DISTRIBUTOR_ADDRESS_STUB1))
         .to.emit(cardPaymentProcessor, EVENT_NAME_SET_CASHBACK_DISTRIBUTOR)
@@ -2167,14 +2175,14 @@ describe("Contract 'CardPaymentProcessor'", async () => {
 
       expect(await cardPaymentProcessor.cashbackDistributor()).to.equal(CASHBACK_DISTRIBUTOR_ADDRESS_STUB1);
       expect(
-        await tokenMock.allowance(cardPaymentProcessor.address, CASHBACK_DISTRIBUTOR_ADDRESS_STUB1)
+        await tokenMock.allowance(getAddress(cardPaymentProcessor), CASHBACK_DISTRIBUTOR_ADDRESS_STUB1)
       ).to.equal(MAX_UINT256);
     });
 
     it("Is reverted if the caller does not have the owner role", async () => {
       const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await expect(
-        cardPaymentProcessor.connect(user1).setCashbackDistributor(CASHBACK_DISTRIBUTOR_ADDRESS_STUB1)
+        connect(cardPaymentProcessor, user1).setCashbackDistributor(CASHBACK_DISTRIBUTOR_ADDRESS_STUB1)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
     });
 
@@ -2209,7 +2217,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     it("Is reverted if the caller does not have the owner role", async () => {
       const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await expect(
-        cardPaymentProcessor.connect(user1).setCashbackRate(CASHBACK_RATE_IN_PERMIL)
+        connect(cardPaymentProcessor, user1).setCashbackRate(CASHBACK_RATE_IN_PERMIL)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
     });
 
@@ -2245,7 +2253,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     it("Is reverted if the caller does not have the owner role", async () => {
       const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await expect(
-        cardPaymentProcessor.connect(user1).enableCashback()
+        connect(cardPaymentProcessor, user1).enableCashback()
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
     });
 
@@ -2282,7 +2290,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     it("Is reverted if the caller does not have the owner role", async () => {
       const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await expect(
-        cardPaymentProcessor.connect(user1).disableCashback()
+        connect(cardPaymentProcessor, user1).disableCashback()
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
     });
 
@@ -2315,7 +2323,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     it("Is reverted if the caller does not have the owner role", async () => {
       const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
       await expect(
-        cardPaymentProcessor.connect(user1).setCashOutAccount(cashOutAccount.address)
+        connect(cardPaymentProcessor, user1).setCashOutAccount(cashOutAccount.address)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
     });
 
@@ -2346,7 +2354,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await cardPaymentProcessorShell.enableCashback();
 
         cardPaymentProcessorShell.model.makePayment(context.payments[0]);
-        const tx = cardPaymentProcessorShell.contract.connect(payment.account).makePayment(
+        const tx = connect(cardPaymentProcessorShell.contract, payment.account).makePayment(
           payment.baseAmount,
           payment.extraAmount,
           payment.authorizationId,
@@ -2366,7 +2374,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(payment.account).makePayment(
+          connect(cardPaymentProcessorShell.contract, payment.account).makePayment(
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -2383,7 +2391,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await proveTx(cardPaymentProcessorShell.contract.blocklist(payment.account.address));
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(payment.account).makePayment(
+          connect(cardPaymentProcessorShell.contract, payment.account).makePayment(
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -2398,7 +2406,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     async function checkPaymentMakingFor(
       context: TestContext,
       props: {
-        sponsor?: SignerWithAddress;
+        sponsor?: HardhatEthersSigner;
         subsidyLimit?: number;
         cashbackEnabled?: boolean;
         cashbackRateInPermil?: number;
@@ -2416,7 +2424,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         cashbackRateInPermil: props.cashbackRateInPermil,
         sender: executor
       });
-      const tx = cardPaymentProcessorShell.contract.connect(executor).makePaymentFor(
+      const tx = connect(cardPaymentProcessorShell.contract, executor).makePaymentFor(
         payment.account.address,
         payment.baseAmount,
         payment.extraAmount,
@@ -2632,7 +2640,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).makePaymentFor(
+          connect(cardPaymentProcessorShell.contract, executor).makePaymentFor(
             payment.account.address,
             payment.baseAmount,
             payment.extraAmount,
@@ -2650,7 +2658,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(payment.account).makePaymentFor(
+          connect(cardPaymentProcessorShell.contract, payment.account).makePaymentFor(
             payment.account.address,
             payment.baseAmount,
             payment.extraAmount,
@@ -2668,7 +2676,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).makePaymentFor(
+          connect(cardPaymentProcessorShell.contract, executor).makePaymentFor(
             ZERO_ADDRESS,
             payment.baseAmount,
             payment.extraAmount,
@@ -2686,7 +2694,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).makePaymentFor(
+          connect(cardPaymentProcessorShell.contract, executor).makePaymentFor(
             payment.account.address,
             payment.baseAmount,
             payment.extraAmount,
@@ -2709,7 +2717,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const excessTokenAmount: number = INITIAL_USER_BALANCE + 1;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).makePaymentFor(
+          connect(cardPaymentProcessorShell.contract, executor).makePaymentFor(
             payment.account.address,
             excessTokenAmount,
             payment.extraAmount,
@@ -2730,7 +2738,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const subsidyLimitLocal = excessTokenAmount + 1;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).makePaymentFor(
+          connect(cardPaymentProcessorShell.contract, executor).makePaymentFor(
             payment.account.address,
             excessTokenAmount,
             payment.extraAmount,
@@ -2751,7 +2759,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const anotherCorrelationId: string = increaseBytesString(payment.correlationId, BYTES16_LENGTH);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).makePaymentFor(
+          connect(cardPaymentProcessorShell.contract, executor).makePaymentFor(
             payment.account.address,
             payment.baseAmount,
             payment.extraAmount,
@@ -2769,7 +2777,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).makePaymentFor(
+          connect(cardPaymentProcessorShell.contract, executor).makePaymentFor(
             payment.account.address,
             payment.baseAmount,
             payment.extraAmount,
@@ -2880,7 +2888,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         payment.authorizationId,
         PAYMENT_UPDATING_CORRELATION_ID_STUB
       );
-      const tx = cardPaymentProcessorShell.contract.connect(executor).updatePaymentAmount(
+      const tx = connect(cardPaymentProcessorShell.contract, executor).updatePaymentAmount(
         newBaseAmount,
         newExtraAmount,
         payment.authorizationId,
@@ -2913,7 +2921,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         payment.authorizationId,
         PAYMENT_UPDATING_CORRELATION_ID_STUB
       );
-      const tx = cardPaymentProcessorShell.contract.connect(executor).updatePaymentAmount(
+      const tx = connect(cardPaymentProcessorShell.contract, executor).updatePaymentAmount(
         props.newBaseAmount,
         props.newExtraAmount,
         payment.authorizationId,
@@ -3246,7 +3254,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).updatePaymentAmount(
+          connect(cardPaymentProcessorShell.contract, executor).updatePaymentAmount(
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -3260,7 +3268,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(deployer).updatePaymentAmount(
+          connect(cardPaymentProcessorShell.contract, deployer).updatePaymentAmount(
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -3274,7 +3282,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).updatePaymentAmount(
+          connect(cardPaymentProcessorShell.contract, executor).updatePaymentAmount(
             payment.baseAmount,
             payment.extraAmount,
             ZERO_AUTHORIZATION_ID,
@@ -3291,7 +3299,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).updatePaymentAmount(
+          connect(cardPaymentProcessorShell.contract, executor).updatePaymentAmount(
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -3309,7 +3317,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await cardPaymentProcessorShell.refundPayment(payment, refundAmount);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).updatePaymentAmount(
+          connect(cardPaymentProcessorShell.contract, executor).updatePaymentAmount(
             refundAmount - 1,
             payment.extraAmount,
             payment.authorizationId,
@@ -3329,7 +3337,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await cardPaymentProcessorShell.clearPayments([payment]);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).updatePaymentAmount(
+          connect(cardPaymentProcessorShell.contract, executor).updatePaymentAmount(
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -3351,7 +3359,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await cardPaymentProcessorShell.refundPayment(payment, refundAmount);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).updatePaymentAmount(
+          connect(cardPaymentProcessorShell.contract, executor).updatePaymentAmount(
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -3374,7 +3382,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.makePayments([payment]);
 
       cardPaymentProcessorShell.model.clearPayment(payment.authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).clearPayment(payment.authorizationId);
+      const tx = connect(cardPaymentProcessorShell.contract, executor).clearPayment(payment.authorizationId);
       expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
       await context.checkPaymentOperationsForTx(tx);
@@ -3391,7 +3399,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.refundPayment(payment, refundAmount);
 
       cardPaymentProcessorShell.model.clearPayment(payment.authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).clearPayment(payment.authorizationId);
+      const tx = connect(cardPaymentProcessorShell.contract, executor).clearPayment(payment.authorizationId);
       expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
       await context.checkPaymentOperationsForTx(tx);
@@ -3409,7 +3417,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.refundPayment(payment, refundAmount);
 
       cardPaymentProcessorShell.model.clearPayment(payment.authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).clearPayment(payment.authorizationId);
+      const tx = connect(cardPaymentProcessorShell.contract, executor).clearPayment(payment.authorizationId);
       expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
       await context.checkPaymentOperationsForTx(tx);
@@ -3421,7 +3429,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, payments: [payment] } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(deployer).clearPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, deployer).clearPayment(payment.authorizationId)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
@@ -3432,7 +3440,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).clearPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, executor).clearPayment(payment.authorizationId)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
@@ -3440,7 +3448,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const context = await prepareForPayments();
       const { cardPaymentProcessorShell } = context;
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).clearPayment(ZERO_AUTHORIZATION_ID)
+        connect(cardPaymentProcessorShell.contract, executor).clearPayment(ZERO_AUTHORIZATION_ID)
       ).to.be.revertedWithCustomError(
         cardPaymentProcessorShell.contract,
         REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
@@ -3452,7 +3460,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, payments: [payment] } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).clearPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, executor).clearPayment(payment.authorizationId)
       ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
@@ -3461,10 +3469,10 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, payments: [payment] } = context;
 
       await cardPaymentProcessorShell.makePayments([payment]);
-      await proveTx(cardPaymentProcessorShell.contract.connect(executor).clearPayment(payment.authorizationId));
+      await proveTx(connect(cardPaymentProcessorShell.contract, executor).clearPayment(payment.authorizationId));
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).clearPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, executor).clearPayment(payment.authorizationId)
       ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_CLEARED);
     });
   });
@@ -3479,7 +3487,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
 
       const operationIndex1 = cardPaymentProcessorShell.model.clearPayment(payments[0].authorizationId);
       const operationIndex2 = cardPaymentProcessorShell.model.clearPayment(payments[1].authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).clearPayments([
+      const tx = connect(cardPaymentProcessorShell.contract, executor).clearPayments([
         payments[0].authorizationId,
         payments[1].authorizationId
       ]);
@@ -3495,7 +3503,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).clearPayments([payment.authorizationId])
+        connect(cardPaymentProcessorShell.contract, executor).clearPayments([payment.authorizationId])
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
@@ -3504,7 +3512,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, payments: [payment] } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(deployer).clearPayments([payment.authorizationId])
+        connect(cardPaymentProcessorShell.contract, deployer).clearPayments([payment.authorizationId])
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
@@ -3513,7 +3521,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).clearPayments([])
+        connect(cardPaymentProcessorShell.contract, executor).clearPayments([])
       ).to.be.revertedWithCustomError(
         cardPaymentProcessorShell.contract,
         REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY
@@ -3526,7 +3534,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.makePayments(payments);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).clearPayments([
+        connect(cardPaymentProcessorShell.contract, executor).clearPayments([
           payments[0].authorizationId,
           ZERO_AUTHORIZATION_ID
         ])
@@ -3542,7 +3550,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.makePayments(payments);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).clearPayments([
+        connect(cardPaymentProcessorShell.contract, executor).clearPayments([
           payments[0].authorizationId,
           increaseBytesString(payments[1].authorizationId, BYTES16_LENGTH)
         ])
@@ -3554,10 +3562,10 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, payments } = context;
       await cardPaymentProcessorShell.makePayments(payments);
 
-      await proveTx(cardPaymentProcessorShell.contract.connect(executor).clearPayment(payments[1].authorizationId));
+      await proveTx(connect(cardPaymentProcessorShell.contract, executor).clearPayment(payments[1].authorizationId));
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).clearPayments([
+        connect(cardPaymentProcessorShell.contract, executor).clearPayments([
           payments[0].authorizationId,
           payments[1].authorizationId
         ])
@@ -3577,7 +3585,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await context.checkCardPaymentProcessorState();
 
       cardPaymentProcessorShell.model.unclearPayment(payment.authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payment.authorizationId);
+      const tx = connect(cardPaymentProcessorShell.contract, executor).unclearPayment(payment.authorizationId);
       expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
       await context.checkPaymentOperationsForTx(tx);
@@ -3597,7 +3605,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await context.checkCardPaymentProcessorState();
 
       cardPaymentProcessorShell.model.unclearPayment(payment.authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payment.authorizationId);
+      const tx = connect(cardPaymentProcessorShell.contract, executor).unclearPayment(payment.authorizationId);
       expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
       await context.checkPaymentOperationsForTx(tx);
@@ -3618,7 +3626,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await context.checkCardPaymentProcessorState();
 
       cardPaymentProcessorShell.model.unclearPayment(payment.authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payment.authorizationId);
+      const tx = connect(cardPaymentProcessorShell.contract, executor).unclearPayment(payment.authorizationId);
       expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
       await context.checkPaymentOperationsForTx(tx);
@@ -3632,7 +3640,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, executor).unclearPayment(payment.authorizationId)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
@@ -3641,7 +3649,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, payments: [payment] } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(deployer).unclearPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, deployer).unclearPayment(payment.authorizationId)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
@@ -3650,7 +3658,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).unclearPayment(ZERO_AUTHORIZATION_ID)
+        connect(cardPaymentProcessorShell.contract, executor).unclearPayment(ZERO_AUTHORIZATION_ID)
       ).to.be.revertedWithCustomError(
         cardPaymentProcessorShell.contract,
         REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
@@ -3662,7 +3670,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, payments: [payment] } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, executor).unclearPayment(payment.authorizationId)
       ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
@@ -3673,10 +3681,10 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.makePayments([payment]);
       await cardPaymentProcessorShell.clearPayments([payment]);
 
-      await proveTx(cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payment.authorizationId));
+      await proveTx(connect(cardPaymentProcessorShell.contract, executor).unclearPayment(payment.authorizationId));
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, executor).unclearPayment(payment.authorizationId)
       ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_IS_ALREADY_UNCLEARED);
     });
   });
@@ -3692,7 +3700,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
 
       const operationIndex1 = cardPaymentProcessorShell.model.unclearPayment(payments[0].authorizationId);
       const operationIndex2 = cardPaymentProcessorShell.model.unclearPayment(payments[1].authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).unclearPayments([
+      const tx = connect(cardPaymentProcessorShell.contract, executor).unclearPayments([
         payments[0].authorizationId,
         payments[1].authorizationId
       ]);
@@ -3708,7 +3716,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).unclearPayments([payment.authorizationId])
+        connect(cardPaymentProcessorShell.contract, executor).unclearPayments([payment.authorizationId])
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
@@ -3717,7 +3725,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, payments: [payment] } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(deployer).unclearPayments([payment.authorizationId])
+        connect(cardPaymentProcessorShell.contract, deployer).unclearPayments([payment.authorizationId])
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
@@ -3726,7 +3734,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).unclearPayments([])
+        connect(cardPaymentProcessorShell.contract, executor).unclearPayments([])
       ).to.be.revertedWithCustomError(
         cardPaymentProcessorShell.contract,
         REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY
@@ -3740,7 +3748,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.clearPayments(payments);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).unclearPayments([
+        connect(cardPaymentProcessorShell.contract, executor).unclearPayments([
           payments[0].authorizationId,
           ZERO_AUTHORIZATION_ID
         ])
@@ -3757,7 +3765,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.clearPayments(payments);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).unclearPayments([
+        connect(cardPaymentProcessorShell.contract, executor).unclearPayments([
           payments[0].authorizationId,
           increaseBytesString(payments[1].authorizationId, BYTES16_LENGTH)
         ])
@@ -3770,10 +3778,10 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.makePayments(payments);
       await cardPaymentProcessorShell.clearPayments(payments);
 
-      await proveTx(cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payments[1].authorizationId));
+      await proveTx(connect(cardPaymentProcessorShell.contract, executor).unclearPayment(payments[1].authorizationId));
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).unclearPayments([
+        connect(cardPaymentProcessorShell.contract, executor).unclearPayments([
           payments[0].authorizationId,
           payments[1].authorizationId
         ])
@@ -3794,7 +3802,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         PAYMENT_REVOKING_CORRELATION_ID_STUB,
         payment.parentTxHash
       );
-      const tx = cardPaymentProcessorShell.contract.connect(executor).revokePayment(
+      const tx = connect(cardPaymentProcessorShell.contract, executor).revokePayment(
         payment.authorizationId,
         PAYMENT_REVOKING_CORRELATION_ID_STUB,
         payment.parentTxHash
@@ -3898,7 +3906,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).revokePayment(
+          connect(cardPaymentProcessorShell.contract, executor).revokePayment(
             payment.authorizationId,
             PAYMENT_REVOKING_CORRELATION_ID_STUB,
             payment.parentTxHash
@@ -3911,7 +3919,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(deployer).revokePayment(
+          connect(cardPaymentProcessorShell.contract, deployer).revokePayment(
             payment.authorizationId,
             PAYMENT_REVOKING_CORRELATION_ID_STUB,
             payment.parentTxHash
@@ -3926,7 +3934,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await proveTx(cardPaymentProcessorShell.contract.setRevocationLimit(0));
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).revokePayment(
+          connect(cardPaymentProcessorShell.contract, executor).revokePayment(
             payment.authorizationId,
             PAYMENT_REVOKING_CORRELATION_ID_STUB,
             payment.parentTxHash
@@ -3942,7 +3950,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).revokePayment(
+          connect(cardPaymentProcessorShell.contract, executor).revokePayment(
             ZERO_AUTHORIZATION_ID,
             PAYMENT_REVOKING_CORRELATION_ID_STUB,
             payment.parentTxHash
@@ -3958,7 +3966,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).revokePayment(
+          connect(cardPaymentProcessorShell.contract, executor).revokePayment(
             payment.authorizationId,
             PAYMENT_REVOKING_CORRELATION_ID_STUB,
             ZERO_TRANSACTION_HASH
@@ -3971,7 +3979,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).revokePayment(
+          connect(cardPaymentProcessorShell.contract, executor).revokePayment(
             increaseBytesString(payment.authorizationId, BYTES16_LENGTH),
             PAYMENT_REVOKING_CORRELATION_ID_STUB,
             payment.parentTxHash
@@ -3994,7 +4002,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         PAYMENT_REVOKING_CORRELATION_ID_STUB,
         payment.parentTxHash
       );
-      const tx = cardPaymentProcessorShell.contract.connect(executor).reversePayment(
+      const tx = connect(cardPaymentProcessorShell.contract, executor).reversePayment(
         payment.authorizationId,
         PAYMENT_REVOKING_CORRELATION_ID_STUB,
         payment.parentTxHash
@@ -4080,7 +4088,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).reversePayment(
+          connect(cardPaymentProcessorShell.contract, executor).reversePayment(
             payment.authorizationId,
             PAYMENT_REVERSING_CORRELATION_ID_STUB,
             payment.parentTxHash
@@ -4093,7 +4101,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(deployer).reversePayment(
+          connect(cardPaymentProcessorShell.contract, deployer).reversePayment(
             payment.authorizationId,
             PAYMENT_REVERSING_CORRELATION_ID_STUB,
             payment.parentTxHash
@@ -4106,7 +4114,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).reversePayment(
+          connect(cardPaymentProcessorShell.contract, executor).reversePayment(
             ZERO_AUTHORIZATION_ID,
             PAYMENT_REVERSING_CORRELATION_ID_STUB,
             payment.parentTxHash
@@ -4122,7 +4130,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).reversePayment(
+          connect(cardPaymentProcessorShell.contract, executor).reversePayment(
             payment.authorizationId,
             PAYMENT_REVERSING_CORRELATION_ID_STUB,
             ZERO_TRANSACTION_HASH
@@ -4135,7 +4143,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).reversePayment(
+          connect(cardPaymentProcessorShell.contract, executor).reversePayment(
             increaseBytesString(payment.authorizationId, BYTES16_LENGTH),
             PAYMENT_REVERSING_CORRELATION_ID_STUB,
             payment.parentTxHash
@@ -4155,7 +4163,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.clearPayments([payment]);
 
       cardPaymentProcessorShell.model.confirmPayment(payment.authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).confirmPayment(payment.authorizationId);
+      const tx = connect(cardPaymentProcessorShell.contract, executor).confirmPayment(payment.authorizationId);
       expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
       await context.checkPaymentOperationsForTx(tx);
@@ -4173,7 +4181,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.refundPayment(payment, refundAmount);
 
       cardPaymentProcessorShell.model.confirmPayment(payment.authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).confirmPayment(payment.authorizationId);
+      const tx = connect(cardPaymentProcessorShell.contract, executor).confirmPayment(payment.authorizationId);
       expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
       await context.checkPaymentOperationsForTx(tx);
@@ -4192,7 +4200,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.refundPayment(payment, refundAmount);
 
       cardPaymentProcessorShell.model.confirmPayment(payment.authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).confirmPayment(payment.authorizationId);
+      const tx = connect(cardPaymentProcessorShell.contract, executor).confirmPayment(payment.authorizationId);
       expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
       await context.checkPaymentOperationsForTx(tx);
@@ -4205,7 +4213,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).confirmPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, executor).confirmPayment(payment.authorizationId)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
@@ -4214,7 +4222,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, payments: [payment] } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(deployer).confirmPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, deployer).confirmPayment(payment.authorizationId)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
@@ -4223,7 +4231,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).confirmPayment(ZERO_AUTHORIZATION_ID)
+        connect(cardPaymentProcessorShell.contract, executor).confirmPayment(ZERO_AUTHORIZATION_ID)
       ).to.be.revertedWithCustomError(
         cardPaymentProcessorShell.contract,
         REVERT_ERROR_IF_PAYMENT_AUTHORIZATION_ID_IS_ZERO
@@ -4235,7 +4243,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, payments: [payment] } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).confirmPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, executor).confirmPayment(payment.authorizationId)
       ).to.be.revertedWithCustomError(cardPaymentProcessorShell.contract, REVERT_ERROR_IF_PAYMENT_DOES_NOT_EXIST);
     });
 
@@ -4245,7 +4253,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.makePayments([payment]);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).confirmPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, executor).confirmPayment(payment.authorizationId)
       ).to.be.revertedWithCustomError(
         cardPaymentProcessorShell.contract,
         REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
@@ -4261,7 +4269,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await proveTx(cardPaymentProcessorShell.contract.setCashOutAccount(ZERO_ADDRESS));
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).confirmPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, executor).confirmPayment(payment.authorizationId)
       ).to.be.revertedWithCustomError(
         cardPaymentProcessorShell.contract,
         REVERT_ERROR_IF_CASH_OUT_ACCOUNT_ADDRESS_IS_ZERO
@@ -4280,7 +4288,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
 
       const operationIndex1 = cardPaymentProcessorShell.model.confirmPayment(payments[0].authorizationId);
       const operationIndex2 = cardPaymentProcessorShell.model.confirmPayment(payments[1].authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).confirmPayments([
+      const tx = connect(cardPaymentProcessorShell.contract, executor).confirmPayments([
         payments[0].authorizationId,
         payments[1].authorizationId
       ]);
@@ -4296,7 +4304,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).confirmPayments([payment.authorizationId])
+        connect(cardPaymentProcessorShell.contract, executor).confirmPayments([payment.authorizationId])
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
@@ -4305,7 +4313,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, payments: [payment] } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(deployer).confirmPayments([payment.authorizationId])
+        connect(cardPaymentProcessorShell.contract, deployer).confirmPayments([payment.authorizationId])
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
@@ -4314,7 +4322,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).confirmPayments([])
+        connect(cardPaymentProcessorShell.contract, executor).confirmPayments([])
       ).to.be.revertedWithCustomError(
         cardPaymentProcessorShell.contract,
         REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY
@@ -4328,7 +4336,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.clearPayments(payments);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).confirmPayments([
+        connect(cardPaymentProcessorShell.contract, executor).confirmPayments([
           payments[0].authorizationId,
           ZERO_AUTHORIZATION_ID
         ])
@@ -4345,7 +4353,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.clearPayments(payments);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).confirmPayments([
+        connect(cardPaymentProcessorShell.contract, executor).confirmPayments([
           payments[0].authorizationId,
           increaseBytesString(payments[1].authorizationId, BYTES16_LENGTH)
         ])
@@ -4358,10 +4366,10 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.makePayments(payments);
       await cardPaymentProcessorShell.clearPayments(payments);
 
-      await proveTx(cardPaymentProcessorShell.contract.connect(executor).unclearPayment(payments[1].authorizationId));
+      await proveTx(connect(cardPaymentProcessorShell.contract, executor).unclearPayment(payments[1].authorizationId));
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).confirmPayments([
+        connect(cardPaymentProcessorShell.contract, executor).confirmPayments([
           payments[0].authorizationId,
           payments[1].authorizationId
         ])
@@ -4380,7 +4388,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await proveTx(cardPaymentProcessorShell.contract.setCashOutAccount(ZERO_ADDRESS));
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).confirmPayments([
+        connect(cardPaymentProcessorShell.contract, executor).confirmPayments([
           payments[0].authorizationId,
           payments[1].authorizationId
         ])
@@ -4402,7 +4410,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
 
       const operationIndex1 = cardPaymentProcessorShell.model.clearPayment(payment.authorizationId);
       const operationIndex2 = cardPaymentProcessorShell.model.confirmPayment(payment.authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).clearAndConfirmPayment(payment.authorizationId);
+      const tx = connect(cardPaymentProcessorShell.contract, executor).clearAndConfirmPayment(payment.authorizationId);
       expect(tx).to.be.not.undefined; // Silence TypeScript linter warning about assertion absence
 
       await context.checkPaymentOperationsForTx(tx, [operationIndex1, operationIndex2]);
@@ -4415,7 +4423,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).clearAndConfirmPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, executor).clearAndConfirmPayment(payment.authorizationId)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
@@ -4424,7 +4432,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, payments: [payment] } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(deployer).clearAndConfirmPayment(payment.authorizationId)
+        connect(cardPaymentProcessorShell.contract, deployer).clearAndConfirmPayment(payment.authorizationId)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
@@ -4481,7 +4489,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const operationIndex3 = cardPaymentProcessorShell.model.confirmPayment(payment.authorizationId);
       operationIndexes.push(operationIndex3);
 
-      const tx = cardPaymentProcessorShell.contract.connect(executor).updateLazyClearConfirmPayment(
+      const tx = connect(cardPaymentProcessorShell.contract, executor).updateLazyClearConfirmPayment(
         newBaseAmount,
         newExtraAmount,
         payment.authorizationId,
@@ -4518,7 +4526,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).updateLazyClearConfirmPayment(
+          connect(cardPaymentProcessorShell.contract, executor).updateLazyClearConfirmPayment(
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -4532,7 +4540,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(deployer).updateLazyClearConfirmPayment(
+          connect(cardPaymentProcessorShell.contract, deployer).updateLazyClearConfirmPayment(
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -4557,7 +4565,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const operationIndex2 = cardPaymentProcessorShell.model.clearPayment(payments[1].authorizationId);
       const operationIndex3 = cardPaymentProcessorShell.model.confirmPayment(payments[0].authorizationId);
       const operationIndex4 = cardPaymentProcessorShell.model.confirmPayment(payments[1].authorizationId);
-      const tx = cardPaymentProcessorShell.contract.connect(executor).clearAndConfirmPayments([
+      const tx = connect(cardPaymentProcessorShell.contract, executor).clearAndConfirmPayments([
         payments[0].authorizationId,
         payments[1].authorizationId
       ]);
@@ -4578,7 +4586,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await pauseContract(cardPaymentProcessorShell.contract);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).clearAndConfirmPayments([payment.authorizationId])
+        connect(cardPaymentProcessorShell.contract, executor).clearAndConfirmPayments([payment.authorizationId])
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
 
@@ -4587,7 +4595,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, payments: [payment] } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(deployer).clearAndConfirmPayments([payment.authorizationId])
+        connect(cardPaymentProcessorShell.contract, deployer).clearAndConfirmPayments([payment.authorizationId])
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, executorRole));
     });
 
@@ -4596,7 +4604,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell } = context;
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).clearAndConfirmPayments([])
+        connect(cardPaymentProcessorShell.contract, executor).clearAndConfirmPayments([])
       ).to.be.revertedWithCustomError(
         cardPaymentProcessorShell.contract,
         REVERT_ERROR_IF_INPUT_ARRAY_OF_AUTHORIZATION_IDS_IS_EMPTY
@@ -4666,7 +4674,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         payment.authorizationId,
         PAYMENT_REFUNDING_CORRELATION_ID_STUB
       );
-      const tx = cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT_FULL](
+      const tx = connect(cardPaymentProcessorShell.contract, executor)[FUNCTION_REFUND_PAYMENT_FULL](
         refundAmount,
         newExtraAmount,
         payment.authorizationId,
@@ -4707,7 +4715,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         payment.authorizationId,
         PAYMENT_REFUNDING_CORRELATION_ID_STUB
       );
-      const tx = cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT_FULL](
+      const tx = connect(cardPaymentProcessorShell.contract, executor)[FUNCTION_REFUND_PAYMENT_FULL](
         props.refundAmount,
         props.newExtraAmount,
         payment.authorizationId,
@@ -4977,7 +4985,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT_FULL](
+          connect(cardPaymentProcessorShell.contract, executor)[FUNCTION_REFUND_PAYMENT_FULL](
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -4991,7 +4999,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(deployer).functions[FUNCTION_REFUND_PAYMENT_FULL](
+          connect(cardPaymentProcessorShell.contract, deployer)[FUNCTION_REFUND_PAYMENT_FULL](
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -5005,7 +5013,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT_FULL](
+          connect(cardPaymentProcessorShell.contract, executor)[FUNCTION_REFUND_PAYMENT_FULL](
             payment.baseAmount,
             payment.extraAmount,
             ZERO_AUTHORIZATION_ID,
@@ -5022,7 +5030,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT_FULL](
+          connect(cardPaymentProcessorShell.contract, executor)[FUNCTION_REFUND_PAYMENT_FULL](
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -5038,7 +5046,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const refundAmount = payment.baseAmount + 1;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT_FULL](
+          connect(cardPaymentProcessorShell.contract, executor)[FUNCTION_REFUND_PAYMENT_FULL](
             refundAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -5060,7 +5068,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await proveTx(cardPaymentProcessorShell.contract.setCashOutAccount(ZERO_ADDRESS));
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT_FULL](
+          connect(cardPaymentProcessorShell.contract, executor)[FUNCTION_REFUND_PAYMENT_FULL](
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -5079,7 +5087,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await cardPaymentProcessorShell.revokePayment(payment);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT_FULL](
+          connect(cardPaymentProcessorShell.contract, executor)[FUNCTION_REFUND_PAYMENT_FULL](
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -5098,7 +5106,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await cardPaymentProcessorShell.reversePayment(payment);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT_FULL](
+          connect(cardPaymentProcessorShell.contract, executor)[FUNCTION_REFUND_PAYMENT_FULL](
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -5117,7 +5125,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         payment.extraAmount += 1;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT_FULL](
+          connect(cardPaymentProcessorShell.contract, executor)[FUNCTION_REFUND_PAYMENT_FULL](
             payment.baseAmount,
             payment.extraAmount,
             payment.authorizationId,
@@ -5148,7 +5156,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
             payment.authorizationId,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
           );
-          const tx = cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT_PRUNED](
+          const tx = connect(cardPaymentProcessorShell.contract, executor)[FUNCTION_REFUND_PAYMENT_PRUNED](
             refundAmount,
             payment.authorizationId,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
@@ -5168,7 +5176,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).functions[FUNCTION_REFUND_PAYMENT_PRUNED](
+          connect(cardPaymentProcessorShell.contract, executor)[FUNCTION_REFUND_PAYMENT_PRUNED](
             payment.baseAmount,
             payment.authorizationId,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
@@ -5181,7 +5189,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell, payments: [payment] } = context;
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(deployer).functions[FUNCTION_REFUND_PAYMENT_PRUNED](
+          connect(cardPaymentProcessorShell.contract, deployer)[FUNCTION_REFUND_PAYMENT_PRUNED](
             payment.baseAmount,
             payment.authorizationId,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
@@ -5199,7 +5207,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       const { cardPaymentProcessorShell, tokenMock } = await prepareForPayments();
       await proveTx(tokenMock.mint(cashOutAccount.address, tokenAmount));
 
-      const tx = await cardPaymentProcessorShell.contract.connect(executor).refundAccount(
+      const tx = await connect(cardPaymentProcessorShell.contract, executor).refundAccount(
         user1.address,
         tokenAmount,
         PAYMENT_REFUNDING_CORRELATION_ID_STUB
@@ -5232,7 +5240,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await pauseContract(cardPaymentProcessorShell.contract);
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).refundAccount(
+          connect(cardPaymentProcessorShell.contract, executor).refundAccount(
             user1.address,
             nonZeroTokenAmount,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
@@ -5244,7 +5252,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell } = await prepareForPayments();
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(deployer).refundAccount(
+          connect(cardPaymentProcessorShell.contract, deployer).refundAccount(
             user1.address,
             nonZeroTokenAmount,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
@@ -5256,7 +5264,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         const { cardPaymentProcessorShell } = await prepareForPayments();
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).refundAccount(
+          connect(cardPaymentProcessorShell.contract, executor).refundAccount(
             ZERO_ADDRESS,
             nonZeroTokenAmount,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
@@ -5270,7 +5278,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         await proveTx(tokenMock.mint(cashOutAccount.address, tokenAmount - 1));
 
         await expect(
-          cardPaymentProcessorShell.contract.connect(executor).refundAccount(
+          connect(cardPaymentProcessorShell.contract, executor).refundAccount(
             user1.address,
             tokenAmount,
             PAYMENT_REFUNDING_CORRELATION_ID_STUB
@@ -5287,24 +5295,24 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       status: PaymentStatus
     ) {
       const authorizationIds = payments.map(payment => payment.authorizationId);
-      await expect(cardPaymentProcessor.connect(executor).clearPayment(authorizationIds[0]))
+      await expect(connect(cardPaymentProcessor, executor).clearPayment(authorizationIds[0]))
         .to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS)
         .withArgs(status);
 
-      await expect(cardPaymentProcessor.connect(executor).clearPayments(authorizationIds))
+      await expect(connect(cardPaymentProcessor, executor).clearPayments(authorizationIds))
         .to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS)
         .withArgs(status);
 
-      await expect(cardPaymentProcessor.connect(executor).unclearPayment(authorizationIds[0]))
+      await expect(connect(cardPaymentProcessor, executor).unclearPayment(authorizationIds[0]))
         .to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS)
         .withArgs(status);
 
-      await expect(cardPaymentProcessor.connect(executor).unclearPayments(authorizationIds))
+      await expect(connect(cardPaymentProcessor, executor).unclearPayments(authorizationIds))
         .to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS)
         .withArgs(status);
 
       await expect(
-        cardPaymentProcessor.connect(executor).revokePayment(
+        connect(cardPaymentProcessor, executor).revokePayment(
           authorizationIds[0],
           PAYMENT_REVOKING_CORRELATION_ID_STUB,
           payments[0].parentTxHash
@@ -5315,7 +5323,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       ).withArgs(status);
 
       await expect(
-        cardPaymentProcessor.connect(executor).reversePayment(
+        connect(cardPaymentProcessor, executor).reversePayment(
           authorizationIds[0],
           PAYMENT_REVERSING_CORRELATION_ID_STUB,
           payments[0].parentTxHash
@@ -5325,16 +5333,16 @@ describe("Contract 'CardPaymentProcessor'", async () => {
         REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS
       ).withArgs(status);
 
-      await expect(cardPaymentProcessor.connect(executor).confirmPayment(authorizationIds[0]))
+      await expect(connect(cardPaymentProcessor, executor).confirmPayment(authorizationIds[0]))
         .to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS)
         .withArgs(status);
 
-      await expect(cardPaymentProcessor.connect(executor).confirmPayments(authorizationIds))
+      await expect(connect(cardPaymentProcessor, executor).confirmPayments(authorizationIds))
         .to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_PAYMENT_HAS_INAPPROPRIATE_STATUS)
         .withArgs(status);
 
       await expect(
-        cardPaymentProcessor.connect(executor).updatePaymentAmount(
+        connect(cardPaymentProcessor, executor).updatePaymentAmount(
           payments[0].baseAmount,
           payments[0].extraAmount,
           authorizationIds[0],
@@ -5361,7 +5369,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       );
 
       cardPaymentProcessorShell.model.makePayment(payments[0], { sender: executor });
-      const tx = cardPaymentProcessorShell.contract.connect(executor).makePaymentFor(
+      const tx = connect(cardPaymentProcessorShell.contract, executor).makePaymentFor(
         payments[0].account.address,
         payments[0].baseAmount,
         payments[0].extraAmount,
@@ -5383,7 +5391,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.reversePayment(payments[0]);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).makePaymentFor(
+        connect(cardPaymentProcessorShell.contract, executor).makePaymentFor(
           payments[0].account.address,
           payments[0].baseAmount,
           payments[0].extraAmount,
@@ -5412,7 +5420,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.confirmPayments([payments[0]]);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).makePaymentFor(
+        connect(cardPaymentProcessorShell.contract, executor).makePaymentFor(
           payments[0].account.address,
           payments[0].baseAmount,
           payments[0].extraAmount,
@@ -5440,7 +5448,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.clearPayments(payments);
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).makePaymentFor(
+        connect(cardPaymentProcessorShell.contract, executor).makePaymentFor(
           payments[0].account.address,
           payments[0].baseAmount,
           payments[0].extraAmount,
@@ -5468,7 +5476,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await context.checkCardPaymentProcessorState();
 
       await expect(
-        cardPaymentProcessorShell.contract.connect(executor).makePaymentFor(
+        connect(cardPaymentProcessorShell.contract, executor).makePaymentFor(
           payments[0].account.address,
           payments[0].baseAmount,
           payments[0].extraAmount,
@@ -5510,9 +5518,9 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await cardPaymentProcessorShell.makePayments([payments[0]]);
       await cardPaymentProcessorShell.clearPayments([payments[0]]);
 
-      const cashOutAccountBalanceBefore: BigNumber = await tokenMock.balanceOf(cashOutAccount.address);
+      const cashOutAccountBalanceBefore: bigint = await tokenMock.balanceOf(cashOutAccount.address);
       await cardPaymentProcessorShell.confirmPayments([payments[0]]);
-      const cashOutAccountBalanceAfter: BigNumber = await tokenMock.balanceOf(cashOutAccount.address);
+      const cashOutAccountBalanceAfter: bigint = await tokenMock.balanceOf(cashOutAccount.address);
       await context.checkCardPaymentProcessorState();
       expect(cashOutAccountBalanceBefore).to.equal(cashOutAccountBalanceAfter);
     });

--- a/test/CashbackDistributor.test.ts
+++ b/test/CashbackDistributor.test.ts
@@ -1,17 +1,16 @@
 import { ethers, network, upgrades } from "hardhat";
 import { expect } from "chai";
-import { BigNumber, Contract, ContractFactory } from "ethers";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { Block, Contract, ContractFactory, TransactionReceipt } from "ethers";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
-import { proveTx } from "../test-utils/eth";
+import { connect, getAddress, proveTx } from "../test-utils/eth";
 import { createBytesString, createRevertMessageDueToMissingRole } from "../test-utils/misc";
-import { Block, TransactionReceipt } from "@ethersproject/abstract-provider";
 import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
 
-const MAX_UINT256 = ethers.constants.MaxUint256;
-const MAX_INT256 = ethers.constants.MaxInt256;
-const ZERO_ADDRESS = ethers.constants.AddressZero;
-const ZERO_HASH = ethers.constants.HashZero;
+const MAX_UINT256 = ethers.MaxUint256;
+const MAX_INT256 = ethers.MaxInt256;
+const ZERO_ADDRESS = ethers.ZeroAddress;
+const ZERO_HASH = ethers.ZeroHash;
 const BYTES32_LENGTH: number = 32;
 
 enum CashbackStatus {
@@ -54,10 +53,10 @@ interface TestCashback {
   kind: CashbackKind;
   status: CashbackStatus;
   externalId: string;
-  recipient: SignerWithAddress;
+  recipient: HardhatEthersSigner;
   requestedAmount: number;
   sentAmount: number;
-  sender: SignerWithAddress;
+  sender: HardhatEthersSigner;
   nonce: number;
   revokedAmount?: number;
   increaseRequestedAmount?: number;
@@ -121,7 +120,7 @@ function checkEquality(
     checkNonexistentCashback(actualOnChainCashback, expectedCashback.nonce);
   } else {
     expect(actualOnChainCashback.token).to.equal(
-      expectedCashback.token.address,
+      getAddress(expectedCashback.token),
       `cashback[${expectedCashback.nonce - 1}].token is incorrect`
     );
     expect(actualOnChainCashback.kind).to.equal(
@@ -192,18 +191,18 @@ describe("Contract 'CashbackDistributor'", async () => {
   const REVERT_ERROR_IF_RECIPIENT_ADDRESS_IS_ZERO = "ZeroRecipientAddress";
   const REVERT_ERROR_IF_EXTERNAL_ID_IS_ZERO = "ZeroExternalId";
 
-  const ownerRole: string = ethers.utils.id("OWNER_ROLE");
-  const blocklisterRole: string = ethers.utils.id("BLOCKLISTER_ROLE");
-  const pauserRole: string = ethers.utils.id("PAUSER_ROLE");
-  const rescuerRole: string = ethers.utils.id("RESCUER_ROLE");
-  const distributorRole: string = ethers.utils.id("DISTRIBUTOR_ROLE");
+  const ownerRole: string = ethers.id("OWNER_ROLE");
+  const blocklisterRole: string = ethers.id("BLOCKLISTER_ROLE");
+  const pauserRole: string = ethers.id("PAUSER_ROLE");
+  const rescuerRole: string = ethers.id("RESCUER_ROLE");
+  const distributorRole: string = ethers.id("DISTRIBUTOR_ROLE");
 
   let cashbackDistributorFactory: ContractFactory;
   let tokenMockFactory: ContractFactory;
 
-  let deployer: SignerWithAddress;
-  let distributor: SignerWithAddress;
-  let user: SignerWithAddress;
+  let deployer: HardhatEthersSigner;
+  let distributor: HardhatEthersSigner;
+  let user: HardhatEthersSigner;
 
   before(async () => {
     cashbackDistributorFactory = await ethers.getContractFactory("CashbackDistributor");
@@ -217,14 +216,14 @@ describe("Contract 'CashbackDistributor'", async () => {
     const symbol = "TEST" + nameSuffix;
 
     const tokenMock: Contract = await upgrades.deployProxy(tokenMockFactory, [name, symbol]);
-    await tokenMock.deployed();
+    await tokenMock.waitForDeployment();
 
     return tokenMock;
   }
 
   async function deployCashbackDistributor(): Promise<{ cashbackDistributor: Contract }> {
     const cashbackDistributor: Contract = await upgrades.deployProxy(cashbackDistributorFactory);
-    await cashbackDistributor.deployed();
+    await cashbackDistributor.waitForDeployment();
 
     return { cashbackDistributor };
   }
@@ -245,7 +244,7 @@ describe("Contract 'CashbackDistributor'", async () => {
   }
 
   async function setUpContractsForSendingCashbacks(
-    cashbackDistributor: Contract,
+    cashbackDistributorAddress: Contract,
     cashbacks: TestCashback[]
   ): Promise<{ cashbackDistributorInitialBalanceByToken: Map<Contract, number> }> {
     const cashbackDistributorInitialBalanceByToken: Map<Contract, number> = new Map<Contract, number>();
@@ -255,7 +254,7 @@ describe("Contract 'CashbackDistributor'", async () => {
       cashbackDistributorInitialBalanceByToken.set(cashback.token, totalCashbackAmount);
     });
     for (const [token, totalCashbackAmount] of cashbackDistributorInitialBalanceByToken.entries()) {
-      await proveTx(token.mint(cashbackDistributor.address, totalCashbackAmount));
+      await proveTx(token.mint(cashbackDistributorAddress, totalCashbackAmount));
     }
     return { cashbackDistributorInitialBalanceByToken };
   }
@@ -273,8 +272,8 @@ describe("Contract 'CashbackDistributor'", async () => {
     const transactionReceipts: TransactionReceipt[] = [];
     for (const cashback of cashbacks) {
       const transactionReceipt = await proveTx(
-        cashbackDistributor.connect(cashback.sender).sendCashback(
-          cashback.token.address,
+        connect(cashbackDistributor, cashback.sender).sendCashback(
+          getAddress(cashback.token),
           cashback.kind,
           cashback.externalId,
           cashback.recipient.address,
@@ -299,7 +298,7 @@ describe("Contract 'CashbackDistributor'", async () => {
   async function revokeCashback(cashbackDistributor: Contract, cashback: TestCashback, amount: number) {
     cashback.revokedAmount = amount + (cashback.revokedAmount || 0);
 
-    await expect(cashbackDistributor.connect(distributor).revokeCashback(cashback.nonce, amount))
+    await expect(connect(cashbackDistributor, distributor).revokeCashback(cashback.nonce, amount))
       .to.emit(cashbackDistributor, EVENT_NAME_REVOKE_CASHBACK)
       .withArgs(
         anyValue,
@@ -319,7 +318,7 @@ describe("Contract 'CashbackDistributor'", async () => {
     cashback.requestedAmount += amount;
     cashback.sentAmount += amount;
 
-    await expect(cashbackDistributor.connect(distributor).increaseCashback(cashback.nonce, amount))
+    await expect(connect(cashbackDistributor, distributor).increaseCashback(cashback.nonce, amount))
       .to.emit(cashbackDistributor, EVENT_NAME_INCREASE_CASHBACK)
       .withArgs(
         anyValue,
@@ -354,11 +353,11 @@ describe("Contract 'CashbackDistributor'", async () => {
 
   async function checkCashbackNonceByExternalId(context: TestContext) {
     const { fixture: { cashbackDistributor }, cashbacks } = context;
-    const expectedMap = new Map<string, BigNumber[]>();
+    const expectedMap = new Map<string, bigint[]>();
 
     cashbacks.forEach(cashback => {
-      const nonces: BigNumber[] = expectedMap.get(cashback.externalId) || [];
-      nonces.push(BigNumber.from(cashback.nonce));
+      const nonces: bigint[] = expectedMap.get(cashback.externalId) || [];
+      nonces.push(BigInt(cashback.nonce));
       expectedMap.set(cashback.externalId, nonces);
     });
 
@@ -384,7 +383,9 @@ describe("Contract 'CashbackDistributor'", async () => {
 
     for (const [token, expectedTotalCashbackByExternalId] of expectedMap) {
       for (const [externalId, expectedTotalCashback] of expectedTotalCashbackByExternalId) {
-        expect(await cashbackDistributor.getTotalCashbackByTokenAndExternalId(token.address, externalId)).to.equal(
+        expect(
+          await cashbackDistributor.getTotalCashbackByTokenAndExternalId(getAddress(token), externalId)
+        ).to.equal(
           expectedTotalCashback,
           `Wrong total cashback for the token with symbol ${await token.symbol()} and external ID ${externalId}`
         );
@@ -408,7 +409,9 @@ describe("Contract 'CashbackDistributor'", async () => {
     for (const [token, expectedTotalCashbackByRecipient] of expectedMap) {
       const tokenSymbol: string = await token.symbol();
       for (const [recipientAddress, expectedTotalCashback] of expectedTotalCashbackByRecipient) {
-        expect(await cashbackDistributor.getTotalCashbackByTokenAndRecipient(token.address, recipientAddress)).to.equal(
+        expect(
+          await cashbackDistributor.getTotalCashbackByTokenAndRecipient(getAddress(token), recipientAddress)
+        ).to.equal(
           expectedTotalCashback,
           `Wrong total cashback for the token with symbol "${tokenSymbol}" and recipient address ${recipientAddress}`
         );
@@ -433,7 +436,7 @@ describe("Contract 'CashbackDistributor'", async () => {
 
     for (const [token, expectedBalance] of expectedMap) {
       const tokenSymbol: string = await token.symbol();
-      expect(await token.balanceOf(cashbackDistributor.address)).to.equal(
+      expect(await token.balanceOf(getAddress(cashbackDistributor))).to.equal(
         expectedBalance,
         `Wrong balance of the cashback distributor for token address with symbol "${tokenSymbol}"`
       );
@@ -453,7 +456,7 @@ describe("Contract 'CashbackDistributor'", async () => {
   ): Promise<{ fixture: Fixture; cashback: TestCashback }> {
     const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
     const cashback: TestCashback = {
-      token: tokenMockFactory.attach(TOKEN_ADDRESS_STUB),
+      token: tokenMockFactory.attach(TOKEN_ADDRESS_STUB) as Contract,
       kind: CashbackKind.CardPayment,
       status: CashbackStatus.Nonexistent,
       externalId: CASHBACK_EXTERNAL_ID_STUB1,
@@ -531,7 +534,7 @@ describe("Contract 'CashbackDistributor'", async () => {
     it("Is reverted if the caller does not have the owner role", async () => {
       const { cashbackDistributor } = await setUpFixture(deployCashbackDistributor);
       await expect(
-        cashbackDistributor.connect(user).enable()
+        connect(cashbackDistributor, user).enable()
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(user.address, ownerRole));
     });
 
@@ -559,7 +562,7 @@ describe("Contract 'CashbackDistributor'", async () => {
     it("Is reverted if the caller does not have the owner role", async () => {
       const { cashbackDistributor } = await setUpFixture(deployCashbackDistributor);
       await expect(
-        cashbackDistributor.connect(user).disable()
+        connect(cashbackDistributor, user).disable()
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(user.address, ownerRole));
     });
 
@@ -577,31 +580,28 @@ describe("Contract 'CashbackDistributor'", async () => {
       const cashback: TestCashback = cashbacks[cashbacks.length - 1];
       const recipientBalanceChange = cashback.sentAmount;
 
-      const returnValues = await cashbackDistributor.connect(cashback.sender).callStatic.sendCashback(
-        cashback.token.address,
+      const returnValues = await connect(cashbackDistributor, cashback.sender).sendCashback.staticCall(
+        getAddress(cashback.token),
         cashback.kind,
         cashback.externalId,
         cashback.recipient.address,
         cashback.requestedAmount
       );
 
-      await expect(
-        cashbackDistributor.connect(cashback.sender).sendCashback(
-          cashback.token.address,
-          cashback.kind,
-          cashback.externalId,
-          cashback.recipient.address,
-          cashback.requestedAmount
-        )
-      ).to.changeTokenBalances(
+      const tx = connect(cashbackDistributor, cashback.sender).sendCashback(
+        getAddress(cashback.token),
+        cashback.kind,
+        cashback.externalId,
+        cashback.recipient.address,
+        cashback.requestedAmount
+      );
+      await expect(tx).to.changeTokenBalances(
         cashback.token,
         [cashbackDistributor, cashback.recipient, cashback.sender],
         [-recipientBalanceChange, +recipientBalanceChange, 0]
-      ).and.to.emit(
-        cashbackDistributor,
-        EVENT_NAME_SEND_CASHBACK
-      ).withArgs(
-        cashback.token.address,
+      );
+      await expect(tx).to.emit(cashbackDistributor, EVENT_NAME_SEND_CASHBACK).withArgs(
+        getAddress(cashback.token),
         cashback.kind,
         cashback.status,
         cashback.externalId,
@@ -683,8 +683,8 @@ describe("Contract 'CashbackDistributor'", async () => {
             [cashback1, cashback2]
           );
           await proveTx(
-            fixture.cashbackDistributor.connect(cashback1.sender).sendCashback(
-              cashback1.token.address,
+            connect(fixture.cashbackDistributor, cashback1.sender).sendCashback(
+              getAddress(cashback1.token),
               cashback1.kind,
               cashback1.externalId,
               cashback1.recipient.address,
@@ -715,8 +715,8 @@ describe("Contract 'CashbackDistributor'", async () => {
         const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
         await pauseContract(cashbackDistributor);
         await expect(
-          cashbackDistributor.connect(cashback.sender).sendCashback(
-            cashback.token.address,
+          connect(cashbackDistributor, cashback.sender).sendCashback(
+            getAddress(cashback.token),
             cashback.kind,
             cashback.externalId,
             cashback.recipient.address,
@@ -729,7 +729,7 @@ describe("Contract 'CashbackDistributor'", async () => {
         const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
         await expect(
           cashbackDistributor.sendCashback(
-            cashback.token.address,
+            getAddress(cashback.token),
             cashback.kind,
             cashback.externalId,
             cashback.recipient.address,
@@ -741,7 +741,7 @@ describe("Contract 'CashbackDistributor'", async () => {
       it("The token address is zero", async () => {
         const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
         await expect(
-          cashbackDistributor.connect(cashback.sender).sendCashback(
+          connect(cashbackDistributor, cashback.sender).sendCashback(
             ZERO_ADDRESS,
             cashback.kind,
             cashback.externalId,
@@ -754,8 +754,8 @@ describe("Contract 'CashbackDistributor'", async () => {
       it("The recipient address is zero", async () => {
         const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
         await expect(
-          cashbackDistributor.connect(cashback.sender).sendCashback(
-            cashback.token.address,
+          connect(cashbackDistributor, cashback.sender).sendCashback(
+            getAddress(cashback.token),
             cashback.kind,
             cashback.externalId,
             ZERO_ADDRESS,
@@ -768,8 +768,8 @@ describe("Contract 'CashbackDistributor'", async () => {
         const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
         cashback.externalId = ZERO_HASH;
         await expect(
-          cashbackDistributor.connect(cashback.sender).sendCashback(
-            cashback.token.address,
+          connect(cashbackDistributor, cashback.sender).sendCashback(
+            getAddress(cashback.token),
             cashback.kind,
             cashback.externalId,
             cashback.recipient.address,
@@ -786,22 +786,19 @@ describe("Contract 'CashbackDistributor'", async () => {
       const contractBalanceChange =
         targetRevocationStatus === RevocationStatus.Success ? cashback.revokedAmount || 0 : 0;
 
-      const returnValue = await cashbackDistributor.connect(cashback.sender).callStatic.revokeCashback(
+      const returnValue = await connect(cashbackDistributor, cashback.sender).revokeCashback.staticCall(
         cashback.nonce,
         cashback.revokedAmount
       );
 
-      await expect(
-        cashbackDistributor.connect(distributor).revokeCashback(cashback.nonce, cashback.revokedAmount)
-      ).to.changeTokenBalances(
+      const tx = connect(cashbackDistributor, distributor).revokeCashback(cashback.nonce, cashback.revokedAmount);
+      await expect(tx).to.changeTokenBalances(
         cashback.token,
         [cashbackDistributor, cashback.recipient, cashback.sender],
         [+contractBalanceChange, 0, -contractBalanceChange]
-      ).and.to.emit(
-        cashbackDistributor,
-        EVENT_NAME_REVOKE_CASHBACK
-      ).withArgs(
-        cashback.token.address,
+      );
+      await expect(tx).to.emit(cashbackDistributor, EVENT_NAME_REVOKE_CASHBACK).withArgs(
+        getAddress(cashback.token),
         cashback.kind,
         cashback.status,
         targetRevocationStatus,
@@ -828,7 +825,7 @@ describe("Contract 'CashbackDistributor'", async () => {
         cashback.sentAmount = MAX_CASHBACK_FOR_PERIOD;
       }
       await proveTx(cashback.token.mint(distributor.address, cashback.revokedAmount));
-      await proveTx(cashback.token.connect(distributor).approve(cashbackDistributor.address, MAX_UINT256));
+      await proveTx(connect(cashback.token, distributor).approve(getAddress(cashbackDistributor), MAX_UINT256));
     }
 
     describe("Executes as expected and emits the correct event if the revocation", async () => {
@@ -881,7 +878,7 @@ describe("Contract 'CashbackDistributor'", async () => {
           await sendCashbacks(cashbackDistributor, [cashback], CashbackStatus.Success);
           cashback.revokedAmount = Math.floor(cashback.requestedAmount * 0.1);
           await proveTx(cashback.token.mint(distributor.address, (cashback.revokedAmount || 0) - 1));
-          await proveTx(cashback.token.connect(distributor).approve(cashbackDistributor.address, MAX_UINT256));
+          await proveTx(connect(cashback.token, distributor).approve(getAddress(cashbackDistributor), MAX_UINT256));
           await checkRevoking(RevocationStatus.OutOfFunds, context);
         });
 
@@ -892,7 +889,7 @@ describe("Contract 'CashbackDistributor'", async () => {
           cashback.sentAmount = MAX_CASHBACK_FOR_PERIOD;
           cashback.revokedAmount = Math.floor(MAX_CASHBACK_FOR_PERIOD * 0.1);
           await proveTx(cashback.token.mint(distributor.address, (cashback.revokedAmount || 0) - 1));
-          await proveTx(cashback.token.connect(distributor).approve(cashbackDistributor.address, MAX_UINT256));
+          await proveTx(connect(cashback.token, distributor).approve(getAddress(cashbackDistributor), MAX_UINT256));
           await checkRevoking(RevocationStatus.OutOfFunds, context);
         });
 
@@ -902,9 +899,10 @@ describe("Contract 'CashbackDistributor'", async () => {
           await sendCashbacks(cashbackDistributor, [cashback], CashbackStatus.Success);
           cashback.revokedAmount = Math.floor(cashback.requestedAmount * 0.1);
           await proveTx(cashback.token.mint(distributor.address, cashback.revokedAmount));
-          await proveTx(
-            cashback.token.connect(distributor).approve(cashbackDistributor.address, (cashback.revokedAmount || 0) - 1)
-          );
+          await proveTx(connect(cashback.token, distributor).approve(
+            getAddress(cashbackDistributor),
+            (cashback.revokedAmount ?? 0) - 1
+          ));
           await checkRevoking(RevocationStatus.OutOfAllowance, context);
         });
 
@@ -913,7 +911,7 @@ describe("Contract 'CashbackDistributor'", async () => {
           const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
           await sendCashbacks(cashbackDistributor, [cashback], CashbackStatus.Success);
           await proveTx(cashback.token.mint(distributor.address, cashback.requestedAmount + 1));
-          await proveTx(cashback.token.connect(distributor).approve(cashbackDistributor.address, MAX_UINT256));
+          await proveTx(connect(cashback.token, distributor).approve(getAddress(cashbackDistributor), MAX_UINT256));
           cashback.revokedAmount = cashback.requestedAmount + 1;
           await checkRevoking(RevocationStatus.OutOfBalance, context);
         });
@@ -933,7 +931,7 @@ describe("Contract 'CashbackDistributor'", async () => {
         const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
         await pauseContract(cashbackDistributor);
         await expect(
-          cashbackDistributor.connect(distributor).revokeCashback(cashback.nonce, cashback.revokedAmount)
+          connect(cashbackDistributor, distributor).revokeCashback(cashback.nonce, cashback.revokedAmount)
         ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
       });
 
@@ -951,7 +949,7 @@ describe("Contract 'CashbackDistributor'", async () => {
       const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
       const recipientBalanceChange = cashback.increaseSentAmount || 0;
 
-      const returnValues = await cashbackDistributor.connect(distributor).callStatic.increaseCashback(
+      const returnValues = await connect(cashbackDistributor, distributor).increaseCashback.staticCall(
         cashback.nonce,
         cashback.increaseRequestedAmount
       );
@@ -959,17 +957,17 @@ describe("Contract 'CashbackDistributor'", async () => {
       cashback.requestedAmount += recipientBalanceChange;
       cashback.sentAmount += recipientBalanceChange;
 
-      await expect(
-        cashbackDistributor.connect(distributor).increaseCashback(cashback.nonce, cashback.increaseRequestedAmount)
-      ).to.changeTokenBalances(
+      const tx = connect(cashbackDistributor, distributor).increaseCashback(
+        cashback.nonce,
+        cashback.increaseRequestedAmount
+      );
+      await expect(tx).to.changeTokenBalances(
         cashback.token,
         [cashbackDistributor, cashback.recipient, cashback.sender],
         [-recipientBalanceChange, +recipientBalanceChange, 0]
-      ).and.to.emit(
-        cashbackDistributor,
-        EVENT_NAME_INCREASE_CASHBACK
-      ).withArgs(
-        cashback.token.address,
+      );
+      await expect(tx).to.emit(cashbackDistributor, EVENT_NAME_INCREASE_CASHBACK).withArgs(
+        getAddress(cashback.token),
         cashback.kind,
         cashback.status,
         targetIncreaseStatus,
@@ -993,7 +991,7 @@ describe("Contract 'CashbackDistributor'", async () => {
     async function prepareIncrease(context: TestContext) {
       const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
       await sendCashbacks(cashbackDistributor, [cashback], CashbackStatus.Success);
-      await proveTx(cashback.token.mint(cashbackDistributor.address, cashback.increaseRequestedAmount));
+      await proveTx(cashback.token.mint(getAddress(cashbackDistributor), cashback.increaseRequestedAmount));
       context.cashbackDistributorInitialBalanceByToken.set(
         cashback.token,
         cashback.requestedAmount + (cashback.increaseRequestedAmount || 0)
@@ -1099,7 +1097,7 @@ describe("Contract 'CashbackDistributor'", async () => {
         const { fixture: { cashbackDistributor }, cashback } = await prepareForSingleCashback();
         await pauseContract(cashbackDistributor);
         await expect(
-          cashbackDistributor.connect(distributor).increaseCashback(cashback.nonce, cashback.revokedAmount)
+          connect(cashbackDistributor, distributor).increaseCashback(cashback.nonce, cashback.revokedAmount)
         ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
       });
 
@@ -1129,7 +1127,7 @@ describe("Contract 'CashbackDistributor'", async () => {
           nonce: nonceValue
         };
       });
-      const cashbackNonces: BigNumber[] = cashbacks.map(cashback => BigNumber.from(cashback.nonce));
+      const cashbackNonces: bigint[] = cashbacks.map(cashback => BigInt(cashback.nonce));
       await setUpContractsForSendingCashbacks(cashbackDistributor, cashbacks);
       await sendCashbacks(cashbackDistributor, cashbacks, CashbackStatus.Success);
 
@@ -1148,7 +1146,7 @@ describe("Contract 'CashbackDistributor'", async () => {
       checkNonexistentCashback(actualCashbacks[1], nonceAfterExistingCashbacks);
 
       // Check getting of cashback nonces in different cases
-      let actualNonces: BigNumber[];
+      let actualNonces: bigint[];
 
       actualNonces = await cashbackDistributor.getCashbackNonces(CASHBACK_EXTERNAL_ID_STUB1, 0, 50);
       expect(actualNonces).to.be.deep.equal(cashbackNonces);
@@ -1196,9 +1194,9 @@ describe("Contract 'CashbackDistributor'", async () => {
       );
       const context: TestContext = { fixture, cashbacks, cashbackDistributorInitialBalanceByToken };
       await proveTx(tokenMock1.mint(distributor.address, MAX_INT256));
-      await proveTx(tokenMock1.connect(distributor).approve(cashbackDistributor.address, MAX_UINT256));
+      await proveTx(connect(tokenMock1, distributor).approve(getAddress(cashbackDistributor), MAX_UINT256));
       await proveTx(tokenMock2.mint(distributor.address, MAX_INT256));
-      await proveTx(tokenMock2.connect(distributor).approve(cashbackDistributor.address, MAX_UINT256));
+      await proveTx(connect(tokenMock2, distributor).approve(getAddress(cashbackDistributor), MAX_UINT256));
 
       await sendCashbacks(cashbackDistributor, cashbacks, CashbackStatus.Success);
       await checkCashbackDistributorState(context);
@@ -1222,7 +1220,7 @@ describe("Contract 'CashbackDistributor'", async () => {
     it("Executes as expected", async () => {
       const fixture: Fixture = await setUpFixture(deployAndConfigureAllContracts);
       const { cashbackDistributor, tokenMocks: [tokenMock] } = fixture;
-      const recipient: SignerWithAddress = user;
+      const recipient: HardhatEthersSigner = user;
       const cashbacks: TestCashback[] = [1, 2, 3, 4, 5].map(nonce => {
         return {
           token: tokenMock,
@@ -1245,17 +1243,21 @@ describe("Contract 'CashbackDistributor'", async () => {
       );
       const context: TestContext = { fixture, cashbacks, cashbackDistributorInitialBalanceByToken };
       await proveTx(tokenMock.mint(distributor.address, MAX_INT256));
-      await proveTx(tokenMock.connect(distributor).approve(cashbackDistributor.address, MAX_UINT256));
+      await proveTx(connect(tokenMock, distributor).approve(getAddress(cashbackDistributor), MAX_UINT256));
 
       async function checkPeriodCapRelatedValues(props: {
         expectedLastTimeReset: number;
         expectedCashbackSum: number;
       }) {
-        expect(await cashbackDistributor.getCashbackLastTimeReset(tokenMock.address, recipient.address)).to.equal(
+        expect(
+          await cashbackDistributor.getCashbackLastTimeReset(getAddress(tokenMock), recipient.address)
+        ).to.equal(
           props.expectedLastTimeReset
         );
 
-        expect(await cashbackDistributor.getCashbackSinceLastReset(tokenMock.address, recipient.address)).to.equal(
+        expect(
+          await cashbackDistributor.getCashbackSinceLastReset(getAddress(tokenMock), recipient.address)
+        ).to.equal(
           props.expectedCashbackSum
         );
       }
@@ -1263,11 +1265,11 @@ describe("Contract 'CashbackDistributor'", async () => {
       // Reset the cashback sum for period cashback cap control and check the cap-related values.
       cashbacks[0].sentAmount = cashbacks[0].requestedAmount;
       const [transactionReceipt1] = await sendCashbacks(cashbackDistributor, [cashbacks[0]], CashbackStatus.Success);
-      const block1: Block = await ethers.provider.getBlock(transactionReceipt1.blockNumber);
+      const block1: Block | null = await ethers.provider.getBlock(transactionReceipt1.blockNumber);
       context.cashbacks = [cashbacks[0]];
       await checkCashbackDistributorState(context);
       await checkPeriodCapRelatedValues({
-        expectedLastTimeReset: block1.timestamp,
+        expectedLastTimeReset: block1?.timestamp ?? 0,
         expectedCashbackSum: cashbacks[0].requestedAmount
       });
 
@@ -1277,7 +1279,7 @@ describe("Contract 'CashbackDistributor'", async () => {
       context.cashbacks = [cashbacks[0], cashbacks[1]];
       await checkCashbackDistributorState(context);
       await checkPeriodCapRelatedValues({
-        expectedLastTimeReset: block1.timestamp,
+        expectedLastTimeReset: block1?.timestamp ?? 0,
         expectedCashbackSum: MAX_CASHBACK_FOR_PERIOD
       });
 
@@ -1285,7 +1287,7 @@ describe("Contract 'CashbackDistributor'", async () => {
       await revokeCashback(cashbackDistributor, cashbacks[1], cashbacks[1].sentAmount);
       await checkCashbackDistributorState(context);
       await checkPeriodCapRelatedValues({
-        expectedLastTimeReset: block1.timestamp,
+        expectedLastTimeReset: block1?.timestamp ?? 0,
         expectedCashbackSum: MAX_CASHBACK_FOR_PERIOD - cashbacks[1].sentAmount
       });
 
@@ -1295,7 +1297,7 @@ describe("Contract 'CashbackDistributor'", async () => {
       context.cashbacks = [cashbacks[0], cashbacks[1], cashbacks[2]];
       await checkCashbackDistributorState(context);
       await checkPeriodCapRelatedValues({
-        expectedLastTimeReset: block1.timestamp,
+        expectedLastTimeReset: block1?.timestamp ?? 0,
         expectedCashbackSum: MAX_CASHBACK_FOR_PERIOD
       });
 
@@ -1304,7 +1306,7 @@ describe("Contract 'CashbackDistributor'", async () => {
       context.cashbacks = [cashbacks[0], cashbacks[1], cashbacks[2], cashbacks[3]];
       await checkCashbackDistributorState(context);
       await checkPeriodCapRelatedValues({
-        expectedLastTimeReset: block1.timestamp,
+        expectedLastTimeReset: block1?.timestamp ?? 0,
         expectedCashbackSum: MAX_CASHBACK_FOR_PERIOD
       });
 
@@ -1319,11 +1321,11 @@ describe("Contract 'CashbackDistributor'", async () => {
       // Check that next cashback sending executes successfully due to the cap period resets
       cashbacks[4].sentAmount = cashbacks[4].requestedAmount;
       const [transactionReceipt4] = await sendCashbacks(cashbackDistributor, [cashbacks[4]], CashbackStatus.Success);
-      const block4: Block = await ethers.provider.getBlock(transactionReceipt4.blockNumber);
+      const block4: Block | null = await ethers.provider.getBlock(transactionReceipt4.blockNumber);
       context.cashbacks = cashbacks;
       await checkCashbackDistributorState(context);
       await checkPeriodCapRelatedValues({
-        expectedLastTimeReset: block4.timestamp,
+        expectedLastTimeReset: block4?.timestamp ?? 0,
         expectedCashbackSum: cashbacks[4].requestedAmount
       });
 
@@ -1331,7 +1333,7 @@ describe("Contract 'CashbackDistributor'", async () => {
       await revokeCashback(cashbackDistributor, cashbacks[0], cashbacks[0].sentAmount);
       await checkCashbackDistributorState(context);
       await checkPeriodCapRelatedValues({
-        expectedLastTimeReset: block4.timestamp,
+        expectedLastTimeReset: block4?.timestamp ?? 0,
         expectedCashbackSum: 0
       });
     });

--- a/test/CashbackDistributor.test.ts
+++ b/test/CashbackDistributor.test.ts
@@ -205,25 +205,30 @@ describe("Contract 'CashbackDistributor'", async () => {
   let user: HardhatEthersSigner;
 
   before(async () => {
-    cashbackDistributorFactory = await ethers.getContractFactory("CashbackDistributor");
-    tokenMockFactory = await ethers.getContractFactory("ERC20TokenMock");
-
     [deployer, distributor, user] = await ethers.getSigners();
+
+    // Contract factories with the explicitly specified deployer account
+    cashbackDistributorFactory = await ethers.getContractFactory("CashbackDistributor");
+    cashbackDistributorFactory = cashbackDistributorFactory.connect(deployer);
+    tokenMockFactory = await ethers.getContractFactory("ERC20TokenMock");
+    tokenMockFactory = tokenMockFactory.connect(deployer);
   });
 
   async function deployTokenMock(nameSuffix: string): Promise<Contract> {
     const name = "ERC20 Test" + nameSuffix;
     const symbol = "TEST" + nameSuffix;
 
-    const tokenMock: Contract = await upgrades.deployProxy(tokenMockFactory, [name, symbol]);
+    let tokenMock: Contract = await upgrades.deployProxy(tokenMockFactory, [name, symbol]);
     await tokenMock.waitForDeployment();
+    tokenMock = connect(tokenMock, deployer); // Explicitly specifying the initial account
 
     return tokenMock;
   }
 
   async function deployCashbackDistributor(): Promise<{ cashbackDistributor: Contract }> {
-    const cashbackDistributor: Contract = await upgrades.deployProxy(cashbackDistributorFactory);
+    let cashbackDistributor: Contract = await upgrades.deployProxy(cashbackDistributorFactory);
     await cashbackDistributor.waitForDeployment();
+    cashbackDistributor = connect(cashbackDistributor, deployer);
 
     return { cashbackDistributor };
   }

--- a/test/CashbackDistributor.test.ts
+++ b/test/CashbackDistributor.test.ts
@@ -2,8 +2,8 @@ import { ethers, network, upgrades } from "hardhat";
 import { expect } from "chai";
 import { Block, Contract, ContractFactory, TransactionReceipt } from "ethers";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
-import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
-import { connect, getAddress, proveTx } from "../test-utils/eth";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { connect, getAddress, increaseBlockTimestamp, proveTx } from "../test-utils/eth";
 import { createBytesString, createRevertMessageDueToMissingRole } from "../test-utils/misc";
 import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
 
@@ -1310,13 +1310,13 @@ describe("Contract 'CashbackDistributor'", async () => {
         expectedCashbackSum: MAX_CASHBACK_FOR_PERIOD
       });
 
-      // The following part of the test is executed only for Hardhat network because we need to shift block time.
-      if (network.name !== "hardhat") {
+      // The following part of the test is executed only for some networks because we need to shift block time.
+      if (network.name !== "hardhat" && network.name !== "stratus") {
         return;
       }
 
       // Shift next block time for a period of cap checking.
-      await time.increase(CASHBACK_RESET_PERIOD);
+      await increaseBlockTimestamp(CASHBACK_RESET_PERIOD);
 
       // Check that next cashback sending executes successfully due to the cap period resets
       cashbacks[4].sentAmount = cashbacks[4].requestedAmount;

--- a/test/base/AccessControlExtUpgradeable.test.ts
+++ b/test/base/AccessControlExtUpgradeable.test.ts
@@ -31,15 +31,19 @@ describe("Contract 'AccessControlExtUpgradeable'", async () => {
   let userAddresses: string[];
 
   before(async () => {
-    accessControlExtMockFactory = await ethers.getContractFactory("AccessControlExtUpgradeableMock");
     [deployer, attacker, ...users] = await ethers.getSigners();
+    accessControlExtMockFactory = await ethers.getContractFactory("AccessControlExtUpgradeableMock");
+    // Explicitly specifying the deployer account
+    accessControlExtMockFactory = accessControlExtMockFactory.connect(deployer);
 
     userAddresses = [users[0].address, users[1].address, users[2].address];
   });
 
   async function deployAccessControlExtMock(): Promise<{ accessControlExtMock: Contract }> {
-    const accessControlExtMock: Contract = await upgrades.deployProxy(accessControlExtMockFactory);
+    let accessControlExtMock: Contract = await upgrades.deployProxy(accessControlExtMockFactory);
     await accessControlExtMock.waitForDeployment();
+    accessControlExtMock = connect(accessControlExtMock, deployer); // Explicitly specifying the initial account
+
     return { accessControlExtMock };
   }
 

--- a/test/base/BlocklistableUpgradeable.test.ts
+++ b/test/base/BlocklistableUpgradeable.test.ts
@@ -37,11 +37,14 @@ describe("Contract 'BlocklistableUpgradeable'", async () => {
   before(async () => {
     [deployer, blocklister, user] = await ethers.getSigners();
     blocklistableMockFactory = await ethers.getContractFactory("BlocklistableUpgradeableMock");
+    // Explicitly specifying the deployer account
+    blocklistableMockFactory = blocklistableMockFactory.connect(deployer);
   });
 
   async function deployBlocklistableMock(): Promise<{ blocklistableMock: Contract }> {
-    const blocklistableMock: Contract = await upgrades.deployProxy(blocklistableMockFactory);
+    let blocklistableMock: Contract = await upgrades.deployProxy(blocklistableMockFactory);
     await blocklistableMock.waitForDeployment();
+    blocklistableMock = connect(blocklistableMock, deployer); // Explicitly specifying the initial account
 
     return { blocklistableMock };
   }

--- a/test/base/PausableExtUpgradeable.test.ts
+++ b/test/base/PausableExtUpgradeable.test.ts
@@ -1,9 +1,9 @@
 import { ethers, network, upgrades } from "hardhat";
 import { expect } from "chai";
 import { Contract, ContractFactory } from "ethers";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { proveTx } from "../../test-utils/eth";
+import { connect, proveTx } from "../../test-utils/eth";
 import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
 
 async function setUpFixture<T>(func: () => Promise<T>): Promise<T> {
@@ -18,13 +18,13 @@ describe("Contract 'PausableExtUpgradeable'", async () => {
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
   const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
 
-  const ownerRole: string = ethers.utils.id("OWNER_ROLE");
-  const pauserRole: string = ethers.utils.id("PAUSER_ROLE");
+  const ownerRole: string = ethers.id("OWNER_ROLE");
+  const pauserRole: string = ethers.id("PAUSER_ROLE");
 
   let pausableExtMockFactory: ContractFactory;
 
-  let deployer: SignerWithAddress;
-  let pauser: SignerWithAddress;
+  let deployer: HardhatEthersSigner;
+  let pauser: HardhatEthersSigner;
 
   before(async () => {
     pausableExtMockFactory = await ethers.getContractFactory("PausableExtUpgradeableMock");
@@ -33,7 +33,7 @@ describe("Contract 'PausableExtUpgradeable'", async () => {
 
   async function deployPausableExtMock(): Promise<{ pausableExtMock: Contract }> {
     const pausableExtMock: Contract = await upgrades.deployProxy(pausableExtMockFactory);
-    await pausableExtMock.deployed();
+    await pausableExtMock.waitForDeployment();
     return { pausableExtMock };
   }
 
@@ -52,7 +52,7 @@ describe("Contract 'PausableExtUpgradeable'", async () => {
       expect((await pausableExtMock.PAUSER_ROLE()).toLowerCase()).to.equal(pauserRole);
 
       // The role admins
-      expect(await pausableExtMock.getRoleAdmin(ownerRole)).to.equal(ethers.constants.HashZero);
+      expect(await pausableExtMock.getRoleAdmin(ownerRole)).to.equal(ethers.ZeroHash);
       expect(await pausableExtMock.getRoleAdmin(pauserRole)).to.equal(ownerRole);
 
       // The deployer should have the owner role, but not the other roles
@@ -89,7 +89,7 @@ describe("Contract 'PausableExtUpgradeable'", async () => {
     it("Executes successfully and emits the correct event", async () => {
       const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
 
-      await expect(pausableExtMock.connect(pauser).pause())
+      await expect(connect(pausableExtMock, pauser).pause())
         .to.emit(pausableExtMock, "Paused")
         .withArgs(pauser.address);
 
@@ -107,9 +107,9 @@ describe("Contract 'PausableExtUpgradeable'", async () => {
   describe("Function 'unpause()'", async () => {
     it("Executes successfully and emits the correct event", async () => {
       const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
-      await proveTx(pausableExtMock.connect(pauser).pause());
+      await proveTx(connect(pausableExtMock, pauser).pause());
 
-      await expect(pausableExtMock.connect(pauser).unpause())
+      await expect(connect(pausableExtMock, pauser).unpause())
         .to.emit(pausableExtMock, "Unpaused")
         .withArgs(pauser.address);
 

--- a/test/base/PausableExtUpgradeable.test.ts
+++ b/test/base/PausableExtUpgradeable.test.ts
@@ -27,19 +27,22 @@ describe("Contract 'PausableExtUpgradeable'", async () => {
   let pauser: HardhatEthersSigner;
 
   before(async () => {
-    pausableExtMockFactory = await ethers.getContractFactory("PausableExtUpgradeableMock");
     [deployer, pauser] = await ethers.getSigners();
+    pausableExtMockFactory = await ethers.getContractFactory("PausableExtUpgradeableMock");
+    pausableExtMockFactory = pausableExtMockFactory.connect(deployer); // Explicitly specifying the deployer account
   });
 
   async function deployPausableExtMock(): Promise<{ pausableExtMock: Contract }> {
-    const pausableExtMock: Contract = await upgrades.deployProxy(pausableExtMockFactory);
+    let pausableExtMock: Contract = await upgrades.deployProxy(pausableExtMockFactory);
     await pausableExtMock.waitForDeployment();
+    pausableExtMock = connect(pausableExtMock, deployer); // Explicitly specifying the initial account
     return { pausableExtMock };
   }
 
   async function deployAndConfigurePausableExtMock(): Promise<{ pausableExtMock: Contract }> {
     const { pausableExtMock } = await deployPausableExtMock();
     await proveTx(pausableExtMock.grantRole(pauserRole, pauser.address));
+
     return { pausableExtMock };
   }
 

--- a/test/base/RescuableUpgradeable.test.ts
+++ b/test/base/RescuableUpgradeable.test.ts
@@ -32,22 +32,27 @@ describe("Contract 'RescuableUpgradeable'", async () => {
   let rescuer: HardhatEthersSigner;
 
   before(async () => {
-    rescuableMockFactory = await ethers.getContractFactory("RescuableUpgradeableMock");
-    tokenMockFactory = await ethers.getContractFactory("ERC20TokenMock");
-
     [deployer, rescuer] = await ethers.getSigners();
+
+    // Contract factories with the explicitly specified deployer account
+    rescuableMockFactory = await ethers.getContractFactory("RescuableUpgradeableMock");
+    rescuableMockFactory = rescuableMockFactory.connect(deployer);
+    tokenMockFactory = await ethers.getContractFactory("ERC20TokenMock");
+    tokenMockFactory = tokenMockFactory.connect(deployer);
   });
 
   async function deployRescuableMock(): Promise<{ rescuableMock: Contract }> {
-    const rescuableMock: Contract = await upgrades.deployProxy(rescuableMockFactory);
+    let rescuableMock: Contract = await upgrades.deployProxy(rescuableMockFactory);
     await rescuableMock.waitForDeployment();
+    rescuableMock = connect(rescuableMock, deployer); // Explicitly specifying the initial account
 
     return { rescuableMock };
   }
 
   async function deployTokenMock(): Promise<{ tokenMock: Contract }> {
-    const tokenMock: Contract = await upgrades.deployProxy(tokenMockFactory, ["ERC20 Test", "TEST"]);
+    let tokenMock: Contract = await upgrades.deployProxy(tokenMockFactory, ["ERC20 Test", "TEST"]);
     await tokenMock.waitForDeployment();
+    tokenMock = connect(tokenMock, deployer); // Explicitly specifying the initial account
 
     return { tokenMock };
   }

--- a/test/base/RescuableUpgradeable.test.ts
+++ b/test/base/RescuableUpgradeable.test.ts
@@ -1,9 +1,9 @@
 import { ethers, network, upgrades } from "hardhat";
 import { expect } from "chai";
 import { Contract, ContractFactory } from "ethers";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { proveTx } from "../../test-utils/eth";
+import { connect, getAddress, proveTx } from "../../test-utils/eth";
 import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
 
 async function setUpFixture<T>(func: () => Promise<T>): Promise<T> {
@@ -22,14 +22,14 @@ describe("Contract 'RescuableUpgradeable'", async () => {
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
   const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
 
-  const ownerRole: string = ethers.utils.id("OWNER_ROLE");
-  const rescuerRole: string = ethers.utils.id("RESCUER_ROLE");
+  const ownerRole: string = ethers.id("OWNER_ROLE");
+  const rescuerRole: string = ethers.id("RESCUER_ROLE");
 
   let rescuableMockFactory: ContractFactory;
   let tokenMockFactory: ContractFactory;
 
-  let deployer: SignerWithAddress;
-  let rescuer: SignerWithAddress;
+  let deployer: HardhatEthersSigner;
+  let rescuer: HardhatEthersSigner;
 
   before(async () => {
     rescuableMockFactory = await ethers.getContractFactory("RescuableUpgradeableMock");
@@ -40,13 +40,15 @@ describe("Contract 'RescuableUpgradeable'", async () => {
 
   async function deployRescuableMock(): Promise<{ rescuableMock: Contract }> {
     const rescuableMock: Contract = await upgrades.deployProxy(rescuableMockFactory);
-    await rescuableMock.deployed();
+    await rescuableMock.waitForDeployment();
+
     return { rescuableMock };
   }
 
   async function deployTokenMock(): Promise<{ tokenMock: Contract }> {
     const tokenMock: Contract = await upgrades.deployProxy(tokenMockFactory, ["ERC20 Test", "TEST"]);
-    await tokenMock.deployed();
+    await tokenMock.waitForDeployment();
+
     return { tokenMock };
   }
 
@@ -54,7 +56,7 @@ describe("Contract 'RescuableUpgradeable'", async () => {
     const { rescuableMock } = await deployRescuableMock();
     const { tokenMock } = await deployTokenMock();
 
-    await proveTx(tokenMock.mint(rescuableMock.address, TOKEN_AMOUNT));
+    await proveTx(tokenMock.mint(getAddress(rescuableMock), TOKEN_AMOUNT));
     await proveTx(rescuableMock.grantRole(rescuerRole, rescuer.address));
 
     return {
@@ -72,7 +74,7 @@ describe("Contract 'RescuableUpgradeable'", async () => {
       expect((await rescuableMock.RESCUER_ROLE()).toLowerCase()).to.equal(rescuerRole);
 
       // The role admins
-      expect(await rescuableMock.getRoleAdmin(ownerRole)).to.equal(ethers.constants.HashZero);
+      expect(await rescuableMock.getRoleAdmin(ownerRole)).to.equal(ethers.ZeroHash);
       expect(await rescuableMock.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
 
       // The deployer should have the owner role, but not the other roles
@@ -106,16 +108,21 @@ describe("Contract 'RescuableUpgradeable'", async () => {
     it("Executes as expected and emits the correct event", async () => {
       const { rescuableMock, tokenMock } = await setUpFixture(deployAndConfigureAllContracts);
 
-      await expect(rescuableMock.connect(rescuer).rescueERC20(tokenMock.address, deployer.address, TOKEN_AMOUNT))
-        .to.changeTokenBalances(tokenMock, [rescuableMock, deployer, rescuer], [-TOKEN_AMOUNT, +TOKEN_AMOUNT, 0])
-        .and.to.emit(tokenMock, EVENT_NAME_TRANSFER)
-        .withArgs(rescuableMock.address, deployer.address, TOKEN_AMOUNT);
+      const tx = connect(rescuableMock, rescuer).rescueERC20(getAddress(tokenMock), deployer.address, TOKEN_AMOUNT);
+      await expect(tx).to.changeTokenBalances(
+        tokenMock,
+        [rescuableMock, deployer, rescuer],
+        [-TOKEN_AMOUNT, +TOKEN_AMOUNT, 0]
+      );
+      await expect(tx)
+        .to.emit(tokenMock, EVENT_NAME_TRANSFER)
+        .withArgs(getAddress(rescuableMock), deployer.address, TOKEN_AMOUNT);
     });
 
     it("Is reverted if it is called by an account without the rescuer role", async () => {
       const { rescuableMock, tokenMock } = await setUpFixture(deployAndConfigureAllContracts);
       await expect(
-        rescuableMock.rescueERC20(tokenMock.address, deployer.address, TOKEN_AMOUNT)
+        rescuableMock.rescueERC20(getAddress(tokenMock), deployer.address, TOKEN_AMOUNT)
       ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, rescuerRole));
     });
   });


### PR DESCRIPTION
## Main changes
1. The `@nomicfoundation/hardhat-toolbox` and `@openzeppelin/hardhat-upgrades` packages for contract testing and deployment have been updated to the latest versions that use the [EthersJS v.6](https://docs.ethers.org/v6/) library under the hood.
2. All the tests have been updated according to the new packages and the [EthersJS v.6](https://docs.ethers.org/v6/) library with minor refactoring.
3. The tests have added lines that now explicitly specify:
    * the account used to deploy contracts under test;
    * the initial (default) account that is used for interacting with the contracts under test.
4. The tests have been adopted to be run on the Stratus blockchain.
5. Additional helper functions have been introduced to simplify the tests.

## Test coverage
No changes have been made.