### PR TITLE
feat: improve events of the CardPaymentProcessor V2 contract

### DIFF
--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -66,11 +66,11 @@ contract CardPaymentProcessor is
     /// @dev The maximum cashback for a cap period.
     uint256 public constant MAX_CASHBACK_FOR_CAP_PERIOD = 300 * 10 ** TOKE_DECIMALS;
 
-    /// @dev Event data flag mask defining whether the payment is sponsored.
-    uint256 internal constant EVENT_FLAG_MASK_SPONSORED = 1;
+    /// @dev Event addendum flag mask defining whether the payment is sponsored.
+    uint256 internal constant EVENT_ADDENDUM_FLAG_MASK_SPONSORED = 1;
 
-    /// @dev Default version of the event data.
-    uint8 internal constant EVENT_DEFAULT_VERSION = 1;
+    /// @dev Default version of the event addendum.
+    uint8 internal constant EVENT_ADDENDUM_DEFAULT_VERSION = 1;
 
     // ------------------ Events ---------------------------------- //
 
@@ -656,16 +656,16 @@ contract CardPaymentProcessor is
 
         address sponsor = operation.sponsor;
         uint256 eventFlags = _defineEventFlags(sponsor);
-        bytes memory eventData = abi.encodePacked(
-            EVENT_DEFAULT_VERSION,
+        bytes memory addendum = abi.encodePacked(
+            EVENT_ADDENDUM_DEFAULT_VERSION,
             uint8(eventFlags),
             uint64(operation.baseAmount),
             uint64(operation.extraAmount),
             uint64(operation.payerSumAmount)
         );
-        if (eventFlags & EVENT_FLAG_MASK_SPONSORED != 0) {
-            eventData = abi.encodePacked(
-                eventData,
+        if (eventFlags & EVENT_ADDENDUM_FLAG_MASK_SPONSORED != 0) {
+            addendum = abi.encodePacked(
+                addendum,
                 sponsor,
                 uint64(operation.sponsorSumAmount)
             );
@@ -673,7 +673,7 @@ contract CardPaymentProcessor is
         emit PaymentMade(
             operation.paymentId,
             operation.payer,
-            eventData
+            addendum
         );
     }
 
@@ -721,8 +721,8 @@ contract CardPaymentProcessor is
 
         address sponsor = payment.sponsor;
         uint256 eventFlags = _defineEventFlags(sponsor);
-        bytes memory eventData = abi.encodePacked(
-            EVENT_DEFAULT_VERSION,
+        bytes memory addendum = abi.encodePacked(
+            EVENT_ADDENDUM_DEFAULT_VERSION,
             uint8(eventFlags),
             uint64(oldBaseAmount),
             uint64(newBaseAmount),
@@ -731,9 +731,9 @@ contract CardPaymentProcessor is
             uint64(oldPaymentDetails.payerSumAmount),
             uint64(newPaymentDetails.payerSumAmount)
         );
-        if (eventFlags & EVENT_FLAG_MASK_SPONSORED != 0) {
-            eventData = abi.encodePacked(
-                eventData,
+        if (eventFlags & EVENT_ADDENDUM_FLAG_MASK_SPONSORED != 0) {
+            addendum = abi.encodePacked(
+                addendum,
                 sponsor,
                 uint64(oldPaymentDetails.sponsorSumAmount),
                 uint64(newPaymentDetails.sponsorSumAmount)
@@ -742,7 +742,7 @@ contract CardPaymentProcessor is
         emit PaymentUpdated(
             paymentId,
             payment.payer,
-            eventData
+            addendum
         );
     }
 
@@ -770,16 +770,16 @@ contract CardPaymentProcessor is
 
         address sponsor = payment.sponsor;
         uint256 eventFlags = _defineEventFlags(sponsor);
-        bytes memory eventData = abi.encodePacked(
-            EVENT_DEFAULT_VERSION,
+        bytes memory addendum = abi.encodePacked(
+            EVENT_ADDENDUM_DEFAULT_VERSION,
             uint8(eventFlags),
             uint64(payment.baseAmount),
             uint64(payment.extraAmount),
             uint64(oldPaymentDetails.payerRemainder)
         );
-        if (eventFlags & EVENT_FLAG_MASK_SPONSORED != 0) {
-            eventData = abi.encodePacked(
-                eventData,
+        if (eventFlags & EVENT_ADDENDUM_FLAG_MASK_SPONSORED != 0) {
+            addendum = abi.encodePacked(
+                addendum,
                 sponsor,
                 uint64(oldPaymentDetails.sponsorRemainder)
             );
@@ -789,13 +789,13 @@ contract CardPaymentProcessor is
             emit PaymentRevoked(
                 paymentId,
                 payment.payer,
-                eventData
+                addendum
             );
         } else {
             emit PaymentReversed(
                 paymentId,
                 payment.payer,
-                eventData
+                addendum
             );
         }
     }
@@ -874,15 +874,15 @@ contract CardPaymentProcessor is
 
         address sponsor = payment.sponsor;
         uint256 eventFlags = _defineEventFlags(sponsor);
-        bytes memory eventData = abi.encodePacked(
-            EVENT_DEFAULT_VERSION,
+        bytes memory addendum = abi.encodePacked(
+            EVENT_ADDENDUM_DEFAULT_VERSION,
             uint8(eventFlags),
             uint64(oldPaymentDetails.payerSumAmount - oldPaymentDetails.payerRemainder), // oldPayerRefundAmount
             uint64(newPaymentDetails.payerSumAmount - newPaymentDetails.payerRemainder)  // newPayerRefundAmount
         );
-        if (eventFlags & EVENT_FLAG_MASK_SPONSORED != 0) {
-            eventData = abi.encodePacked(
-                eventData,
+        if (eventFlags & EVENT_ADDENDUM_FLAG_MASK_SPONSORED != 0) {
+            addendum = abi.encodePacked(
+                addendum,
                 sponsor,
                 uint64(oldPaymentDetails.sponsorSumAmount - oldPaymentDetails.sponsorRemainder),//oldSponsorRefundAmount
                 uint64(newPaymentDetails.sponsorSumAmount - newPaymentDetails.sponsorRemainder) //newSponsorRefundAmount
@@ -892,7 +892,7 @@ contract CardPaymentProcessor is
         emit PaymentRefunded(
             paymentId,
             payment.payer,
-            eventData
+            addendum
         );
     }
 
@@ -1027,15 +1027,15 @@ contract CardPaymentProcessor is
         uint256 newConfirmedAmount
     ) internal {
         uint256 eventFlags = _defineEventFlags(sponsor);
-        bytes memory eventData = abi.encodePacked(
-            EVENT_DEFAULT_VERSION,
+        bytes memory addendum = abi.encodePacked(
+            EVENT_ADDENDUM_DEFAULT_VERSION,
             uint8(eventFlags),
             uint64(oldConfirmedAmount),
             uint64(newConfirmedAmount)
         );
-        if (eventFlags & EVENT_FLAG_MASK_SPONSORED != 0) {
-            eventData = abi.encodePacked(
-                eventData,
+        if (eventFlags & EVENT_ADDENDUM_FLAG_MASK_SPONSORED != 0) {
+            addendum = abi.encodePacked(
+                addendum,
                 sponsor
             );
         }
@@ -1043,7 +1043,7 @@ contract CardPaymentProcessor is
         emit PaymentConfirmedAmountChanged(
             paymentId,
             payer,
-            eventData
+            addendum
         );
     }
 
@@ -1348,7 +1348,7 @@ contract CardPaymentProcessor is
     function _defineEventFlags(address sponsor) internal pure returns (uint256) {
         uint256 eventFlags = 0;
         if (sponsor != address(0)) {
-            eventFlags |= EVENT_FLAG_MASK_SPONSORED;
+            eventFlags |= EVENT_ADDENDUM_FLAG_MASK_SPONSORED;
         }
         return eventFlags;
     }

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -773,6 +773,8 @@ contract CardPaymentProcessor is
         bytes memory eventData = abi.encodePacked(
             EVENT_DEFAULT_VERSION,
             uint8(eventFlags),
+            uint64(payment.baseAmount),
+            uint64(payment.extraAmount),
             uint64(oldPaymentDetails.payerRemainder)
         );
         if (eventFlags & EVENT_FLAG_MASK_SPONSORED != 0) {

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -154,6 +154,8 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * - uint8(version) -- the version of the event data, for now it equals `0x01`.
      * - uint8(flags) -- the flags that for now define whether the payment is subsidized (`0x01`) or not (`0x00`).
+     * - uint64(baseAmount) -- the base amount of the payment.
+     * - uint64(extraAmount) -- the extra amount of the payment.
      * - uint64(payerRemainder) -- the payer remainder part of the payment.
      * - address(sponsor) -- the address of the sponsor or skipped if the payment is not subsidized.
      * - uint64(sponsorRemainder) -- the sponsor remainder part or skipped if the payment is not subsidized.
@@ -177,6 +179,8 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * - uint8(version) -- the version of the event data, for now it equals `0x01`.
      * - uint8(flags) -- the flags that for now define whether the payment is subsidized (`0x01`) or not (`0x00`).
+     * - uint64(baseAmount) -- the base amount of the payment.
+     * - uint64(extraAmount) -- the extra amount of the payment.
      * - uint64(payerRemainder) -- the payer remainder part of the payment.
      * - address(sponsor) -- the address of the sponsor or skipped if the payment is not subsidized.
      * - uint64(sponsorRemainder) -- the sponsor remainder part or skipped if the payment is not subsidized.

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -94,7 +94,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
     /**
      * @dev Emitted when a payment is made.
      *
-     * The useful data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
+     * Some data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
      * function as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
      * with the following arguments (addendum fields):
      *
@@ -108,7 +108,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param paymentId The card transaction payment ID from the off-chain card processing backend.
      * @param payer The account on that behalf the payment is made.
-     * @param addendum The useful data of the event as described above.
+     * @param addendum The data of the event as described above.
      */
     event PaymentMade(
         bytes32 indexed paymentId,
@@ -119,7 +119,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
     /**
      * @dev Emitted when a payment is updated inside a function whose name started with the `update` word.
      *
-     * The useful data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
+     * Some data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
      * function as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
      * with the following arguments (addendum fields):
      *
@@ -137,7 +137,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param paymentId The card transaction payment ID from the off-chain card processing backend.
      * @param payer The account on that behalf the payment is made.
-     * @param addendum The useful data of the event as described above.
+     * @param addendum The data of the event as described above.
      */
     event PaymentUpdated(
         bytes32 indexed paymentId,
@@ -148,7 +148,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
     /**
      * @dev Emitted when a payment is revoked.
      *
-     * The useful data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
+     * Some data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
      * function as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
      * with the following arguments (addendum fields):
      *
@@ -162,7 +162,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param paymentId The card transaction payment ID from the off-chain card processing backend.
      * @param payer The account on that behalf the payment is made.
-     * @param addendum The useful data of the event as described above.
+     * @param addendum The data of the event as described above.
      */
     event PaymentRevoked(
         bytes32 indexed paymentId,
@@ -173,7 +173,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
     /**
      * @dev Emitted when a payment is reversed.
      *
-     * The useful data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
+     * Some data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
      * function as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
      * with the following arguments (addendum fields):
      *
@@ -187,7 +187,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param paymentId The card transaction payment ID from the off-chain card processing backend.
      * @param payer The account on that behalf the payment is made.
-     * @param addendum The useful data of the event as described above.
+     * @param addendum The data of the event as described above.
      */
     event PaymentReversed(
         bytes32 indexed paymentId,
@@ -198,7 +198,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
     /**
      * @dev Emitted when the confirmed amount of a payment is changed. It can be emitted during any operation.
      *
-     * The useful data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
+     * Some data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
      * function as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
      * with the following arguments (addendum fields):
      *
@@ -210,7 +210,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param paymentId The card transaction payment ID from the off-chain card processing backend.
      * @param payer The account on that behalf the payment is made.
-     * @param addendum The useful data of the event as described above.
+     * @param addendum The data of the event as described above.
      */
     event PaymentConfirmedAmountChanged(
         bytes32 indexed paymentId,
@@ -221,7 +221,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
     /**
      * @dev Emitted when a payment is refunded inside a function whose name started with the `refund` word.
      *
-     * The useful data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
+     * Some data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
      * function as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
      * with the following arguments (addendum fields):
      *
@@ -235,7 +235,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param paymentId The card transaction payment ID from the off-chain card processing backend.
      * @param payer The account on that behalf the payment is made.
-     * @param addendum The useful data of the event as described above.
+     * @param addendum The data of the event as described above.
      */
     event PaymentRefunded(
         bytes32 indexed paymentId,

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -94,11 +94,11 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
     /**
      * @dev Emitted when a payment is made.
      *
-     * The main data is encoded in the `data` field as the result of calling of the `abi.encodePacked()` function
-     * as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
-     * with the following arguments:
+     * The useful data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
+     * function as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
+     * with the following arguments (addendum fields):
      *
-     * - uint8(version) -- the version of the event data, for now it equals `0x01`.
+     * - uint8(version) -- the version of the event addendum, for now it equals `0x01`.
      * - uint8(flags) -- the flags that for now define whether the payment is subsidized (`0x01`) or not (`0x00`).
      * - uint64(baseAmount) -- the base amount of the payment.
      * - uint64(extraAmount) -- the extra amount of the payment.
@@ -108,22 +108,22 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param paymentId The card transaction payment ID from the off-chain card processing backend.
      * @param payer The account on that behalf the payment is made.
-     * @param data The main data of the event as described above.
+     * @param addendum The useful data of the event as described above.
      */
     event PaymentMade(
         bytes32 indexed paymentId,
         address indexed payer,
-        bytes data
+        bytes addendum
     );
 
     /**
      * @dev Emitted when a payment is updated inside a function whose name started with the `update` word.
      *
-     * The main data is encoded in the `data` field as the result of calling of the `abi.encodePacked()` function
-     * as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
-     * with the following arguments:
+     * The useful data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
+     * function as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
+     * with the following arguments (addendum fields):
      *
-     * - uint8(version) -- the version of the event data, for now it equals `0x01`.
+     * - uint8(version) -- the version of the event addendum, for now it equals `0x01`.
      * - uint8(flags) -- the flags that for now define whether the payment is subsidized (`0x01`) or not (`0x00`).
      * - uint64(oldBaseAmount) -- the old base amount of the payment.
      * - uint64(newBaseAmount) -- the new base amount of the payment.
@@ -137,22 +137,22 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param paymentId The card transaction payment ID from the off-chain card processing backend.
      * @param payer The account on that behalf the payment is made.
-     * @param data The main data of the event as described above.
+     * @param addendum The useful data of the event as described above.
      */
     event PaymentUpdated(
         bytes32 indexed paymentId,
         address indexed payer,
-        bytes data
+        bytes addendum
     );
 
     /**
      * @dev Emitted when a payment is revoked.
      *
-     * The main data is encoded in the `data` field as the result of calling of the `abi.encodePacked()` function
-     * as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
-     * with the following arguments:
+     * The useful data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
+     * function as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
+     * with the following arguments (addendum fields):
      *
-     * - uint8(version) -- the version of the event data, for now it equals `0x01`.
+     * - uint8(version) -- the version of the event addendum, for now it equals `0x01`.
      * - uint8(flags) -- the flags that for now define whether the payment is subsidized (`0x01`) or not (`0x00`).
      * - uint64(baseAmount) -- the base amount of the payment.
      * - uint64(extraAmount) -- the extra amount of the payment.
@@ -162,22 +162,22 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param paymentId The card transaction payment ID from the off-chain card processing backend.
      * @param payer The account on that behalf the payment is made.
-     * @param data The main data of the event as described above.
+     * @param addendum The useful data of the event as described above.
      */
     event PaymentRevoked(
         bytes32 indexed paymentId,
         address indexed payer,
-        bytes data
+        bytes addendum
     );
 
     /**
      * @dev Emitted when a payment is reversed.
      *
-     * The main data is encoded in the `data` field as the result of calling of the `abi.encodePacked()` function
-     * as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
-     * with the following arguments:
+     * The useful data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
+     * function as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
+     * with the following arguments (addendum fields):
      *
-     * - uint8(version) -- the version of the event data, for now it equals `0x01`.
+     * - uint8(version) -- the version of the event addendum, for now it equals `0x01`.
      * - uint8(flags) -- the flags that for now define whether the payment is subsidized (`0x01`) or not (`0x00`).
      * - uint64(baseAmount) -- the base amount of the payment.
      * - uint64(extraAmount) -- the extra amount of the payment.
@@ -187,22 +187,22 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param paymentId The card transaction payment ID from the off-chain card processing backend.
      * @param payer The account on that behalf the payment is made.
-     * @param data The main data of the event as described above.
+     * @param addendum The useful data of the event as described above.
      */
     event PaymentReversed(
         bytes32 indexed paymentId,
         address indexed payer,
-        bytes data
+        bytes addendum
     );
 
     /**
      * @dev Emitted when the confirmed amount of a payment is changed. It can be emitted during any operation.
      *
-     * The main data is encoded in the `data` field as the result of calling of the `abi.encodePacked()` function
-     * as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
-     * with the following arguments:
+     * The useful data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
+     * function as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
+     * with the following arguments (addendum fields):
      *
-     * - uint8(version) -- the version of the event data, for now it equals `0x01`.
+     * - uint8(version) -- the version of the event addendum, for now it equals `0x01`.
      * - uint8(flags) -- the flags that for now define whether the payment is subsidized (`0x01`) or not (`0x00`).
      * - uint64(oldConfirmedAmount) -- the old confirmed amount of the payment.
      * - uint64(newConfirmedAmount) -- the new confirmed amount of the payment.
@@ -210,22 +210,22 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param paymentId The card transaction payment ID from the off-chain card processing backend.
      * @param payer The account on that behalf the payment is made.
-     * @param data The main data of the event as described above.
+     * @param addendum The useful data of the event as described above.
      */
     event PaymentConfirmedAmountChanged(
         bytes32 indexed paymentId,
         address indexed payer,
-        bytes data
+        bytes addendum
     );
 
     /**
      * @dev Emitted when a payment is refunded inside a function whose name started with the `refund` word.
      *
-     * The main data is encoded in the `data` field as the result of calling of the `abi.encodePacked()` function
-     * as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
-     * with the following arguments:
+     * The useful data is encoded in the `addendum` parameter as the result of calling of the `abi.encodePacked()`
+     * function as described in https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
+     * with the following arguments (addendum fields):
      *
-     * - uint8(version) -- the version of the event data, for now it equals `0x01`.
+     * - uint8(version) -- the version of the event addendum, for now it equals `0x01`.
      * - uint8(flags) -- the flags that for now define whether the payment is subsidized (`0x01`) or not (`0x00`).
      * - uint64(oldPayerRefundAmount) -- the old payer refund amount of the payment.
      * - uint64(newPayerRefundAmount) -- the new payer refund amount of the payment.
@@ -235,12 +235,12 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
      *
      * @param paymentId The card transaction payment ID from the off-chain card processing backend.
      * @param payer The account on that behalf the payment is made.
-     * @param data The main data of the event as described above.
+     * @param addendum The useful data of the event as described above.
      */
     event PaymentRefunded(
         bytes32 indexed paymentId,
         address indexed payer,
-        bytes data
+        bytes addendum
     );
 
     /**

--- a/test-utils/checkers.ts
+++ b/test-utils/checkers.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-export interface EventFieldCheckingOptions {
+export interface EventParameterCheckingOptions {
   showValuesInErrorMessage?: boolean;
   caseInsensitiveComparison?: boolean;
   convertToJson?: boolean;
@@ -10,10 +10,10 @@ interface Stringable {
   toString(): string;
 }
 
-function checkEventField<T extends Stringable>(
+function checkEventParameter<T extends Stringable>(
   fieldName: string,
   expectedValue: T | string | undefined | null,
-  options: EventFieldCheckingOptions = {}
+  options: EventParameterCheckingOptions = {}
 ): (value: T) => boolean {
   const f = function (value: T | string): boolean {
     if (options.convertToJson) {
@@ -35,10 +35,10 @@ function checkEventField<T extends Stringable>(
   return f;
 }
 
-function checkEventFieldNotEqual<T extends Stringable>(
+function checkEventParameterNotEqual<T extends Stringable>(
   fieldName: string,
   notExpectedValue: T | string | undefined | null,
-  options: EventFieldCheckingOptions = {}
+  options: EventParameterCheckingOptions = {}
 ): (value: T | string) => boolean {
   const f = function (value: T | string): boolean {
     if (options.convertToJson) {
@@ -62,6 +62,6 @@ function checkEventFieldNotEqual<T extends Stringable>(
 }
 
 export {
-  checkEventField,
-  checkEventFieldNotEqual
+  checkEventParameter,
+  checkEventParameterNotEqual
 };

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1339,6 +1339,8 @@ class TestContext {
     const expectedDataField: string = defineEventDataField(
       EVENT_DATA_FIELD_VERSION_DEFAULT_VALUE,
       !operation.sponsor ? EVENT_DATA_FIELD_FLAGS_NON_SUBSIDIZED : EVENT_DATA_FIELD_FLAGS_SUBSIDIZED,
+      encodeEventDataFieldForAmount(operation.oldBaseAmount),
+      encodeEventDataFieldForAmount(operation.oldExtraAmount),
       encodeEventDataFieldForAmount(operation.oldPayerRemainder),
       !operation.sponsor ? "" : encodeEventDataFieldForAddress(operation.sponsor?.address ?? ZERO_ADDRESS),
       !operation.sponsor ? "" : encodeEventDataFieldForAmount(operation.oldSponsorRemainder)


### PR DESCRIPTION
### Main changes
1. The current base amount and extra amount of the canceled payment have been added to events `PaymentRevoked` and `PaymentReversed`.
2. The `data` parameter of payment-related events has been renamed to `addendum`. This is done to avoid confusion between the name of this parameter and the `data` part of blockchain transaction's logs.
3. The following entities have been separated in the contract code comments:
    * `event parameters` -- the data that is included to blockchain events as their indexed or unindexed parameters;
    * `addendum fields` --  the data that is included in dense-packing manner to the `addendum` parameter of payment-related events.
4. The current set of addendum fields for the `PaymentRevoked` and `PaymentReversed` events looks like:
    ```
    - uint8(version) -- the version of the event addendum, for now it equals `0x01`.
    - uint8(flags) -- the flags that for now define whether the payment is subsidized (`0x01`) or not (`0x00`).
    - uint64(baseAmount) -- the base amount of the payment.
    - uint64(extraAmount) -- the extra amount of the payment.
    - uint64(payerRemainder) -- the payer remainder part of the payment.
    - address(sponsor) -- the address of the sponsor or skipped if the payment is not subsidized.
    - uint64(sponsorRemainder) -- the sponsor remainder part or skipped if the payment is not subsidized.
    ```

### Test coverage

| File  | % Stmts | % Branch | % Funcs | % Lines |
|---|---:|---:|---:|---:|
| contracts/ | 100 | 99.01 | 100 | 100 |
| &nbsp;&nbsp;CardPaymentProcessor.sol | 100 | 99.01 | 100 | 100 |
| &nbsp;&nbsp;CardPaymentProcessorStorage.sol | 100 | 100 | 100 | 100 |
| contracts/base/ | 100 | 100 | 100 | 100 |
| &nbsp;&nbsp;AccessControlExtUpgradeable.sol | 100 | 100 | 100 | 100 |
| &nbsp;&nbsp;BlocklistableUpgradeable.sol | 100 | 100 | 100 | 100 |
| &nbsp;&nbsp;PausableExtUpgradeable.sol | 100 | 100 | 100 | 100 |
| &nbsp;&nbsp;RescuableUpgradeable.sol | 100 | 100 | 100 | 100 |
| contracts/interfaces/ | 100 | 100 | 100 | 100 |
| contracts/mocks/base/ | 100 | 100 | 100 | 100 |
| contracts/mocks/tokens/ | 100 | 100 | 100 | 100 |
|---|---|---|---|---|
| All files | 100 | 99.22 | 100 | 100 |
