### PR TITLE
test: fix block time shift value

### DIFF
--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -4839,7 +4839,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       }
 
       // Shift next block time for a period of cap checking
-      await increaseBlockTimestamp(CASHBACK_CAP_RESET_PERIOD);
+      await increaseBlockTimestamp(CASHBACK_CAP_RESET_PERIOD + 1);
 
       // Set new start amount for the cashback cap checking in the model
       cardPaymentProcessorShell.model.capPeriodStartAmount =


### PR DESCRIPTION
## Main changes
An incorrect time shift caused tests on the Stratus network to fail. This has now been fixed.