### PR TITLE
feat: add ability to move liquidity from Compound to CapybaraFinance

### DIFF
--- a/contracts/Dispatcher.sol
+++ b/contracts/Dispatcher.sol
@@ -98,7 +98,7 @@ contract Dispatcher is
 
     /**
      * @dev Initializes the liquidity mover role for a batch of accounts and
-     *      sets the owner role as the default admin for the liquidity mover role.
+     *      sets the owner role as the admin for the liquidity mover role.
      *
      * Requirements:
      *
@@ -120,7 +120,7 @@ contract Dispatcher is
 
     /**
      * @dev Removes the liquidity mover role for a batch of accounts
-     *      and sets the default admin role for the liquidity mover role.
+     *      and sets the default role as the admin for the liquidity mover role.
      *
      * Requirements:
      *

--- a/contracts/Dispatcher.sol
+++ b/contracts/Dispatcher.sol
@@ -2,6 +2,8 @@
 
 pragma solidity 0.8.24;
 
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 import { AccessControlExtUpgradeable } from "./base/AccessControlExtUpgradeable.sol";
 import { PausableExtUpgradeable } from "./base/PausableExtUpgradeable.sol";
 import { RescuableUpgradeable } from "./base/RescuableUpgradeable.sol";
@@ -14,6 +16,13 @@ import { DispatcherStorage } from "./DispatcherStorage.sol";
 interface ICompoundAgent {
     function transferOwnership(address newOwner) external;
     function configureAdmin(address account, bool newStatus) external;
+    function redeemUnderlying(uint256 redeemAmount) external;
+}
+
+/// @dev Interface for the liquidity pool contract from the `CapybaraFinance` protocol with the necessary functions.
+interface ILiquidityPool {
+    function deposit(uint256 amount) external;
+    function token() external view returns (address);
 }
 
 /**
@@ -34,10 +43,16 @@ contract Dispatcher is
     /// @dev The role of this contract owner.
     bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
 
+    /// @dev The role that allows to move liquidity from Compound to Capybara.
+    bytes32 public constant LIQUIDITY_MOVER_ROLE = keccak256("LIQUIDITY_MOVER_ROLE");
+
     // ------------------ Errors ---------------------------------- //
 
     /// @dev Thrown if the provided new implementation address is not of a dispatcher contract.
     error Dispatcher_ImplementationAddressInvalid();
+
+    /// @dev Thrown if the provided account address is zero.
+    error Dispatcher_AccountAddressZero();
 
     // ------------------ Initializers ---------------------------- //
 
@@ -82,6 +97,50 @@ contract Dispatcher is
     // ------------------ Functions ------------------------------- //
 
     /**
+     * @dev Initializes the liquidity mover role for a batch of accounts and
+     *      sets the owner role as the default admin for the liquidity mover role.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {OWNER_ROLE} role.
+     *
+     * @param accounts The addresses of the accounts to initialize the liquidity mover role for.
+     */
+    function initLiquidityMoverRole(address[] calldata accounts) external onlyRole(OWNER_ROLE) {
+        _setRoleAdmin(LIQUIDITY_MOVER_ROLE, OWNER_ROLE);
+        uint256 len = accounts.length;
+        for (uint256 i = 0; i < len; ++i) {
+            address account = accounts[i];
+            if (account == address(0)) {
+                revert Dispatcher_AccountAddressZero();
+            }
+            _grantRole(LIQUIDITY_MOVER_ROLE, account);
+        }
+    }
+
+    /**
+     * @dev Removes the liquidity mover role for a batch of accounts
+     *      and sets the default admin role for the liquidity mover role.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {OWNER_ROLE} role.
+     *
+     * @param accounts The addresses of the accounts to remove the liquidity mover role for.
+     */
+    function removeLiquidityMoverRole(address[] calldata accounts) external onlyRole(OWNER_ROLE) {
+        uint256 len = accounts.length;
+        for (uint256 i = 0; i < len; ++i) {
+            address account = accounts[i];
+            if (account == address(0)) {
+                revert Dispatcher_AccountAddressZero();
+            }
+            _revokeRole(LIQUIDITY_MOVER_ROLE, account);
+        }
+        _setRoleAdmin(LIQUIDITY_MOVER_ROLE, DEFAULT_ADMIN_ROLE);
+    }
+
+    /**
      * @dev Transfers ownership of a CompoundAgent contract to a new owner.
      *
      * Requirements:
@@ -120,6 +179,30 @@ contract Dispatcher is
         for (uint256 i = 0; i < counter; ++i) {
             ICompoundAgent(compoundAgent).configureAdmin(accounts[i], newStatus);
         }
+    }
+
+    /**
+     * @dev Moves liquidity from a CompoundAgent contract to a liquidity pool of the `CapybaraFinance` protocol.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {LIQUIDITY_MOVER_ROLE} role.
+     *  
+     * @param amount The amount of liquidity to move.
+     * @param compoundAgent The address of the CompoundAgent contract to move liquidity from.
+     * @param capybaraLiquidityPool The address of the liquidity pool to move liquidity to.
+     */
+    function moveLiquidityFromCompoundToCapybara(
+        uint256 amount,
+        address compoundAgent,
+        address capybaraLiquidityPool
+    ) external whenNotPaused onlyRole(LIQUIDITY_MOVER_ROLE) {
+        address underlyingToken = ILiquidityPool(capybaraLiquidityPool).token();
+        ICompoundAgent(compoundAgent).redeemUnderlying(amount);
+        IERC20(underlyingToken).transferFrom(compoundAgent, address(this), amount);
+        IERC20(underlyingToken).approve(capybaraLiquidityPool, amount);
+        ILiquidityPool(capybaraLiquidityPool).deposit(amount);
     }
 
     // ------------------ Pure functions -------------------------- //

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 0, 0);
+        return Version(1, 1, 0);
     }
 }

--- a/contracts/mocks/CapybaraLiquidityPoolMock.sol
+++ b/contracts/mocks/CapybaraLiquidityPoolMock.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title CapybaraLiquidityPoolMock contract
+ * @author CloudWalk Inc. (See https://cloudwalk.io)
+ * @dev A simplified version of the liquidity pool smart-contract of the `CapybaraFinance` protocol
+ *      to use in tests for other contracts.
+ */
+contract CapybaraLiquidityPoolMock {
+    /// @dev The address of the underlying token.
+    address public underlyingToken;
+
+    // ------------------ Events ---------------------------------- //
+
+    /// @dev Emitted when the `deposit()` function is called with the parameters of the function.
+    event MockDepositCalled(
+        uint256 amount
+    );
+
+    // ------------------ Constructor ----------------------------- //
+
+    /**
+     * @dev The constructor of the contract.
+     * @param underlyingToken_ The address of the underlying token.
+     */
+    constructor(address underlyingToken_) {
+        underlyingToken = underlyingToken_;
+    }
+
+    // ------------------ Functions ------------------------------ //
+
+    /**
+     * @dev Imitates the same-name function of the liquidity pool of the `CapybaraFinance` protocol.
+     * @param amount The amount of the underlying token to deposit.
+     */
+    function deposit(uint256 amount) external {
+        emit MockDepositCalled(amount);
+        IERC20(underlyingToken).transferFrom(msg.sender, address(this), amount);
+    }
+
+    /**
+     * @dev Imitates the same-name function of the liquidity pool of the `CapybaraFinance` protocol.
+     * @return The address of the underlying token.
+     */
+    function token() external view returns (address) {
+        return underlyingToken;
+    }
+}

--- a/contracts/mocks/CompoundAgentMock.sol
+++ b/contracts/mocks/CompoundAgentMock.sol
@@ -51,7 +51,10 @@ contract CompoundAgentMock {
     // ------------------ Functions -------------------------------- //
 
     /**
-     * @dev Imitates the same-name function of the CompoundAgent smart-contract. Just emits an event about the call.
+     * @dev Imitates the same-name function of the CompoundAgent smart-contract.
+     *
+     * Just emits an event about the call and manage allowance for token transfers from the contract.
+     *
      * @param newOwner The address of the new owner.
      */
     function transferOwnership(address newOwner) external {

--- a/contracts/mocks/CompoundAgentMock.sol
+++ b/contracts/mocks/CompoundAgentMock.sol
@@ -2,14 +2,24 @@
 
 pragma solidity ^0.8.0;
 
+import { ERC20TokenMock } from "./tokens/ERC20TokenMock.sol";
+
 /**
  * @title CompoundAgentMock contract
  * @author CloudWalk Inc. (See https://cloudwalk.io)
  * @dev A simplified version of the CompoundAgent contract to use in tests for other contracts.
  */
 contract CompoundAgentMock {
+    /// @dev The owner of the contract.
+    address public owner;
+
     /// @dev The counter of the `configureAdmin()` function calls.
     uint256 public configureAdminCallCounter;
+
+    /// @dev The address of the underlying token.
+    address public underlyingToken;
+
+    // ------------------ Events ---------------------------------- //
 
     /// @dev Emitted when the `transferOwnership()` function is called with the parameters of the function.
     event MockTransferOwnershipCalled(
@@ -23,12 +33,44 @@ contract CompoundAgentMock {
         uint256 configureAdminCallCounter
     );
 
-    /// @dev Imitates the same-name function of the CompoundAgent interface. Just emits an event about the call.
-    function transferOwnership(address newOwner) external {
-        emit MockTransferOwnershipCalled(newOwner);
+    /// @dev Emitted when the `redeemUnderlying()` function is called with the parameters of the function
+    event MockRedeemUnderlyingCalled(
+        uint256 redeemAmount
+    );
+
+    // ------------------ Constructor ----------------------------- //
+
+    /**
+     * @dev The constructor of the contract.
+     * @param underlyingToken_ The address of the underlying token.
+     */
+    constructor(address underlyingToken_) {
+        underlyingToken = underlyingToken_;
     }
 
-    /// @dev Imitates the same-name function of the CompoundAgent interface. Just emits an event about the call.
+    // ------------------ Functions -------------------------------- //
+
+    /**
+     * @dev Imitates the same-name function of the CompoundAgent smart-contract. Just emits an event about the call.
+     * @param newOwner The address of the new owner.
+     */
+    function transferOwnership(address newOwner) external {
+        emit MockTransferOwnershipCalled(newOwner);
+        address oldOwner = owner;
+        owner = newOwner;
+        if (oldOwner != address(0)) {
+            ERC20TokenMock(underlyingToken).approve(oldOwner, 0);
+        }
+        if (newOwner != address(0)) {
+            ERC20TokenMock(underlyingToken).approve(newOwner, type(uint256).max);
+        }
+    }
+
+    /**
+     * @dev Imitates the same-name function of the CompoundAgent smart-contract. Just emits an event about the call.
+     * @param account The address of the account to configure.
+     * @param newStatus The new status of the account.
+     */
     function configureAdmin(
         address account,
         bool newStatus
@@ -39,5 +81,14 @@ contract CompoundAgentMock {
             newStatus,
             configureAdminCallCounter
         );
+    }
+
+    /**
+     * @dev Imitates the same-name function of the CompoundAgent smart-contract.
+     * @param redeemAmount The amount of the underlying token to redeem.
+     */
+    function redeemUnderlying(uint256 redeemAmount) external {
+        emit MockRedeemUnderlyingCalled(redeemAmount);
+        ERC20TokenMock(underlyingToken).mint(address(this), redeemAmount);
     }
 }

--- a/test/Dispatcher.test.ts
+++ b/test/Dispatcher.test.ts
@@ -18,6 +18,8 @@ interface Version {
 interface Fixture {
   dispatcherContract: Contract;
   compoundAgentMock: Contract;
+  capybaraLiquidityPoolMock: Contract;
+  tokenMock: Contract;
 }
 
 function checkEquality<T extends Record<string, unknown>>(actualObject: T, expectedObject: T, index?: number) {
@@ -42,7 +44,7 @@ async function setUpFixture<T>(func: () => Promise<T>): Promise<T> {
   }
 }
 
-describe("Contracts 'Dispatcher'", async () => {
+describe("Contract 'Dispatcher'", async () => {
   // Errors of the lib contracts
   const REVERT_ERROR_IF_CONTRACT_INITIALIZATION_IS_INVALID = "InvalidInitialization";
   const REVERT_ERROR_IF_CONTRACT_IS_NOT_INITIALIZING = "NotInitializing";
@@ -51,10 +53,16 @@ describe("Contracts 'Dispatcher'", async () => {
 
   // Errors of the contracts under test
   const REVERT_ERROR_IF_IMPLEMENTATION_ADDRESS_INVALID = "Dispatcher_ImplementationAddressInvalid";
+  const REVERT_ERROR_IF_ACCOUNT_ADDRESS_ZERO = "Dispatcher_AccountAddressZero";
 
   // Events of the mock contracts
-  const EVENT_NAME_MOCK_TRANSFER_OWNERSHIP_CALLED = "MockTransferOwnershipCalled";
   const EVENT_NAME_MOCK_CONFIGURE_ADMIN_CALLED = "MockConfigureAdminCalled";
+  const EVENT_NAME_MOCK_DEPOSIT_CALLED = "MockDepositCalled";
+  const EVENT_NAME_MOCK_TRANSFER_OWNERSHIP_CALLED = "MockTransferOwnershipCalled";
+  const EVENT_NAME_MOCK_REDEEM_UNDERLYING_CALLED = "MockRedeemUnderlyingCalled";
+
+  // Events of the ERC20 contract
+  const EVENT_NAME_TRANSFER = "Transfer";
 
   const EXPECTED_VERSION: Version = {
     major: 1,
@@ -63,22 +71,23 @@ describe("Contracts 'Dispatcher'", async () => {
   };
 
   let dispatcherContractFactory: ContractFactory;
-  let compoundAgentMockFactory: ContractFactory;
+
   let deployer: HardhatEthersSigner;
+  let liquidityMover: HardhatEthersSigner;
   let stranger: HardhatEthersSigner;
 
-  const ownerRole: string = ethers.id("OWNER_ROLE");
-  const pauserRole: string = ethers.id("PAUSER_ROLE");
-  const rescuerRole: string = ethers.id("RESCUER_ROLE");
+  const DEFAULT_ADMIN_ROLE: string = ethers.ZeroHash;
+  const OWNER_ROLE: string = ethers.id("OWNER_ROLE");
+  const PAUSER_ROLE: string = ethers.id("PAUSER_ROLE");
+  const RESCUER_ROLE: string = ethers.id("RESCUER_ROLE");
+  const LIQUIDITY_MOVER_ROLE: string = ethers.id("LIQUIDITY_MOVER_ROLE");
 
   before(async () => {
-    [deployer, stranger] = await ethers.getSigners();
+    [deployer, liquidityMover, stranger] = await ethers.getSigners();
 
     // Contract factories with the explicitly specified deployer account
     dispatcherContractFactory = await ethers.getContractFactory("DispatcherTestable");
     dispatcherContractFactory = dispatcherContractFactory.connect(deployer);
-    compoundAgentMockFactory = await ethers.getContractFactory("CompoundAgentMock");
-    compoundAgentMockFactory = compoundAgentMockFactory.connect(deployer);
   });
 
   async function deployContracts(): Promise<Fixture> {
@@ -86,18 +95,38 @@ describe("Contracts 'Dispatcher'", async () => {
     await dispatcherContract.waitForDeployment();
     dispatcherContract = connect(dispatcherContract, deployer); // Explicitly specifying the initial account
 
-    let compoundAgentMock: Contract = await compoundAgentMockFactory.deploy() as Contract;
+    // Contract factories with the explicitly specified deployer account
+    const tokenMockFactory = (await ethers.getContractFactory("ERC20TokenMock")).connect(deployer);
+    const compoundAgentMockFactory = (await ethers.getContractFactory("CompoundAgentMock")).connect(deployer);
+    const capybaraLiquidityPoolMockFactory =
+      (await ethers.getContractFactory("CapybaraLiquidityPoolMock")).connect(deployer);
+
+    let tokenMock: Contract = (await tokenMockFactory.deploy("ERC20 Test", "TEST")) as Contract;
+    await tokenMock.waitForDeployment();
+
+    let compoundAgentMock: Contract = (await compoundAgentMockFactory.deploy(getAddress(tokenMock))) as Contract;
     await compoundAgentMock.waitForDeployment();
-    compoundAgentMock = connect(compoundAgentMock, deployer); // Explicitly specifying the initial account
+
+    let capybaraLiquidityPoolMock: Contract = (await capybaraLiquidityPoolMockFactory.deploy(
+      getAddress(tokenMock)
+    )) as Contract;
+    await capybaraLiquidityPoolMock.waitForDeployment();
+
+    // Explicitly specifying the initial account
+    tokenMock = connect(tokenMock, deployer);
+    capybaraLiquidityPoolMock = connect(capybaraLiquidityPoolMock, deployer);
+    compoundAgentMock = connect(compoundAgentMock, deployer);
 
     return {
       dispatcherContract,
-      compoundAgentMock
+      compoundAgentMock,
+      capybaraLiquidityPoolMock,
+      tokenMock
     };
   }
 
   async function pauseContract(contract: Contract) {
-    await proveTx(contract.grantRole(pauserRole, deployer.address));
+    await proveTx(contract.grantRole(PAUSER_ROLE, deployer.address));
     await proveTx(contract.pause());
   }
 
@@ -106,19 +135,22 @@ describe("Contracts 'Dispatcher'", async () => {
       const { dispatcherContract } = await setUpFixture(deployContracts);
 
       // Role hashes
-      expect(await dispatcherContract.OWNER_ROLE()).to.equal(ownerRole);
-      expect(await dispatcherContract.PAUSER_ROLE()).to.equal(pauserRole);
-      expect(await dispatcherContract.RESCUER_ROLE()).to.equal(rescuerRole);
+      expect(await dispatcherContract.OWNER_ROLE()).to.equal(OWNER_ROLE);
+      expect(await dispatcherContract.PAUSER_ROLE()).to.equal(PAUSER_ROLE);
+      expect(await dispatcherContract.RESCUER_ROLE()).to.equal(RESCUER_ROLE);
+      expect(await dispatcherContract.LIQUIDITY_MOVER_ROLE()).to.equal(LIQUIDITY_MOVER_ROLE);
 
       // The role admins
-      expect(await dispatcherContract.getRoleAdmin(ownerRole)).to.equal(ownerRole);
-      expect(await dispatcherContract.getRoleAdmin(pauserRole)).to.equal(ownerRole);
-      expect(await dispatcherContract.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
+      expect(await dispatcherContract.getRoleAdmin(OWNER_ROLE)).to.equal(OWNER_ROLE);
+      expect(await dispatcherContract.getRoleAdmin(PAUSER_ROLE)).to.equal(OWNER_ROLE);
+      expect(await dispatcherContract.getRoleAdmin(RESCUER_ROLE)).to.equal(OWNER_ROLE);
+      expect(await dispatcherContract.getRoleAdmin(LIQUIDITY_MOVER_ROLE)).to.equal(DEFAULT_ADMIN_ROLE);
 
       // The deployer should have the owner role, but not the other roles
-      expect(await dispatcherContract.hasRole(ownerRole, deployer.address)).to.equal(true);
-      expect(await dispatcherContract.hasRole(pauserRole, deployer.address)).to.equal(false);
-      expect(await dispatcherContract.hasRole(rescuerRole, deployer.address)).to.equal(false);
+      expect(await dispatcherContract.hasRole(OWNER_ROLE, deployer.address)).to.equal(true);
+      expect(await dispatcherContract.hasRole(PAUSER_ROLE, deployer.address)).to.equal(false);
+      expect(await dispatcherContract.hasRole(RESCUER_ROLE, deployer.address)).to.equal(false);
+      expect(await dispatcherContract.hasRole(LIQUIDITY_MOVER_ROLE, deployer.address)).to.equal(false);
 
       // The initial contract state is unpaused
       expect(await dispatcherContract.paused()).to.equal(false);
@@ -157,7 +189,7 @@ describe("Contracts 'Dispatcher'", async () => {
 
       await expect(connect(dispatcherContract, stranger).upgradeToAndCall(getAddress(dispatcherContract), "0x"))
         .to.be.revertedWithCustomError(dispatcherContract, REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT)
-        .withArgs(stranger.address, ownerRole);
+        .withArgs(stranger.address, OWNER_ROLE);
     });
   });
 
@@ -172,7 +204,7 @@ describe("Contracts 'Dispatcher'", async () => {
 
       await expect(connect(dispatcherContract, stranger).upgradeTo(getAddress(dispatcherContract)))
         .to.be.revertedWithCustomError(dispatcherContract, REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT)
-        .withArgs(stranger.address, ownerRole);
+        .withArgs(stranger.address, OWNER_ROLE);
     });
 
     it("Is reverted if the provided implementation address is not a dispatcher contract", async () => {
@@ -188,6 +220,110 @@ describe("Contracts 'Dispatcher'", async () => {
       const { dispatcherContract } = await setUpFixture(deployContracts);
       const tokenVersion = await dispatcherContract.$__VERSION();
       checkEquality(tokenVersion, EXPECTED_VERSION);
+    });
+  });
+
+  describe("Function 'initLiquidityMoverRole()'", async () => {
+    async function executeAndCheck(dispatcherContract: Contract, accounts: string[]) {
+      await proveTx(dispatcherContract.initLiquidityMoverRole(accounts));
+
+      expect(await dispatcherContract.getRoleAdmin(LIQUIDITY_MOVER_ROLE)).to.equal(OWNER_ROLE);
+      for (const account of accounts) {
+        expect(await dispatcherContract.hasRole(LIQUIDITY_MOVER_ROLE, account))
+          .to.equal(true, `The role is NOT set for account with address ${account}`);
+      }
+      expect(await dispatcherContract.hasRole(LIQUIDITY_MOVER_ROLE, deployer.address))
+        .to.equal(false, `The role is set for the deployer (${deployer.address}) but it must not be`);
+    }
+
+    it("Executes as expected for some accounts with non-zero addresses", async () => {
+      const { dispatcherContract } = await setUpFixture(deployContracts);
+      await executeAndCheck(dispatcherContract, [stranger.address, getAddress(dispatcherContract)]);
+    });
+
+    it("Executes as expected for an empty account array", async () => {
+      const { dispatcherContract } = await setUpFixture(deployContracts);
+      await executeAndCheck(dispatcherContract, []);
+    });
+
+    it("Executes as expected even if the contract is paused", async () => {
+      const { dispatcherContract } = await setUpFixture(deployContracts);
+      await pauseContract(dispatcherContract);
+      await executeAndCheck(dispatcherContract, [stranger.address, getAddress(dispatcherContract)]);
+    });
+
+    it("Is reverted if the caller does not have the owner role", async () => {
+      const { dispatcherContract } = await setUpFixture(deployContracts);
+      await expect(
+        connect(dispatcherContract, stranger).initLiquidityMoverRole([])
+      ).to.be.revertedWithCustomError(
+        dispatcherContract,
+        REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT
+      ).withArgs(stranger.address, OWNER_ROLE);
+    });
+
+    it("Is reverted if one of the provided accounts has the zero address", async () => {
+      const { dispatcherContract } = await setUpFixture(deployContracts);
+      await expect(
+        dispatcherContract.initLiquidityMoverRole([stranger.address, ADDRESS_ZERO])
+      ).to.be.revertedWithCustomError(
+        dispatcherContract,
+        REVERT_ERROR_IF_ACCOUNT_ADDRESS_ZERO
+      );
+    });
+  });
+
+  describe("Function 'removeLiquidityMoverRole()'", async () => {
+    async function executeAndCheck(dispatcherContract: Contract, accounts: string[]) {
+      await proveTx(dispatcherContract.removeLiquidityMoverRole(accounts));
+
+      expect(await dispatcherContract.getRoleAdmin(LIQUIDITY_MOVER_ROLE)).to.equal(DEFAULT_ADMIN_ROLE);
+      for (const account of accounts) {
+        expect(await dispatcherContract.hasRole(LIQUIDITY_MOVER_ROLE, account))
+          .to.equal(false, `The role is NOT set for account with address ${account}`);
+      }
+    }
+
+    it("Executes as expected for some accounts with non-zero addresses", async () => {
+      const { dispatcherContract } = await setUpFixture(deployContracts);
+      const accounts = [stranger.address, getAddress(dispatcherContract)];
+      await proveTx(dispatcherContract.initLiquidityMoverRole(accounts));
+
+      await executeAndCheck(dispatcherContract, accounts);
+    });
+
+    it("Executes as expected for an empty account array", async () => {
+      const { dispatcherContract } = await setUpFixture(deployContracts);
+      await executeAndCheck(dispatcherContract, []);
+    });
+
+    it("Executes as expected even if the contract is paused", async () => {
+      const { dispatcherContract } = await setUpFixture(deployContracts);
+      const accounts = [stranger.address, getAddress(dispatcherContract)];
+      await proveTx(dispatcherContract.initLiquidityMoverRole(accounts));
+      await pauseContract(dispatcherContract);
+
+      await executeAndCheck(dispatcherContract, [stranger.address, getAddress(dispatcherContract)]);
+    });
+
+    it("Is reverted if the caller does not have the owner role", async () => {
+      const { dispatcherContract } = await setUpFixture(deployContracts);
+      await expect(
+        connect(dispatcherContract, stranger).removeLiquidityMoverRole([])
+      ).to.be.revertedWithCustomError(
+        dispatcherContract,
+        REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT
+      ).withArgs(stranger.address, OWNER_ROLE);
+    });
+
+    it("Is reverted if one of the provided accounts has the zero address", async () => {
+      const { dispatcherContract } = await setUpFixture(deployContracts);
+      await expect(
+        dispatcherContract.removeLiquidityMoverRole([stranger.address, ADDRESS_ZERO])
+      ).to.be.revertedWithCustomError(
+        dispatcherContract,
+        REVERT_ERROR_IF_ACCOUNT_ADDRESS_ZERO
+      );
     });
   });
 
@@ -228,7 +364,7 @@ describe("Contracts 'Dispatcher'", async () => {
       ).to.be.revertedWithCustomError(
         dispatcherContract,
         REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT
-      ).withArgs(stranger.address, ownerRole);
+      ).withArgs(stranger.address, OWNER_ROLE);
     });
   });
 
@@ -299,7 +435,85 @@ describe("Contracts 'Dispatcher'", async () => {
       ).to.be.revertedWithCustomError(
         dispatcherContract,
         REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT
-      ).withArgs(stranger.address, ownerRole);
+      ).withArgs(stranger.address, OWNER_ROLE);
+    });
+  });
+
+  describe("Function 'moveLiquidityFromCompoundToCapybara()'", async () => {
+    it("Executes as expected ", async () => {
+      const fixture = await setUpFixture(deployContracts);
+      const { dispatcherContract, compoundAgentMock, capybaraLiquidityPoolMock, tokenMock } = fixture;
+      const amount = 12345678;
+
+      await proveTx(dispatcherContract.initLiquidityMoverRole([liquidityMover.address]));
+      await proveTx(compoundAgentMock.transferOwnership(getAddress(dispatcherContract)));
+
+      expect(await tokenMock.balanceOf(getAddress(capybaraLiquidityPoolMock))).to.equal(0);
+
+      const tx = connect(dispatcherContract, liquidityMover).moveLiquidityFromCompoundToCapybara(
+        amount,
+        getAddress(compoundAgentMock),
+        getAddress(capybaraLiquidityPoolMock)
+      );
+
+      await expect(tx)
+        .to.emit(compoundAgentMock, EVENT_NAME_MOCK_REDEEM_UNDERLYING_CALLED)
+        .withArgs(amount);
+      await expect(tx)
+        .to.emit(capybaraLiquidityPoolMock, EVENT_NAME_MOCK_DEPOSIT_CALLED)
+        .withArgs(amount);
+      await expect(tx)
+        .to.emit(tokenMock, EVENT_NAME_TRANSFER)
+        .withArgs(ADDRESS_ZERO, getAddress(compoundAgentMock), amount);
+      await expect(tx)
+        .to.emit(tokenMock, EVENT_NAME_TRANSFER)
+        .withArgs(getAddress(compoundAgentMock), getAddress(dispatcherContract), amount);
+      await expect(tx)
+        .to.emit(tokenMock, EVENT_NAME_TRANSFER)
+        .withArgs(getAddress(dispatcherContract), getAddress(capybaraLiquidityPoolMock), amount);
+
+      expect(await tokenMock.balanceOf(getAddress(capybaraLiquidityPoolMock))).to.equal(amount);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      const { dispatcherContract, compoundAgentMock, capybaraLiquidityPoolMock } = await setUpFixture(deployContracts);
+      await pauseContract(dispatcherContract);
+      const amount = 123456789;
+
+      await expect(
+        dispatcherContract.moveLiquidityFromCompoundToCapybara(
+          amount,
+          getAddress(compoundAgentMock),
+          getAddress(capybaraLiquidityPoolMock)
+        )
+      ).to.be.revertedWithCustomError(dispatcherContract, REVERT_ERROR_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the liquidity mover role", async () => {
+      const { dispatcherContract, compoundAgentMock, capybaraLiquidityPoolMock } = await setUpFixture(deployContracts);
+      const amount = 123456789;
+
+      await expect(
+        connect(dispatcherContract, deployer).moveLiquidityFromCompoundToCapybara(
+          amount,
+          getAddress(compoundAgentMock),
+          getAddress(capybaraLiquidityPoolMock)
+        )
+      ).to.be.revertedWithCustomError(
+        dispatcherContract,
+        REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT
+      ).withArgs(deployer.address, LIQUIDITY_MOVER_ROLE);
+
+      await expect(
+        connect(dispatcherContract, stranger).moveLiquidityFromCompoundToCapybara(
+          amount,
+          getAddress(compoundAgentMock),
+          getAddress(capybaraLiquidityPoolMock)
+        )
+      ).to.be.revertedWithCustomError(
+        dispatcherContract,
+        REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT
+      ).withArgs(stranger.address, LIQUIDITY_MOVER_ROLE);
     });
   });
 });

--- a/test/Dispatcher.test.ts
+++ b/test/Dispatcher.test.ts
@@ -66,7 +66,7 @@ describe("Contract 'Dispatcher'", async () => {
 
   const EXPECTED_VERSION: Version = {
     major: 1,
-    minor: 0,
+    minor: 1,
     patch: 0
   };
 


### PR DESCRIPTION
## Main changes
1. The ability to move liquidity form the `Compound` protocol to the `CapybaraFinance` one has been added to the `Dispatcher` smart-contract.
2. The new `moveLiquidityFromCompoundToCapybara()` function has been introduced to execute the movements:

    <details>
    
    <summary>The definition of new function </summary>
    
    ```solidity
    /**
     * @dev Moves liquidity from a CompoundAgent contract to a liquidity pool of the `CapybaraFinance` protocol.
     *
     * Requirements:
     *
     * - The contract must not be paused.
     * - The caller must have the {LIQUIDITY_MOVER_ROLE} role.
     *  
     * @param amount The amount of liquidity to move.
     * @param compoundAgent The address of the CompoundAgent contract to move liquidity from.
     * @param capybaraLiquidityPool The address of the liquidity pool to move liquidity to.
     */
    function moveLiquidityFromCompoundToCapybara(
        uint256 amount,
        address compoundAgent,
        address capybaraLiquidityPool
    ) external whenNotPaused onlyRole(LIQUIDITY_MOVER_ROLE) {....}
    ```
    
    </details>

3. The new function can be executed only by an account with the new `LIQUIDITY_MOVER_ROLE` role: 

    <details>
    
    <summary>The new role definition </summary>
    
    ```solidity
    /// @dev The role that allows to move liquidity from Compound to Capybara.
    bytes32 public constant LIQUIDITY_MOVER_ROLE = keccak256("LIQUIDITY_MOVER_ROLE");
    ```
    
    </details>

4. To properly initialize the new role and remove it (when it is time) the two new functions `initLiquidityMoverRole()` and `removeLiquidityMoverRole()` have been introduced:

    <details>
    
    <summary>The definition of new functions </summary>
    
    ```solidity
    /**
     * @dev Initializes the liquidity mover role for a batch of accounts and
     *      sets the owner role as the default admin for the liquidity mover role.
     *
     * Requirements:
     *
     * - The caller must have the {OWNER_ROLE} role.
     *
     * @param accounts The addresses of the accounts to initialize the liquidity mover role for.
     */
    function initLiquidityMoverRole(address[] calldata accounts) external onlyRole(OWNER_ROLE) {....}
    
    /**
     * @dev Removes the liquidity mover role for a batch of accounts
     *      and sets the default admin role for the liquidity mover role.
     *
     * Requirements:
     *
     * - The caller must have the {OWNER_ROLE} role.
     *
     * @param accounts The addresses of the accounts to remove the liquidity mover role for.
     */
    function removeLiquidityMoverRole(address[] calldata accounts) external onlyRole(OWNER_ROLE) {....}
    ```
    
    </details>

## Versioning

The smart contracts version has been updated to `v1.1.0`.

## Configuration flow

Before staring to move liquidity the following steps must be done:
1. On each `CompoundAgent` smart-contract, configure the `Dispatcher` smart-contract as the owner.
2. On each `LiqudityPool` smart-contract within the `CapybaraFinance` protocol, grant the owner role for the `Dispatcher` smart-contract.
3. Select accounts  that should have the `LIQUIDITY_MOVER_ROLE` role on the `Dispatcher` smart-contract.
4. On the the `Dispatcher` smart-contract, initiate the `LIQUIDITY_MOVER_ROLE` role on and grant it to the selected accounts by calling the `initLiquidityMoverRole()` function.
5. Everything is ready to move liquidity using the `moveLiquidityFromCompoundToCapybara()` function.

## Restoration flow
If the `Dispatcher` contract is no more needed for liquidity movements the following steps must be done:
1. On the `Dispatcher` smart contract, revoke the `LIQUIDITY_MOVER_ROLE` role from all previously configured accounts and remove the role itself by calling the `removeLiquidityMoverRole()` function.
2. On each `LiqudityPool` smart-contract, revoke the owner role  for the `Dispatcher` smart-contract.
3. On the `Dispatcher` smart contract, transfer ownership of each `CompoundAgent` contract to another account by calling the `transferOwnershipForCompoundAgent()` function.
4. The state of all contracts is restored now.

## Test Coverage
The changes are fully covered by tests.

<details>

<summary>Test coverage details</summary>

| File                                   |  % Stmts | % Branch |  % Funcs |  % Lines |
|----------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Dispatcher.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ DispatcherStorage.sol               |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/base/                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeable.sol     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ PausableExtUpgradeable.sol          |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ RescuableUpgradeable.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ UUPSExtUpgradeable.sol              |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Versionable.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/interfaces/                  |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ IVersionable.sol                    |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/                       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CapybaraLiquidityPoolMock.sol       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CompoundAgentMock.sol               |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/base/                  |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeableMock.sol |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ PausableExtUpgradeableMock.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ RescuableUpgradeableMock.sol        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ UUPSExtUpgradableMock.sol           |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/tokens/                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ERC20TokenMock.sol                  |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/testables/                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ DispatcherTestable.sol              |   100.00 |   100.00 |   100.00 |   100.00 |
|----------------------------------------|----------|----------|----------|----------|
| All files                              |   100.00 |   100.00 |   100.00 |   100.00 |
|----------------------------------------|----------|----------|----------|----------|

</details>
